### PR TITLE
Port Shiny rates

### DIFF
--- a/src/mod/externals/Dpr/Item/ItemInfo.h
+++ b/src/mod/externals/Dpr/Item/ItemInfo.h
@@ -12,5 +12,9 @@ namespace Dpr::Item {
         inline int32_t get_Id() {
             return external<int32_t>(0x01ca61f0, this);
         }
+
+        inline int32_t get_count() {
+            return external<int32_t>(0x01ca5cc0, this);
+        }
     };
 }

--- a/src/mod/externals/ItemWork.h
+++ b/src/mod/externals/ItemWork.h
@@ -2,14 +2,18 @@
 
 #include "il2cpp-api.h"
 
+#include "externals/Dpr/Item/ItemInfo.h"
+
 struct ItemWork : ILClass<ItemWork> {
     static inline int32_t AddItem(int32_t itemno, int32_t num) {
         return external<int32_t>(0x01aea3a0, itemno, num);
     }
 
-    static inline int32_t SubItem(int32_t itemno,int32_t num) {
+    static inline int32_t SubItem(int32_t itemno, int32_t num) {
         return external<int32_t>(0x01aea450, itemno, num);
     }
 
-
+    static inline Dpr::Item::ItemInfo::Object* GetItemInfo(int32_t itemno) {
+        return external<Dpr::Item::ItemInfo::Object*>(0x01aea5b0, itemno);
+    }
 };

--- a/src/mod/externals/Pml/Local/Random.h
+++ b/src/mod/externals/Pml/Local/Random.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+
+namespace Pml::Local {
+    struct Random : ILClass<Random> {
+        struct Fields {
+            // TODO
+        };
+
+        static inline uint32_t GetValue() {
+            return external<uint32_t>(0x024a00a0);
+        }
+    };
+}

--- a/src/mod/externals/Pml/Local/RandomGenerator.h
+++ b/src/mod/externals/Pml/Local/RandomGenerator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+
+namespace Pml::Local {
+    struct RandomGenerator : ILClass<RandomGenerator> {
+        struct Fields {
+            // TODO
+        };
+
+        inline uint32_t GetRand() {
+            return external<uint32_t>(0x024a0420, this);
+        }
+    };
+}

--- a/src/mod/externals/Pml/PokePara/CalcTool.h
+++ b/src/mod/externals/Pml/PokePara/CalcTool.h
@@ -7,5 +7,9 @@ namespace Pml::PokePara {
         static inline uint8_t GetArceusType(uint32_t itemno) {
             return external<uint8_t>(0x024ae710, itemno);
         }
+
+        static inline bool IsRareColor(uint32_t id, uint32_t rnd) {
+            return external<bool>(0x024ad790, id, rnd);
+        }
     };
 }

