### PR TITLE
Move 2-button Pokétch to RomFS

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -381,6 +381,10 @@ namespace Dpr::EvScript {
             return external<int32_t>(0x02c4ea10, this);
         }
 
+        inline bool IsRunningEvent() {
+            return external<bool>(0x02c423a0, this);
+        }
+
         static inline Dpr::EvScript::EvDataManager::Object* get_Instanse() {
             return external<Dpr::EvScript::EvDataManager::Object*>(0x02c3d4d0);
         }

--- a/src/mod/externals/Dpr/Field/SwayGrass.h
+++ b/src/mod/externals/Dpr/Field/SwayGrass.h
@@ -12,8 +12,8 @@ namespace Dpr::Field {
         }
 
         static inline bool SwayGrass_CheckSpEncount(Dpr::Field::FieldEncount::SWAY_ENC_INFO::Object *info, UnityEngine::Vector3::Object *pos, float size) {
-            struct { float x; float y; float z; } posProxy = { pos->fields.x, pos->fields.y, pos->fields.z };
-            return external<bool>(0x019b4fa0, info, &posProxy, size);
+            UnityEngine::Vector3::Fields posProxy = { .x = pos->fields.x, .y = pos->fields.y, .z = pos->fields.z };
+            return external<bool>(0x019b43d0, info, &posProxy, size);
         }
     };
 }

--- a/src/mod/externals/Dpr/MsgWindow/MsgWindowManager.h
+++ b/src/mod/externals/Dpr/MsgWindow/MsgWindowManager.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+
+namespace Dpr::MsgWindow {
+    struct MsgWindowManager : ILClass<MsgWindowManager> {
+        struct Fields : SmartPoint::AssetAssistant::SingletonMonoBehaviour::Fields {
+            // TODO
+        };
+
+        static inline bool get_IsOpenWindow() {
+            return external<bool>(0x01dd9810);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/PoketchAppBase.h
+++ b/src/mod/externals/Dpr/UI/PoketchAppBase.h
@@ -17,6 +17,10 @@ namespace Dpr::UI {
             Dpr::UI::PoketchButton::Object* _PreButton_k__BackingField;
             int32_t _PreState_k__BackingField;
         };
+
+        inline void OnUpdate(bool isAppControlEnable, Dpr::UI::PoketchButton::Object* currentButton, int32_t currentState) {
+            external<void>(0x019ffa60, this, isAppControlEnable, currentButton, currentState);
+        }
     };
 }
 

--- a/src/mod/externals/Dpr/UI/PoketchButton.h
+++ b/src/mod/externals/Dpr/UI/PoketchButton.h
@@ -44,5 +44,13 @@ namespace Dpr::UI {
         inline void Initialize(UnityEngine::Events::UnityAction* callback, int32_t seEventId) {
             external<void>(0x01e5e060, this, callback, seEventId);
         }
+
+        inline void SetRelease() {
+            external<void>(0x01e66280, this);
+        }
+
+        inline void SetTouch() {
+            external<void>(0x01e65f60, this);
+        }
     };
 }

--- a/src/mod/externals/Dpr/UI/PoketchWindow.h
+++ b/src/mod/externals/Dpr/UI/PoketchWindow.h
@@ -1,14 +1,16 @@
 #pragma once
 
-#include "externals/il2cpp.h"
 #include "externals/il2cpp-api.h"
-#include "externals/Dpr/UI/UIWindow.h"
-#include "externals/Dpr/UI/PoketchButton.h"
+
 #include "externals/Dpr/UI/PoketchAppBase.h"
+#include "externals/Dpr/UI/PoketchButton.h"
+#include "externals/Dpr/UI/UIInputButton.h"
+#include "externals/Dpr/UI/UIWindow.h"
+#include "externals/UnityEngine/Color32.h"
+#include "externals/UnityEngine/Events/UnityAction.h"
 #include "externals/UnityEngine/RectTransform.h"
 #include "externals/UnityEngine/UI/Image.h"
 #include "externals/UnityEngine/Vector3.h"