--- a/src/mod/externals/Pml/PokePara/InitialSpec.h
+++ b/src/mod/externals/Pml/PokePara/InitialSpec.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+
+namespace Pml::PokePara {
+    struct InitialSpec : ILClass<InitialSpec> {
+        struct Fields {
+            uint64_t randomSeed;
+            bool isRandomSeedEnable;
+            uint64_t personalRnd;
+            uint64_t rareRnd;
+            uint64_t id;
+            int32_t monsno;
+            uint16_t formno;
+            uint16_t level;
+            uint16_t sex;
+            uint16_t seikaku;
+            uint8_t tokuseiIndex;
+            uint8_t rareTryCount;
+            System::UInt16_array* talentPower;
+            uint32_t friendship;
+            uint8_t talentVNum;
+            uint16_t weight;
+            uint16_t height;
+        };
+    };
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -72,6 +72,9 @@ void exl_save_data_expansion();
 // Adds support for new settings.
 void exl_settings_main();
 
+// Reworks the shiny rates.
+void exl_shiny_rates_main();
+
 // Adds support for Sigma Platinum-style Sound encounters.
 void exl_sounds_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -21,6 +21,7 @@ void exl_features_main() {
     exl_relearn_tms_main();
     exl_save_data_expansion();
     exl_settings_main();
+    exl_shiny_rates_main();
     exl_wild_held_items_main();
     exl_wild_forms_main();
 

--- a/src/mod/features/shiny_rates.cpp
+++ b/src/mod/features/shiny_rates.cpp
@@ -1,0 +1,92 @@
+#include "exlaunch.hpp"
+
+#include "data/items.h"
+#include "data/utils.h"
+#include "externals/Dpr/Item/ItemInfo.h"
+#include "externals/ItemWork.h"
+#include "externals/Pml/Local/Random.h"
+#include "externals/Pml/Local/RandomGenerator.h"
+#include "externals/Pml/PokePara/CalcTool.h"
+#include "externals/Pml/PokePara/InitialSpec.h"
+
+uint32_t ShinyRolls(Pml::PokePara::InitialSpec::Object* pFixSpec, Pml::Local::RandomGenerator::Object* rng)
+{
+    uint32_t rareTryCount = pFixSpec->fields.rareTryCount;
+    uint32_t rareRnd = 0;
+    uint32_t id = pFixSpec->fields.id;
+
+    // Base rolls
+    rareTryCount += 8;
+
+    // Shiny charm rolls
+    Dpr::Item::ItemInfo::Object* item = ItemWork::GetItemInfo(array_index(ITEMS, "Shiny Charm"));
+    if (item != nullptr && item->get_count() > 0)
+    {
+        rareTryCount += 2;
+    }
+
+    for (uint32_t i=0; i<rareTryCount; i++)
+    {
+        if (rng == nullptr) rareRnd = Pml::Local::Random::GetValue();
+        else rareRnd = rng->GetRand();
+
+        if (Pml::PokePara::CalcTool::IsRareColor(id, rareRnd))
+        {
+            break;
+        }
+    }
+
+    // Make sure that we don't keep looping
+    pFixSpec->fields.rareTryCount = 0;
+
+    return rareRnd;
+}
+
+HOOK_DEFINE_INLINE(Shiny_GetValue) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto pFixSpec = (Pml::PokePara::InitialSpec::Object*)ctx->X[19];
+
+        ctx->X[0] = (uint64_t)ShinyRolls(pFixSpec, nullptr);
+    }
+};
+
+HOOK_DEFINE_INLINE(Shiny_GetRand) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto pFixSpec = (Pml::PokePara::InitialSpec::Object*)ctx->X[20];
+        auto rng = (Pml::Local::RandomGenerator::Object*)ctx->X[19];
+
+        ctx->X[0] = (uint64_t)ShinyRolls(pFixSpec, rng);
+    }
+};
+
+void exl_shiny_rates_main() {
+    // != 0xffffffffffffffff
+    Shiny_GetValue::InstallAtOffset(0x0205393c);
+    Shiny_GetRand::InstallAtOffset(0x0205391c);
+
+    // 0xffffffffffffffff
+    Shiny_GetValue::InstallAtOffset(0x02053928);
+    Shiny_GetRand::InstallAtOffset(0x020538f8);
+
+    // 0x1ffffffff
+    Shiny_GetValue::InstallAtOffset(0x02053ab0);
+    Shiny_GetRand::InstallAtOffset(0x02053a58);
+
+    // 0x2ffffffff
+    Shiny_GetValue::InstallAtOffset(0x02053adc);
+    Shiny_GetRand::InstallAtOffset(0x02053a88);
+
+    // 0x3ffffffff
+    Shiny_GetValue::InstallAtOffset(0x02053a08);
+    Shiny_GetRand::InstallAtOffset(0x020539a0);
+
+    // Assembly Patches
+    using namespace exl::armv8::inst;
+    using namespace exl::armv8::reg;
+    exl::patch::CodePatcher p(0);
+    auto inst = std::vector {
+        std::make_pair<uint32_t, Instruction>(0x02050880, AddImmediate(W9, W8, 0)), // Remove shiny charm effect from egg-only methods
+        std::make_pair<uint32_t, Instruction>(0x02050874, Movz(W8, 6)), // Change amount of masuda rolls for eggs (6 in vanilla)
+    };
+    p.WriteInst(inst);
+}


### PR DESCRIPTION
Closes #20.

- Ports the shiny rates Starlight patch with minor edits.
  - The two almost identical methods that were changed in Starlight were merged into one.