-#include "externals/UnityEngine/Color32.h"
 
 namespace Dpr::UI {
     struct PoketchWindow : ILClass<PoketchWindow> {
@@ -19,6 +21,14 @@ namespace Dpr::UI {
                 Dpr::UI::PoketchWindow::Object* __4__this;
                 int32_t prevWindowId;
             };
+        };
+
+        enum class TouchState: int32_t {
+            None = 0,
+            Touch = 1,
+            Hold = 2,
+            Release = 3,
+            Push = 4,
         };
 
         struct Fields : public Dpr::UI::UIWindow::Fields {
@@ -49,8 +59,8 @@ namespace Dpr::UI {
             UnityEngine::Color32::Array* _bgColors;
             float _cursolMoveValue;
             float _voiceWait;
-            void* _buttonR;
-            void* _buttonSR;
+            Dpr::UI::UIInputButton::Object* _buttonR;
+            Dpr::UI::UIInputButton::Object* _buttonSR;
             bool _isSizeChanging;
             bool _isBackLight;
             bool _isTouch;
@@ -77,7 +87,7 @@ namespace Dpr::UI {
             int32_t AppHeight;
             float _cursorX;
             float _cursorY;
-            int32_t touchState;
+            TouchState _touchState;
         };
 
         static_assert(sizeof(Fields) == 424);
@@ -92,6 +102,18 @@ namespace Dpr::UI {
 
         inline bool IsInRange(Dpr::UI::PoketchButton* btn, float x, float y) {
             return external<bool>(0x01e68830, this, btn, x, y);
+        }
+
+        inline void Close(UnityEngine::Events::UnityAction::Object* onClosed_) {
+            external<void>(0x01e670e0, this, onClosed_);
+        }
+
+        inline void ChangePoketchSize(bool notReleaseUncontrol, UnityEngine::Events::UnityAction::Object* callback) {
+            external<void>(0x01e68410, this, notReleaseUncontrol, callback);
+        }
+
+        inline void SetCursorPosition(float posX, float posY) {
+            external<void>(0x01e68a80, this, posX, posY);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/PoketchWindow.h
+++ b/src/mod/externals/Dpr/UI/PoketchWindow.h
@@ -86,6 +86,10 @@ namespace Dpr::UI {
             external<void>(0x01e68ca0, this, forward);
         }
 
+        inline void OnInputPrev(int32_t button, int32_t state) {
+            external<void>(0x01e68c90, this, button, state);
+        }
+
         inline bool IsInRange(Dpr::UI::PoketchButton* btn, float x, float y) {
             return external<bool>(0x01e68830, this, btn, x, y);
         }

--- a/src/mod/externals/Dpr/UI/UIBag.h
+++ b/src/mod/externals/Dpr/UI/UIBag.h
@@ -105,8 +105,8 @@ namespace Dpr::UI {
         }
 
         inline void OpenContextMenu(System::Int32_array* contextMenuIDs, System::Action::Object* onSelected, UnityEngine::Vector2::Object pivot, UnityEngine::Vector3::Object pos, System::Action::Object* onClosed, bool isNoDecideSe, bool isNoCancelSe) {
-            struct { float x; float y; } pivotProxy = { pivot.fields.x, pivot.fields.y };
-            struct { float x; float y; float z; } posProxy = { pos.fields.x, pos.fields.y, pos.fields.z };
+            UnityEngine::Vector2::Fields pivotProxy = { .x = pivot.fields.x, .y = pivot.fields.y };
+            UnityEngine::Vector3::Fields posProxy = { .x = pos.fields.x, .y = pos.fields.y, .z = pos.fields.z };
             external<void>(0x0185c1f0, this, contextMenuIDs, onSelected, pivotProxy, posProxy, onClosed, isNoDecideSe, isNoCancelSe);
         }
     };

--- a/src/mod/externals/Dpr/UI/UIInputButton.h
+++ b/src/mod/externals/Dpr/UI/UIInputButton.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Events/UnityAction.h"
+
+namespace Dpr::UI {
+    struct UIInputButton : ILClass<UIInputButton> {
+        struct Fields {
+            UnityEngine::Events::UnityAction::Object* _onCallbacked;
+            void* _input; // Dpr_UI_UIInputController_o*
+            float _longPressTime;
+            int32_t _button;
+            float _pressTime;
+        };
+
+        inline void OnUpdate(float deltaTime) {
+            external<void>(0x017ba1d0, this, deltaTime);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -4,7 +4,10 @@
 
 #include "externals/Dpr/UI/UIWazaManage.h"
 #include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/System/Action.h"
+#include "externals/System/Func.h"
 #include "externals/UIWindowID.h"
+#include "externals/UnityEngine/Events/UnityAction.h"
 #include "externals/UnityEngine/Transform.h"
 
 namespace Dpr {
@@ -20,6 +23,35 @@ namespace Dpr::UI {
             char todo[264];
         };
 
+        struct StaticFields {
+            int32_t StickLLeft;
+            int32_t StickLRight;
+            int32_t StickLUp;
+            int32_t StickLDown;
+            int32_t ButtonA;
+            int32_t ButtonB;
+            int32_t ButtonX;
+            int32_t ButtonY;
+            int32_t ButtonPlusMinus;
+            UnityEngine::Events::UnityAction::Object* onWazaFly;
+            UnityEngine::Events::UnityAction::Object* onDressChanged;
+            System::Func::Object* onFieldWaza;
+            System::Func::Object* onUseFieldItem;
+            System::Action::Object* onUseItemInBattle;
+            System::Action::Object* onUseHidenWaza;
+            System::Func::Object* onUseDowsing;
+            void* _comparerPokemonIcon; // Dpr_UI_UIManager_ComparerPokemonIcon_o*
+            void* _comparerAshiatoIcon; // Dpr_UI_UIManager_ComparerAshiatoIcon_o*
+            void* _comparerZukanDisplay; // Dpr_UI_UIManager_ComparerZukanDisplay_o*
+            void* _comparerPokemonVoice; // Dpr_UI_UIManager_ComparerPokemonVoice_o*
+            void* _comparerZukanCompareHeight; // Dpr_UI_UIManager_ComparerZukanCompareHeight_o*
+            void* _langParams; // Dpr_UI_UIManager_LangParam_array*
+            void* _pokemonParamMappings; // System_Collections_Generic_List_UIManager_PokemonParamMapping__o*
+            int32_t _id_GrayscaleAmount;
+            void* _comparerTownMapGuide; // Dpr_UI_UIManager_ComparerTownMapGuide_o*
+            void* _comparerPlaceName; // Dpr_UI_UIManager_ComparerPlaceName_o*
+        };
+
         static inline Dpr::UI::UIManager::Object* instance() {
             return SmartPoint::AssetAssistant::SingletonMonoBehaviour::get_Instance(SmartPoint::AssetAssistant::SingletonMonoBehaviour::Method$$UIManager$$get_Instance);
         }
@@ -27,9 +59,16 @@ namespace Dpr::UI {
         static inline StaticILMethod<0x04c8ffe8, Dpr::UI::ShopBoutiqueChange> Method$$CreateUIWindow_ShopBoutiqueChange_ {};
         static inline StaticILMethod<0x04c90098, Dpr::UI::UIWazaManage> Method$$CreateUIWindow_UIWazaManage_ {};
 
+        static inline StaticILMethod<0x04c90130, Dpr::UI::UIWindow> Method$$GetCurrentUIWindow_UIWindow_ {};
+
         template <typename T>
         inline T::Object* CreateUIWindow(UIWindowID windowId, ILMethod<T>& method) {
             return external<typename T::Object*>(0x01cf9f20, this, (int32_t)windowId, *method);
+        }
+
+        template <typename T>
+        inline T::Object* GetCurrentUIWindow(ILMethod<T>& method) {
+            return external<typename T::Object*>(0x01cfa100, this, *method);
         }
     };
 }

--- a/src/mod/externals/FieldPoketch.h
+++ b/src/mod/externals/FieldPoketch.h
@@ -15,4 +15,12 @@ struct FieldPoketch : ILClass<FieldPoketch, 0x04c5e648> {
     static inline bool IsControlPoketch() {
         return external<bool>(0x01db0a70);
     }
+
+    static inline bool IsRejectPoketch() {
+        return external<bool>(0x01db9c60);
+    }
+
+    static inline bool IsCloseOncePoketch() {
+        return external<bool>(0x01db9e40);
+    }
 };

--- a/src/mod/externals/PlayerWork.h
+++ b/src/mod/externals/PlayerWork.h
@@ -258,4 +258,8 @@ struct PlayerWork : ILClass<PlayerWork, 0x04c59b58> {
     static inline int32_t get_cassetVersion() {
         return external<int32_t>(0x02cefa60);
     }
+
+    static inline bool get_isPlayerInputActive() {
+        return external<bool>(0x02cf1110);
+    }
 };

--- a/src/mod/externals/System/ThrowHelper.h
+++ b/src/mod/externals/System/ThrowHelper.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Touch.h"
+
+namespace System {
+    struct ThrowHelper : ILClass<ThrowHelper> {
+        static inline void ThrowArgumentOutOfRangeException() {
+            external<void>(0x02305100);
+        }
+    };
+}

--- a/src/mod/externals/UnityEngine/Events/UnityAction.h
+++ b/src/mod/externals/UnityEngine/Events/UnityAction.h
@@ -11,14 +11,20 @@ namespace UnityEngine::Events {
         };
 
         static const inline long bool_String_TypeInfo = 0x04c5ee10;
+        static const inline long void_TypeInfo = 0x04c57230;
 
         template <typename T, typename... Args>
         inline void ctor(T* owner, ILMethod<T, Args...>& mi) {
             ctor(owner, *mi);
         }
 
+        // Owner will be the first param of the method it seems
         inline void ctor(void* owner, MethodInfo* mi) {
             external<void>(0x026adeb0, this, owner, mi);
+        }
+
+        inline void ctor() {
+            external<void>(0x026adeb0, this);
         }
 
         // DEBUGGING PURPOSES ONLY

--- a/src/mod/externals/UnityEngine/Input.h
+++ b/src/mod/externals/UnityEngine/Input.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/UnityEngine/Touch.h"
+#include "logger/logger.h"
 
 namespace UnityEngine {
     struct Input : ILClass<Input> {
@@ -10,8 +11,8 @@ namespace UnityEngine {
             return external<int32_t>(0x02c2b130);
         }
 
-        static inline UnityEngine::Touch::Object GetTouch(int32_t index) {
-            return external<UnityEngine::Touch::Object>(0x02c2abb0, index);
+        static inline void GetTouch(int32_t index, UnityEngine::Touch::Object* returnPtr) {
+            external<void>(0x02c2ac50, index, returnPtr);
         }
     };
 }

--- a/src/mod/externals/UnityEngine/Input.h
+++ b/src/mod/externals/UnityEngine/Input.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Touch.h"
+
+namespace UnityEngine {
+    struct Input : ILClass<Input> {
+        static inline int32_t get_touchCount() {
+            return external<int32_t>(0x02c2b130);
+        }
+
+        static inline UnityEngine::Touch::Object GetTouch(int32_t index) {
+            return external<UnityEngine::Touch::Object>(0x02c2abb0, index);
+        }
+    };
+}

--- a/src/mod/externals/UnityEngine/Time.h
+++ b/src/mod/externals/UnityEngine/Time.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace UnityEngine {
+    struct Time : ILClass<Time> {
+        static inline float get_deltaTime() {
+            return external<float>(0x0299c220);
+        }
+    };
+}

--- a/src/mod/externals/UnityEngine/Touch.h
+++ b/src/mod/externals/UnityEngine/Touch.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/TouchType.h"
+#include "externals/UnityEngine/Vector2.h"
+
+namespace UnityEngine {
+    struct Touch : ILStruct<Touch> {
+        struct Fields {
+            int32_t m_FingerId;
+            UnityEngine::Vector2::Object m_Position;
+            UnityEngine::Vector2::Object m_RawPosition;
+            UnityEngine::Vector2::Object m_PositionDelta;
+            float m_TimeDelta;
+            int32_t m_TapCount;
+            int32_t m_Phase;
+            UnityEngine::TouchType m_Type;
+            float m_Pressure;
+            float m_maximumPossiblePressure;
+            float m_Radius;
+            float m_RadiusVariance;
+            float m_AltitudeAngle;
+            float m_AzimuthAngle;
+        };
+
+        inline UnityEngine::Vector2::Object get_position() {
+            return external<UnityEngine::Vector2::Object>(0x02c2c510, this);
+        }
+    };
+}
+
+static_assert(sizeof(UnityEngine::Touch::Object) == 0x44);

--- a/src/mod/externals/UnityEngine/Touch.h
+++ b/src/mod/externals/UnityEngine/Touch.h
@@ -25,7 +25,9 @@ namespace UnityEngine {
         };
 
         inline UnityEngine::Vector2::Object get_position() {
-            return external<UnityEngine::Vector2::Object>(0x02c2c510, this);
+            return {
+                .fields = external<UnityEngine::Vector2::Fields>(0x02c2c510, this)
+            };
         }
     };
 }

--- a/src/mod/externals/UnityEngine/TouchType.h
+++ b/src/mod/externals/UnityEngine/TouchType.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace UnityEngine {
+    enum class TouchType : int32_t {
+        Direct = 0,
+        Indirect = 1,
+        Stylus = 2,
+    };
+}

--- a/src/mod/externals/UnityEngine/Transform.h
+++ b/src/mod/externals/UnityEngine/Transform.h
@@ -40,6 +40,16 @@ namespace UnityEngine {
             external<void>(0x0299e630, this, translation);
         }
 
+        inline UnityEngine::Vector3::Object get_position() {
+            return {
+                .fields = external<UnityEngine::Vector3::Fields>(0x0299d1c0, this)
+            };
+        }
+
+        inline void set_position(UnityEngine::Vector3::Object value) {
+            UnityEngine::Vector3::Fields valueProxy = { .x = value.fields.x, .y = value.fields.y, .z = value.fields.z };
+            external<void>(0x0299d270, this, valueProxy);
+        }
 
         // utility functions
         UnityEngine::Transform::Object* GetChild(std::initializer_list<std::int32_t> index) {

--- a/src/mod/externals/UnityEngine/Vector2.h
+++ b/src/mod/externals/UnityEngine/Vector2.h
@@ -16,11 +16,15 @@ namespace UnityEngine {
         }
 
         static inline bool op_Equality(Vector2::Object lhs, Vector2::Object rhs) {
-            return external<bool>(0x029a1d00, lhs, rhs);
+            UnityEngine::Vector2::Fields lhsProxy = { .x = lhs.fields.x, .y = lhs.fields.y };
+            UnityEngine::Vector2::Fields rhsProxy = { .x = rhs.fields.x, .y = rhs.fields.y };
+            return external<bool>(0x029a1d00, lhsProxy, rhsProxy);
         }
 
         static inline bool op_Inequality(Vector2::Object lhs, Vector2::Object rhs) {
-            return external<bool>(0x029a1d30, lhs, rhs);
+            UnityEngine::Vector2::Fields lhsProxy = { .x = lhs.fields.x, .y = lhs.fields.y };
+            UnityEngine::Vector2::Fields rhsProxy = { .x = rhs.fields.x, .y = rhs.fields.y };
+            return external<bool>(0x029a1d30, lhsProxy, rhsProxy);
         }
     };
 }

--- a/src/mod/externals/UnityEngine/Vector2.h
+++ b/src/mod/externals/UnityEngine/Vector2.h
@@ -8,6 +8,20 @@ namespace UnityEngine {
             float x;
             float y;
         };
+
+        static inline Vector2::Object get_zero() {
+            return {
+                .fields = external<Vector2::Fields>(0x029a1670)
+            };
+        }
+
+        static inline bool op_Equality(Vector2::Object lhs, Vector2::Object rhs) {
+            return external<bool>(0x029a1d00, lhs, rhs);
+        }
+
+        static inline bool op_Inequality(Vector2::Object lhs, Vector2::Object rhs) {
+            return external<bool>(0x029a1d30, lhs, rhs);
+        }
     };
 }
 

--- a/src/mod/externals/UnityEngine/Vector3.h
+++ b/src/mod/externals/UnityEngine/Vector3.h
@@ -9,5 +9,9 @@ namespace UnityEngine {
             float y;
             float z;
         };
+
+        inline void ctor(float x, float y, float z) {
+            external<void>(0x0299e850, this, x, y, z);
+        }
     };
 }

--- a/src/mod/externals/UnityEngine/_Object.h
+++ b/src/mod/externals/UnityEngine/_Object.h
@@ -21,5 +21,9 @@ namespace UnityEngine {
         static inline bool op_Equality(UnityEngine::_Object::Object* x, UnityEngine::_Object::Object* y) {
             return external<bool>(0x02688120, x, y);
         }
+
+        static inline bool op_Inequality(UnityEngine::_Object::Object* x, UnityEngine::_Object::Object* y) {
+            return external<bool>(0x0268b620, x, y);
+        }
     };
 }

--- a/src/mod/externals/UnityEngine/_Object.h
+++ b/src/mod/externals/UnityEngine/_Object.h
@@ -3,7 +3,6 @@
 #include "externals/il2cpp-api.h"
 #include "externals/System/String.h"
 
-
 namespace UnityEngine {
     struct _Object : ILClass<_Object> {
         struct Fields {
@@ -17,6 +16,10 @@ namespace UnityEngine {
 
         System::String::Object* GetName() {
             return external<System::String::Object*>(0x0268a940, this);
+        }
+
+        static inline bool op_Equality(UnityEngine::_Object::Object* x, UnityEngine::_Object::Object* y) {
+            return external<bool>(0x02688120, x, y);
         }
     };
 }

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -57,6 +57,7 @@ void exl_patches_main();
 void exl_pla_context_menu_main();
 
 // Adds support for two-button Pokétch.
+// Requires an edited uiresidentwindow bundle with a second Pokétch button.
 void exl_poketch_main();
 
 // Tweaks the move relearner menu to include owned TMs.

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -26,7 +26,7 @@ void exl_features_main() {
     // Extra rombase features
     //exl_battle_revolver_main();
     //exl_exp_share_main();
-    //exl_poketch_main();
+    exl_poketch_main();
     //exl_remap_main();
     //exl_sounds_main();
     //exl_tms_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -17,6 +17,7 @@ void exl_features_main() {
     exl_level_cap_main();
     exl_patches_main();
     exl_pla_context_menu_main();
+    exl_poketch_main();
     exl_relearn_tms_main();
     exl_save_data_expansion();
     exl_settings_main();
@@ -26,7 +27,6 @@ void exl_features_main() {
     // Extra rombase features
     //exl_battle_revolver_main();
     //exl_exp_share_main();
-    exl_poketch_main();
     //exl_remap_main();
     //exl_sounds_main();
     //exl_tms_main();

--- a/src/mod/features/poketch_back_button.cpp
+++ b/src/mod/features/poketch_back_button.cpp
@@ -1,9 +1,26 @@
 #include "exlaunch.hpp"
 
 #include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/Dpr/MsgWindow/MsgWindowManager.h"
+#include "externals/Dpr/UI/PoketchAppBase.h"
+#include "externals/Dpr/UI/PoketchButton.h"
 #include "externals/Dpr/UI/PoketchWindow.h"
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/Dpr/UI/UIWindow.h"
+#include "externals/FieldPoketch.h"
+#include "externals/GameController.h"
+#include "externals/PlayerWork.h"
+#include "externals/System/ThrowHelper.h"
 #include "externals/UnityEngine/Component.h"
-#include "ui/ui.h"
+#include "externals/UnityEngine/Input.h"
+#include "externals/UnityEngine/Time.h"
+#include "externals/UnityEngine/Touch.h"
+#include "externals/UnityEngine/Transform.h"
+#include "externals/UnityEngine/Vector2.h"
+
+#include "logger/logger.h"
 
 void goBackAction(Dpr::UI::PoketchWindow* __this) {
     __this->SelectApp(false);
@@ -49,7 +66,6 @@ HOOK_DEFINE_INLINE(IsInRange_Small) {
 
 HOOK_DEFINE_INLINE(IsInRange_Big) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        Logger::log("Enter IsInRange_Big\n");
         auto window = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
         auto buttonToCheck = (Dpr::UI::PoketchButton::Object*)ctx->X[1];
 
@@ -61,8 +77,6 @@ HOOK_DEFINE_INLINE(IsInRange_Big) {
                 ->Find(System::String::Create("Image_button2"));
         auto backwardsButton = backwardsTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
 
-        Logger::log("Pre button! %08X\n", window->fields._preButton);
-
         // Get float values from registers (not yet supported through ctx, see: https://github.com/shadowninja108/exlaunch/issues/1)
         float x, y;
         __asm(
@@ -73,29 +87,27 @@ HOOK_DEFINE_INLINE(IsInRange_Big) {
                 : "=w"(x), "=w"(y)
                 );
 
-        /*if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)buttonToCheck, (UnityEngine::_Object::Object*)window->fields._changeButton))
+        if (x != 0 && y != 0) Logger::log("Cursor is at x=%f y-%f\n", x, y);
+
+        if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)buttonToCheck, (UnityEngine::_Object::Object*)window->fields._changeButton))
         {
             if (backwardsButton != nullptr && window->IsInRange(backwardsButton, x, y))
             {
                 Logger::log("Actually, this was the backwards button!\n");
                 ctx->X[20] = (uint64_t)backwardsButton;
-                ctx->X[0] = (uint64_t)true;
-                Logger::log("Exit IsInRange_Big\n");
+                ctx->W[0] = (uint64_t)true;
                 return;
             }
 
             if (window->fields._changeButton != nullptr)
             {
                 Logger::log("Forwards button!\n");
-                ctx->X[0] = (uint64_t)window->IsInRange(window->fields._changeButton, x, y);
-                Logger::log("Exit IsInRange_Big\n");
+                ctx->W[0] = (uint64_t)window->IsInRange(window->fields._changeButton, x, y);
                 return;
             }
-        }*/
+        }
 
-        ctx->X[0] = (uint64_t)window->IsInRange(buttonToCheck, x, y);
-
-        Logger::log("Exit IsInRange_Big\n");
+        ctx->W[0] = (uint64_t)window->IsInRange(buttonToCheck, x, y);
     }
 };
 
@@ -122,10 +134,539 @@ HOOK_DEFINE_INLINE(ButtonInit) {
     }
 };
 
+HOOK_DEFINE_TRAMPOLINE(OnRelease) {
+    static void Callback(Dpr::UI::PoketchButton::Object* __this) {
+        Logger::log("OnRelease: %08X\n", __this);
+        Orig(__this);
+    }
+};
+
+void joined_r0x007101e67668(Dpr::UI::PoketchWindow::Object* __this, float deltaTime) {
+    int32_t currentApp = __this->fields._CurrentAppIndex_k__BackingField;
+    if (__this->fields._poketchAppList->fields._size <= currentApp)
+    {
+        System::ThrowHelper::ThrowArgumentOutOfRangeException();
+    }
+
+    Dpr::UI::PoketchAppBase::Object* app = __this->fields._poketchAppList->fields._items->m_Items[currentApp];
+    bool appNotNull = UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)app, nullptr);
+    if (appNotNull)
+    {
+        app->OnUpdate(false, nullptr, (int32_t)Dpr::UI::PoketchWindow::TouchState::None);
+    }
+}
+
+void joined_r0x007101e681a8(Dpr::UI::PoketchWindow::Object* __this, float deltaTime, Dpr::UI::PoketchButton::Object* target, Dpr::UI::PoketchWindow::TouchState touchState) {
+    int32_t currentApp = __this->fields._CurrentAppIndex_k__BackingField;
+    if (__this->fields._poketchAppList->fields._size <= currentApp)
+    {
+        System::ThrowHelper::ThrowArgumentOutOfRangeException();
+    }
+
+    Dpr::UI::PoketchAppBase::Object* app = __this->fields._poketchAppList->fields._items->m_Items[currentApp];
+    bool appNotNull = UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)app, nullptr);
+    if (appNotNull)
+    {
+        app->OnUpdate(false, target, (int32_t)touchState);
+    }
+
+    auto cursorTransform = __this->fields._cursor->cast<UnityEngine::Component>()->get_transform()->instance();
+    UnityEngine::Vector3::Object cursorVector = cursorTransform->get_position();
+    __this->fields._cursorX = cursorVector.fields.x;
+    __this->fields._cursorY = cursorVector.fields.y;
+    __this->fields._touchState = touchState;
+}
+
+HOOK_DEFINE_REPLACE(PoketchWindow_OnUpdate) {
+    static void Callback(Dpr::UI::PoketchWindow::Object* __this, float deltaTime) {
+        Logger::log("PoketchWindow_OnUpdate Start\n");
+        system_load_typeinfo(0x6f3e);
+        system_load_typeinfo(0x6f47);
+
+        Dpr::UI::PoketchWindow::TouchState touchState;
+        Dpr::UI::PoketchButton::Object * target;
+
+        float voiceTimer = __this->fields._voiceTimer;
+        if (0.0 < voiceTimer)
+        {
+            __this->fields._voiceTimer = voiceTimer - UnityEngine::Time::get_deltaTime();
+        }
+
+        FieldPoketch::getClass()->initIfNeeded();
+
+        if (FieldPoketch::IsRejectPoketch())
+        {
+            __this->Close(__this->fields.onClosed);
+            return;
+        }
+
+        if (FieldPoketch::IsCloseOncePoketch())
+        {
+            __this->Close(nullptr);
+            return;
+        }
+
+        auto uiManager = Dpr::UI::UIManager::instance();
+        auto currentWindow = (UnityEngine::_Object::Object *)uiManager->GetCurrentUIWindow<Dpr::UI::UIWindow>(Dpr::UI::UIManager::Method$$GetCurrentUIWindow_UIWindow_);
+        bool isCurrentWindowPoketch = !UnityEngine::_Object::op_Inequality(currentWindow, (UnityEngine::_Object::Object *)__this);
+        if (isCurrentWindowPoketch)
+        {
+            Dpr::EvScript::EvDataManager::getClass()->initIfNeeded();
+            auto evManager = Dpr::EvScript::EvDataManager::get_Instanse();
+            if (!evManager->IsRunningEvent() && !Dpr::MsgWindow::MsgWindowManager::get_IsOpenWindow())
+            {
+                if (__this->fields._isSizeChanging)
+                {
+                    return;
+                }
+                PlayerWork::getClass()->initIfNeeded();
+                if (PlayerWork::get_isPlayerInputActive() && __this->fields._IsLarge_k__BackingField)
+                {
+                    __this->ChangePoketchSize(false, nullptr);
+                    return;
+                }
+
+                __this->fields._buttonR->OnUpdate(deltaTime);
+                __this->fields._buttonSR->OnUpdate(deltaTime);
+                bool isPrevTouch = __this->fields._isTouch;
+                UnityEngine::Vector2::Object touchVec2 = UnityEngine::Vector2::get_zero();
+                if (UnityEngine::Input::get_touchCount() > 0)
+                {
+                    UnityEngine::Touch::Object __this_00 = UnityEngine::Input::GetTouch(0);
+                    touchVec2 = __this_00.get_position();
+                }
+
+                UnityEngine::Vector2::Object zero = UnityEngine::Vector2::get_zero();
+                bool isCurrentTouch = !UnityEngine::Vector2::op_Equality(touchVec2, zero);
+
+                __this->fields._isTouch = isCurrentTouch;
+                if (!__this->fields._IsLarge_k__BackingField && !__this->fields._IsPauseContinue_k__BackingField)
+                {
+                    if (!isPrevTouch & isCurrentTouch)
+                    {
+                        if (__this->IsInRange(__this->fields._changeButton, touchVec2.fields.x, touchVec2.fields.y))
+                        {
+                            __this->fields._changeButton->OnPush();
+                        }
+                    }
+                    joined_r0x007101e67668(__this, deltaTime);
+                    return;
+                }
+
+                GameController::getClass()->initIfNeeded();
+
+                float cursorX = touchVec2.fields.x;
+                float cursorY = touchVec2.fields.y;
+
+                float changeX = 0.0;
+                float changeY = 0.0;
+
+                bool movingCursor = UnityEngine::Vector2::op_Inequality(GameController::getClass()->static_fields->analogStickL, UnityEngine::Vector2::get_zero());
+                if (!movingCursor)
+                {
+                    if ((uiManager->klass->static_fields->StickLLeft & GameController::getClass()->static_fields->accel) != 0)
+                    {
+                        changeX = -__this->fields._cursolMoveValue;
+                    }
+                    else if ((uiManager->klass->static_fields->StickLRight & GameController::getClass()->static_fields->accel) != 0)
+                    {
+                        changeX = __this->fields._cursolMoveValue;
+                    }
+                    else
+                    {
+                        changeX = 0.0;
+                    }
+
+                    if ((uiManager->klass->static_fields->StickLUp & GameController::getClass()->static_fields->accel) != 0)
+                    {
+                        changeY = __this->fields._cursolMoveValue;
+                    }
+                    else if ((uiManager->klass->static_fields->StickLDown & GameController::getClass()->static_fields->accel) != 0)
+                    {
+                        changeY = -__this->fields._cursolMoveValue;
+                    }
+                    else
+                    {
+                        changeY = 0.0;
+                    }
+                }
+                else
+                {
+                    float cursorMove = __this->fields._cursolMoveValue;
+                    changeX = changeX * cursorMove;
+                    changeY = changeY * cursorMove;
+                }
+
+                if (__this->fields._isTouch)
+                {
+                    __this->SetCursorPosition(cursorX, cursorY);
+                }
+                else
+                {
+                    if (changeX != 0.0 || changeY != 0.0)
+                    {
+                        UnityEngine::Transform::Object* cursorTransform = __this->fields._cursor->cast<UnityEngine::Component>()->get_transform()->instance();
+                        UnityEngine::Vector3::Object cursorVec3 = cursorTransform->get_position();
+                        cursorX = changeX + cursorVec3.fields.x;
+                        cursorY = changeY + cursorVec3.fields.y;
+                        __this->SetCursorPosition(cursorX, cursorY);
+                    }
+                }
+
+                int32_t currentApp = __this->fields._CurrentAppIndex_k__BackingField;
+                if (__this->fields._poketchAppList->fields._size <= currentApp)
+                {
+                    System::ThrowHelper::ThrowArgumentOutOfRangeException();
+                }
+                Dpr::UI::PoketchAppBase::Object* app = __this->fields._poketchAppList->fields._items->m_Items[currentApp];
+
+                if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)app, nullptr))
+                {
+                    if (app->fields.Buttons != nullptr)
+                    {
+                        Dpr::UI::PoketchButton::Object* btn27 = nullptr;
+
+                        for (uint64_t j=0; j<app->fields.Buttons->max_length+1; j++)
+                        {
+                            Dpr::UI::PoketchButton::Object** currentButtonPtr1 = &__this->fields._preButton;
+
+                            Dpr::UI::PoketchButton::Object** currentButtonPtr11 = &__this->fields._changeButton;
+                            if (j < app->fields.Buttons->max_length)
+                            {
+                                currentButtonPtr11 = &app->fields.Buttons->m_Items[j];
+                            }
+                            target = *currentButtonPtr11;
+
+                            UnityEngine::Transform::Object* cursorTransform = __this->fields._cursor->cast<UnityEngine::Component>()->get_transform()->instance();
+                            UnityEngine::Vector3::Object cursorVec3 = cursorTransform->get_position();
+                            if (!__this->IsInRange(target, cursorVec3.fields.x, cursorVec3.fields.y))
+                            {
+                                if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)target, (UnityEngine::_Object::Object*)*currentButtonPtr1))
+                                {
+                                    if (!__this->fields._isTouch)
+                                    {
+                                        if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->on) == 0)
+                                        {
+                                            (*currentButtonPtr1)->SetRelease();
+                                            *currentButtonPtr1 = nullptr;
+                                            target = btn27;
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                            joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                            return;
+                                        }
+                                    }
+
+                                    if (target->fields._canDrag)
+                                    {
+                                        if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)*currentButtonPtr1, nullptr))
+                                        {
+                                            if (cursorVec3.fields.x < __this->fields._cursorMaxX + 1.0)
+                                            {
+                                                UnityEngine::Transform::Object* targetTransform = target->cast<UnityEngine::Component>()->get_transform()->instance();
+
+                                                UnityEngine::Vector3::Object newCursorVec = {};
+                                                newCursorVec.ctor(cursorVec3.fields.x, cursorVec3.fields.y, 0.0);
+                                                targetTransform->set_position(newCursorVec);
+
+                                                touchState = Dpr::UI::PoketchWindow::TouchState::Hold;
+                                                joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                                return;
+                                            }
+                                        }
+                                    }
+
+                                    (*currentButtonPtr1)->SetRelease();
+                                    *currentButtonPtr1 = nullptr;
+                                    touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                    target = btn27;
+                                    joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                    return;
+                                }
+
+                                continue;
+                            }
+
+                            if (cursorX > __this->fields._cursorMaxX && cursorY < __this->fields._cursorMaxY - 16.0)
+                            {
+                                *currentButtonPtr1 = nullptr;
+
+                                if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) != 0)
+                                {
+                                    *currentButtonPtr1 = target;
+                                    target->SetTouch();
+                                    touchState = Dpr::UI::PoketchWindow::TouchState::Touch;
+                                    joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                    return;
+                                }
+
+                                btn27 = target;
+                                if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) == 0)
+                                {
+                                    if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->release) != 0)
+                                    {
+                                        btn27 = *currentButtonPtr1;
+                                        if (!UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)btn27, (UnityEngine::_Object::Object*)target))
+                                        {
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                        }
+                                        else
+                                        {
+                                            __this->fields._preButton = nullptr;
+                                            target->SetRelease();
+                                            if (__this->fields._isSizeChanging)
+                                            {
+                                                return;
+                                            }
+                                            target->OnPush();
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Push;
+                                        }
+                                        joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                        return;
+                                    }
+                                }
+                                else
+                                {
+                                    if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)target, nullptr))
+                                    {
+                                        if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)*currentButtonPtr1, (UnityEngine::_Object::Object*)target))
+                                        {
+                                            if (target->fields._canDrag)
+                                            {
+                                                float clampedCursorX = __this->fields._cursorMaxX;
+                                                if (clampedCursorX > cursorVec3.fields.x)
+                                                {
+                                                    clampedCursorX = cursorVec3.fields.x;
+                                                }
+
+                                                UnityEngine::Transform::Object* targetTransform = target->cast<UnityEngine::Component>()->get_transform()->instance();
+
+                                                UnityEngine::Vector3::Object newCursorVec = {};
+                                                newCursorVec.ctor(clampedCursorX, cursorVec3.fields.y, 0.0);
+                                                targetTransform->set_position(newCursorVec);
+                                            }
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Hold;
+                                            joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                            return;
+                                        }
+                                    }
+                                }
+
+                                continue;
+                            }
+
+                            if (!__this->fields._isTouch)
+                            {
+                                if (!isPrevTouch)
+                                {
+                                    if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) != 0)
+                                    {
+                                        *currentButtonPtr1 = target;
+                                        target->SetTouch();
+                                        touchState = Dpr::UI::PoketchWindow::TouchState::Touch;
+                                        joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                        return;
+                                    }
+
+                                    btn27 = target;
+                                    if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) == 0)
+                                    {
+                                        if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->release) != 0)
+                                        {
+                                            btn27 = *currentButtonPtr1;
+                                            if (!UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)btn27, (UnityEngine::_Object::Object*)target))
+                                            {
+                                                touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                            }
+                                            else
+                                            {
+                                                __this->fields._preButton = nullptr;
+                                                target->SetRelease();
+                                                if (__this->fields._isSizeChanging)
+                                                {
+                                                    return;
+                                                }
+                                                target->OnPush();
+                                                touchState = Dpr::UI::PoketchWindow::TouchState::Push;
+                                            }
+                                            joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                            return;
+                                        }
+                                    }
+                                    else
+                                    {
+                                        if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)target, nullptr))
+                                        {
+                                            if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)*currentButtonPtr1, (UnityEngine::_Object::Object*)target))
+                                            {
+                                                if (target->fields._canDrag)
+                                                {
+                                                    float clampedCursorX = __this->fields._cursorMaxX;
+                                                    if (clampedCursorX > cursorVec3.fields.x)
+                                                    {
+                                                        clampedCursorX = cursorVec3.fields.x;
+                                                    }
+
+                                                    UnityEngine::Transform::Object* targetTransform = target->cast<UnityEngine::Component>()->get_transform()->instance();
+
+                                                    UnityEngine::Vector3::Object newCursorVec = {};
+                                                    newCursorVec.ctor(clampedCursorX, cursorVec3.fields.y, 0.0);
+                                                    targetTransform->set_position(newCursorVec);
+                                                }
+                                                touchState = Dpr::UI::PoketchWindow::TouchState::Hold;
+                                                joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                                return;
+                                            }
+                                        }
+                                    }
+
+                                    continue;
+                                }
+
+                                btn27 = *currentButtonPtr1;
+                                if (!UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)btn27, (UnityEngine::_Object::Object*)target))
+                                {
+                                    touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                }
+                                else
+                                {
+                                    __this->fields._preButton = nullptr;
+                                    target->SetRelease();
+                                    if (__this->fields._isSizeChanging)
+                                    {
+                                        return;
+                                    }
+                                    target->OnPush();
+                                    touchState = Dpr::UI::PoketchWindow::TouchState::Push;
+                                }
+                                joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                return;
+                            }
+
+                            if (!isPrevTouch)
+                            {
+                                *currentButtonPtr1 = target;
+                                target->SetTouch();
+                                touchState = Dpr::UI::PoketchWindow::TouchState::Touch;
+                                joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                return;
+                            }
+
+                            btn27 = *currentButtonPtr1;
+                            if (!UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)btn27, (UnityEngine::_Object::Object*)target))
+                            {
+                                if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) != 0)
+                                {
+                                    *currentButtonPtr1 = target;
+                                    target->SetTouch();
+                                    touchState = Dpr::UI::PoketchWindow::TouchState::Touch;
+                                    joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                    return;
+                                }
+
+                                btn27 = target;
+                                if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->push) == 0)
+                                {
+                                    if ((uiManager->klass->static_fields->ButtonA & GameController::getClass()->static_fields->release) != 0)
+                                    {
+                                        btn27 = *currentButtonPtr1;
+                                        if (!UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)btn27, (UnityEngine::_Object::Object*)target))
+                                        {
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Release;
+                                        }
+                                        else
+                                        {
+                                            __this->fields._preButton = nullptr;
+                                            target->SetRelease();
+                                            if (__this->fields._isSizeChanging)
+                                            {
+                                                return;
+                                            }
+                                            target->OnPush();
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Push;
+                                        }
+                                        joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                        return;
+                                    }
+                                }
+                                else
+                                {
+                                    if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)target, nullptr))
+                                    {
+                                        if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)*currentButtonPtr1, (UnityEngine::_Object::Object*)target))
+                                        {
+                                            if (target->fields._canDrag)
+                                            {
+                                                float clampedCursorX = __this->fields._cursorMaxX;
+                                                if (clampedCursorX > cursorVec3.fields.x)
+                                                {
+                                                    clampedCursorX = cursorVec3.fields.x;
+                                                }
+
+                                                UnityEngine::Transform::Object* targetTransform = target->cast<UnityEngine::Component>()->get_transform()->instance();
+
+                                                UnityEngine::Vector3::Object newCursorVec = {};
+                                                newCursorVec.ctor(clampedCursorX, cursorVec3.fields.y, 0.0);
+                                                targetTransform->set_position(newCursorVec);
+                                            }
+                                            touchState = Dpr::UI::PoketchWindow::TouchState::Hold;
+                                            joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                                            return;
+                                        }
+                                    }
+                                }
+
+                                continue;
+                            }
+
+                            if (target->fields._canDrag)
+                            {
+                                float clampedCursorX = __this->fields._cursorMaxX;
+                                if (cursorVec3.fields.x < clampedCursorX)
+                                {
+                                    clampedCursorX = cursorVec3.fields.x;
+                                }
+
+                                UnityEngine::Transform::Object* targetTransform = target->cast<UnityEngine::Component>()->get_transform()->instance();
+                                UnityEngine::Vector3::Object newCursorVec = {};
+                                newCursorVec.ctor(clampedCursorX, cursorVec3.fields.y, 0.0);
+                                targetTransform->set_position(newCursorVec);
+                            }
+
+                            touchState = Dpr::UI::PoketchWindow::TouchState::Hold;
+                            joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                            return;
+                        }
+
+                        touchState = Dpr::UI::PoketchWindow::TouchState::None;
+                        target = btn27;
+                        joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                        return;
+                    }
+                }
+
+                target = nullptr;
+                touchState = Dpr::UI::PoketchWindow::TouchState::None;
+                joined_r0x007101e681a8(__this, deltaTime, target, touchState);
+                return;
+            }
+        }
+
+        if (__this->fields._IsLarge_k__BackingField)
+        {
+            __this->ChangePoketchSize(false, nullptr);
+        }
+
+        joined_r0x007101e67668(__this, deltaTime);
+    }
+};
+
 void exl_poketch_main() {
-    IsInRange_Small::InstallAtOffset(0x01e67a3c);
-    IsInRange_Big::InstallAtOffset(0x01e67d54);
-    ButtonInit::InstallAtOffset(0x01e66b5c);
+    //IsInRange_Small::InstallAtOffset(0x01e67a3c);
+    //IsInRange_Big::InstallAtOffset(0x01e67d54);
+    //ButtonInit::InstallAtOffset(0x01e66b5c);
+    //OnRelease::InstallAtOffset(0x01e66280);
+
+    PoketchWindow_OnUpdate::InstallAtOffset(0x01e67480);
 
     // Make our CheckOnPush hook get called one extra time, for the backwards button
     /*using namespace exl::armv8::inst;

--- a/src/mod/features/poketch_back_button.cpp
+++ b/src/mod/features/poketch_back_button.cpp
@@ -26,91 +26,6 @@ void goBackAction(Dpr::UI::PoketchWindow* __this) {
     __this->SelectApp(false);
 }
 
-HOOK_DEFINE_INLINE(IsInRange_Small) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto window = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
-        auto forwardsButton = (Dpr::UI::PoketchButton::Object*)ctx->X[1];
-
-        auto windowTransform = window->cast<UnityEngine::Component>()->get_transform();
-        auto backwardsTransform = windowTransform->Find(System::String::Create("Window"))
-                ->Find(System::String::Create("Poketch"))
-                ->Find(System::String::Create("Body_02"))
-                ->Find(System::String::Create("Mask"))
-                ->Find(System::String::Create("Image_button2"));
-        auto backwardsButton = backwardsTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
-
-        // Get float values from registers (not yet supported through ctx, see: https://github.com/shadowninja108/exlaunch/issues/1)
-        float x, y;
-        __asm(
-            R"(
-                mov %0.16B, v8.16B
-                mov %1.16B, v9.16B
-            )"
-            : "=w"(x), "=w"(y)
-        );
-
-        if (backwardsButton != nullptr && window->IsInRange(backwardsButton, x, y))
-        {
-            backwardsButton->OnPush();
-            ctx->X[0] = (uint64_t)false;
-            return;
-        }
-
-        if (forwardsButton != nullptr)
-        {
-            ctx->X[0] = (uint64_t)window->IsInRange(forwardsButton, x, y);
-            return;
-        }
-    }
-};
-
-HOOK_DEFINE_INLINE(IsInRange_Big) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto window = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
-        auto buttonToCheck = (Dpr::UI::PoketchButton::Object*)ctx->X[1];
-
-        auto windowTransform = window->cast<UnityEngine::Component>()->get_transform();
-        auto backwardsTransform = windowTransform->Find(System::String::Create("Window"))
-                ->Find(System::String::Create("Poketch"))
-                ->Find(System::String::Create("Body_02"))
-                ->Find(System::String::Create("Mask"))
-                ->Find(System::String::Create("Image_button2"));
-        auto backwardsButton = backwardsTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
-
-        // Get float values from registers (not yet supported through ctx, see: https://github.com/shadowninja108/exlaunch/issues/1)
-        float x, y;
-        __asm(
-                R"(
-                mov %0.16B, v8.16B
-                mov %1.16B, v9.16B
-            )"
-                : "=w"(x), "=w"(y)
-                );
-
-        if (x != 0 && y != 0) Logger::log("Cursor is at x=%f y-%f\n", x, y);
-
-        if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)buttonToCheck, (UnityEngine::_Object::Object*)window->fields._changeButton))
-        {
-            if (backwardsButton != nullptr && window->IsInRange(backwardsButton, x, y))
-            {
-                Logger::log("Actually, this was the backwards button!\n");
-                ctx->X[20] = (uint64_t)backwardsButton;
-                ctx->W[0] = (uint64_t)true;
-                return;
-            }
-
-            if (window->fields._changeButton != nullptr)
-            {
-                Logger::log("Forwards button!\n");
-                ctx->W[0] = (uint64_t)window->IsInRange(window->fields._changeButton, x, y);
-                return;
-            }
-        }
-
-        ctx->W[0] = (uint64_t)window->IsInRange(buttonToCheck, x, y);
-    }
-};
-
 HOOK_DEFINE_INLINE(ButtonInit) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto forwardsButton = (Dpr::UI::PoketchButton::Object*)ctx->X[0];
@@ -131,13 +46,6 @@ HOOK_DEFINE_INLINE(ButtonInit) {
         auto backwardsAction = UnityEngine::Events::UnityAction::getClass(UnityEngine::Events::UnityAction::void_TypeInfo)->newInstance(poketchWindow, mi.copyWith((Il2CppMethodPointer) &goBackAction));
 
         backwardsButton->Initialize(backwardsAction, forwardsSeEventId);
-    }
-};
-
-HOOK_DEFINE_TRAMPOLINE(OnRelease) {
-    static void Callback(Dpr::UI::PoketchButton::Object* __this) {
-        Logger::log("OnRelease: %08X\n", __this);
-        Orig(__this);
     }
 };
 
@@ -179,7 +87,6 @@ void joined_r0x007101e681a8(Dpr::UI::PoketchWindow::Object* __this, float deltaT
 
 HOOK_DEFINE_REPLACE(PoketchWindow_OnUpdate) {
     static void Callback(Dpr::UI::PoketchWindow::Object* __this, float deltaTime) {
-        Logger::log("PoketchWindow_OnUpdate Start\n");
         system_load_typeinfo(0x6f3e);
         system_load_typeinfo(0x6f47);
 
@@ -232,8 +139,9 @@ HOOK_DEFINE_REPLACE(PoketchWindow_OnUpdate) {
                 UnityEngine::Vector2::Object touchVec2 = UnityEngine::Vector2::get_zero();
                 if (UnityEngine::Input::get_touchCount() > 0)
                 {
-                    UnityEngine::Touch::Object __this_00 = UnityEngine::Input::GetTouch(0);
-                    touchVec2 = __this_00.get_position();
+                    UnityEngine::Touch::Object touch = {};
+                    UnityEngine::Input::GetTouch(0, &touch);
+                    touchVec2 = touch.get_position();
                 }
 
                 UnityEngine::Vector2::Object zero = UnityEngine::Vector2::get_zero();
@@ -661,18 +569,6 @@ HOOK_DEFINE_REPLACE(PoketchWindow_OnUpdate) {
 };
 
 void exl_poketch_main() {
-    //IsInRange_Small::InstallAtOffset(0x01e67a3c);
-    //IsInRange_Big::InstallAtOffset(0x01e67d54);
-    //ButtonInit::InstallAtOffset(0x01e66b5c);
-    //OnRelease::InstallAtOffset(0x01e66280);
-
+    ButtonInit::InstallAtOffset(0x01e66b5c);
     PoketchWindow_OnUpdate::InstallAtOffset(0x01e67480);
-
-    // Make our CheckOnPush hook get called one extra time, for the backwards button
-    /*using namespace exl::armv8::inst;
-    using namespace exl::armv8::reg;
-    exl::patch::CodePatcher p(0x01e67c64);
-    p.WriteInst(Nop());
-    p.WriteInst(AddImmediate(X8, X8, 0x2));
-    p.WriteInst(0xeb08037f);*/ // cmp x27, x8
 }

--- a/src/mod/features/poketch_back_button.cpp
+++ b/src/mod/features/poketch_back_button.cpp
@@ -9,17 +9,18 @@ void goBackAction(Dpr::UI::PoketchWindow* __this) {
     __this->SelectApp(false);
 }
 
-HOOK_DEFINE_INLINE(PoketchInBoundsCheck) {
+HOOK_DEFINE_INLINE(IsInRange_Small) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto res = ctx->X[0];
-        auto prevCheck = ctx->W[8];
-        if (prevCheck == 0 || (res & 1) != 0) return;
-
         auto window = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
+        auto forwardsButton = (Dpr::UI::PoketchButton::Object*)ctx->X[1];
 
         auto windowTransform = window->cast<UnityEngine::Component>()->get_transform();
-        auto buttonTransform = windowTransform->GetChild({ 1, 0, 1, 0, 2});
-        auto button = buttonTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
+        auto backwardsTransform = windowTransform->Find(System::String::Create("Window"))
+                ->Find(System::String::Create("Poketch"))
+                ->Find(System::String::Create("Body_02"))
+                ->Find(System::String::Create("Mask"))
+                ->Find(System::String::Create("Image_button2"));
+        auto backwardsButton = backwardsTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
 
         // Get float values from registers (not yet supported through ctx, see: https://github.com/shadowninja108/exlaunch/issues/1)
         float x, y;
@@ -31,56 +32,106 @@ HOOK_DEFINE_INLINE(PoketchInBoundsCheck) {
             : "=w"(x), "=w"(y)
         );
 
-        if (button != nullptr && window->IsInRange(button, x, y)) {
-            button->OnPush();
+        if (backwardsButton != nullptr && window->IsInRange(backwardsButton, x, y))
+        {
+            backwardsButton->OnPush();
+            ctx->X[0] = (uint64_t)false;
+            return;
+        }
+
+        if (forwardsButton != nullptr)
+        {
+            ctx->X[0] = (uint64_t)window->IsInRange(forwardsButton, x, y);
+            return;
         }
     }
 };
 
-HOOK_DEFINE_TRAMPOLINE(PoketchAppButtonExtend) {
-    static void Callback(Dpr::UI::PoketchWindow::Object* window) {
-        Orig(window);
+HOOK_DEFINE_INLINE(IsInRange_Big) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("Enter IsInRange_Big\n");
+        auto window = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
+        auto buttonToCheck = (Dpr::UI::PoketchButton::Object*)ctx->X[1];
 
         auto windowTransform = window->cast<UnityEngine::Component>()->get_transform();
-        auto mask = windowTransform->GetChild({ 1, 0, 1, 0 });
+        auto backwardsTransform = windowTransform->Find(System::String::Create("Window"))
+                ->Find(System::String::Create("Poketch"))
+                ->Find(System::String::Create("Body_02"))
+                ->Find(System::String::Create("Mask"))
+                ->Find(System::String::Create("Image_button2"));
+        auto backwardsButton = backwardsTransform->GetComponent<Dpr::UI::PoketchButton>(window->fields._changeButton->klass);
 
-        auto change = window->fields._changeButton;
-        auto newButton = UnityEngine::_Object::Instantiate<UnityEngine::Transform>(change->cast<UnityEngine::Component>()->get_transform());
+        Logger::log("Pre button! %08X\n", window->fields._preButton);
 
-        newButton->SetParent(mask, false);
-        auto btn = newButton->GetComponent<Dpr::UI::PoketchButton>(change->klass);
+        // Get float values from registers (not yet supported through ctx, see: https://github.com/shadowninja108/exlaunch/issues/1)
+        float x, y;
+        __asm(
+                R"(
+                mov %0.16B, v8.16B
+                mov %1.16B, v9.16B
+            )"
+                : "=w"(x), "=w"(y)
+                );
 
-        // Reposition button
-        UnityEngine::Vector3::Object trans {
-                .fields = UnityEngine::Vector3::Fields {
-                        .x = 0.0f,
-                        .y = 0.0f,
-                        .z = 0.0f,
-                }
-        };
-        newButton->Translate(&trans);
+        /*if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)buttonToCheck, (UnityEngine::_Object::Object*)window->fields._changeButton))
+        {
+            if (backwardsButton != nullptr && window->IsInRange(backwardsButton, x, y))
+            {
+                Logger::log("Actually, this was the backwards button!\n");
+                ctx->X[20] = (uint64_t)backwardsButton;
+                ctx->X[0] = (uint64_t)true;
+                Logger::log("Exit IsInRange_Big\n");
+                return;
+            }
 
-        // Change button action
-        ILMethod mi(change->fields._onButtonAction->fields.method);
-        auto action = change->fields._onButtonAction->klass->newInstance(window, mi.copyWith((Il2CppMethodPointer) &goBackAction));
-        btn->Initialize(action, -1);
+            if (window->fields._changeButton != nullptr)
+            {
+                Logger::log("Forwards button!\n");
+                ctx->X[0] = (uint64_t)window->IsInRange(window->fields._changeButton, x, y);
+                Logger::log("Exit IsInRange_Big\n");
+                return;
+            }
+        }*/
 
-        // Seems to largely get ignored?
-        window->fields._preButton = btn;
+        ctx->X[0] = (uint64_t)window->IsInRange(buttonToCheck, x, y);
 
-        auto apps = window->fields._poketchAppList->fields._items;
-        for (uint64_t i = 0; i < apps->max_length; i++) {
-            auto app = apps->m_Items[i];
-            auto size = app->fields.Buttons->max_length;
-            auto newArray = (Dpr::UI::PoketchButton::Array*)system_array_new(app->fields.Buttons->obj.klass, size + 1);
-            app->fields.Buttons->copyInto(&newArray->m_Items[0]);
-            app->fields.Buttons = newArray;
-            app->fields.Buttons->m_Items[size] = btn;
-        }
+        Logger::log("Exit IsInRange_Big\n");
+    }
+};
+
+HOOK_DEFINE_INLINE(ButtonInit) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto forwardsButton = (Dpr::UI::PoketchButton::Object*)ctx->X[0];
+        auto forwardsAction = (UnityEngine::Events::UnityAction::Object*)ctx->X[1];
+        auto forwardsSeEventId = (int32_t)ctx->W[2];
+
+        forwardsButton->Initialize(forwardsAction, forwardsSeEventId);
+
+        auto poketchWindow = (Dpr::UI::PoketchWindow::Object*)ctx->X[19];
+        auto windowTransform = poketchWindow->cast<UnityEngine::Component>()->get_transform();
+        auto mask = windowTransform->Find(System::String::Create("Window"))
+                ->Find(System::String::Create("Poketch"))
+                ->Find(System::String::Create("Body_02"))
+                ->Find(System::String::Create("Mask"));
+
+        auto backwardsButton = mask->Find(System::String::Create("Image_button2"))->GetComponent<Dpr::UI::PoketchButton>(poketchWindow->fields._changeButton->klass);
+        ILMethod mi(forwardsAction->fields.method);
+        auto backwardsAction = UnityEngine::Events::UnityAction::getClass(UnityEngine::Events::UnityAction::void_TypeInfo)->newInstance(poketchWindow, mi.copyWith((Il2CppMethodPointer) &goBackAction));
+
+        backwardsButton->Initialize(backwardsAction, forwardsSeEventId);
     }
 };
 
 void exl_poketch_main() {
-    PoketchInBoundsCheck::InstallAtOffset(0x01e67660);
-    PoketchAppButtonExtend::InstallAtOffset(0x01e66870);
+    IsInRange_Small::InstallAtOffset(0x01e67a3c);
+    IsInRange_Big::InstallAtOffset(0x01e67d54);
+    ButtonInit::InstallAtOffset(0x01e66b5c);
+
+    // Make our CheckOnPush hook get called one extra time, for the backwards button
+    /*using namespace exl::armv8::inst;
+    using namespace exl::armv8::reg;
+    exl::patch::CodePatcher p(0x01e67c64);
+    p.WriteInst(Nop());
+    p.WriteInst(AddImmediate(X8, X8, 0x2));
+    p.WriteInst(0xeb08037f);*/ // cmp x27, x8
 }


### PR DESCRIPTION
- Changes the 2-button Pokétch system to look for the back button in the RomFS instead of cloning the forwards button.
  - This required an entire rewrite of Dpr.UI.PoketchWindow$$OnUpdate.
- Adjusted all proxy-using methods (for the floating-point registers weirdness) to use the Fields structure of Vectors instead of defining a new one.