### PR TITLE
Port Poké Radar fixes

### DIFF
--- a/src/mod/externals/Dpr/Field/SwayGrass.h
+++ b/src/mod/externals/Dpr/Field/SwayGrass.h
@@ -2,11 +2,42 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Audio/AudioInstance.h"
 #include "externals/Dpr/Field/FieldEncount.h"
+#include "externals/UnityEngine/GameObject.h"
 #include "externals/UnityEngine/Vector3.h"
 
 namespace Dpr::Field {
-    struct SwayGrass : ILClass<SwayGrass> {
+    struct SwayGrass : ILClass<SwayGrass, 0x04c5ac58> {
+        struct GrassData : ILClass<GrassData> {
+            struct Fields {
+                bool enable;
+                float effectTime;
+                bool rensaMons;
+                int32_t rank;
+                int32_t random_iro;
+                int32_t random_kakure;
+                UnityEngine::Vector3::Object position;
+                int32_t attricode;
+                UnityEngine::GameObject::Object* transObject;
+            };
+        };
+
+        struct StaticFields {
+            bool is_swaygrass_flag;
+            int32_t swayZone;
+            GrassData::Array* grass_data;
+            Audio::AudioInstance::Array* _grassAudio;
+            GrassData::Object* work_data;
+            uint32_t rensa_count;
+            int32_t rensa_mons;
+            uint32_t rensa_lv;
+            bool BattleEndRensaStart;
+            UnityEngine::GameObject::Object* RootGrass;
+            bool _callSwayBGM;
+            bool _callStopSwayBGM;
+        };
+
         static inline void StopSE() {
             external<void>(0x019b4fa0);
         }

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -48,7 +48,8 @@ void exl_exp_share_main();
 // Adds new Pokémon/held item combos that trigger a form change when held.
 void exl_form_change_held_items_main();
 
-// Makes all Boutique outfits (of both Lucas and Dawn) available at the start.
+// Makes all Boutique outfits (of both Lucas and Dawn) available at the start. Also removes the bike outfit in battle on cycling road.
+// Requires a re-indexed CharacterDressData file in masterdatas.
 void exl_gender_neutral_boutique_main();
 
 // Replaces every instance of Hidden Power being shown as "Normal" type with its actual type for the Pokémon.
@@ -74,6 +75,9 @@ void exl_patches_main();
 
 // Adds nicknaming and move relearning to the party menu.
 void exl_pla_context_menu_main();
+
+// Fixes Poké Radar bugs and improves chain rates.
+void exl_poke_radar_fixes_main();
 
 // Adds support for two-button Pokétch.
 // Requires an edited uiresidentwindow bundle with a second Pokétch button.

--- a/src/mod/features/gender_neutral_boutique.cpp
+++ b/src/mod/features/gender_neutral_boutique.cpp
@@ -24,7 +24,7 @@ HOOK_DEFINE_REPLACE(Dpr_UI_ShopBoutiqueChange_SetupBoutiqueItemParams) {
                 dressId == array_index(OUTFITS, "Contest Style Feminine") ||
                 dressId == array_index(OUTFITS, "Bicycle Style Masculine") ||
                 dressId == array_index(OUTFITS, "Bicycle Style Feminine") ||
-                dressId == array_index(OUTFITS, "Cyber Style 2.0 Feminine"))
+                dressId == array_index(OUTFITS, "Cyber Style 2.0 Masculine"))
             {
                 // Don't add these outfits
                 continue;

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -22,6 +22,7 @@ void exl_features_main() {
     exl_outfit_neutral_ui_main();
     exl_patches_main();
     exl_pla_context_menu_main();
+    exl_poke_radar_fixes_main();
     exl_poketch_main();
     exl_relearn_tms_main();
     exl_save_data_expansion();

--- a/src/mod/features/poke_radar_fixes.cpp
+++ b/src/mod/features/poke_radar_fixes.cpp
@@ -1,0 +1,70 @@
+#include "exlaunch.hpp"
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Field/SwayGrass.h"
+
+#include "logger/logger.h"
+
+HOOK_DEFINE_REPLACE(Dpr_Field_SwayGrass_RensaTalent) {
+    static uint8_t Callback() {
+        system_load_typeinfo(0x8259);
+        Dpr::Field::SwayGrass::getClass()->initIfNeeded();
+
+        bool isSwayGrass = Dpr::Field::SwayGrass::getClass()->static_fields->is_swaygrass_flag;
+        if (isSwayGrass)
+        {
+            // Cap chain to 99,999,999
+            uint32_t chainLength = 99999999;
+            if (Dpr::Field::SwayGrass::getClass()->static_fields->rensa_count + 1 < 99999999)
+            {
+                chainLength = Dpr::Field::SwayGrass::getClass()->static_fields->rensa_count + 1;
+            }
+
+            if (chainLength < 20) // 0-19
+            {
+                Logger::log("0 IVs\n");
+                return 0;
+            }
+            else if (chainLength < 40) // 20-39
+            {
+                Logger::log("1 IVs\n");
+                return 1;
+            }
+            else if (chainLength < 60) // 40-59
+            {
+                Logger::log("2 IVs\n");
+                return 2;
+            }
+            else if (chainLength < 80) // 60-79
+            {
+                Logger::log("3 IVs\n");
+                return 3;
+            }
+            else if (chainLength < 100) // 80-99
+            {
+                Logger::log("4 IVs\n");
+                return 4;
+            }
+            else // 100+
+            {
+                Logger::log("5 IVs\n");
+                return 5;
+            }
+        }
+
+        return 0;
+    }
+};
+
+void exl_poke_radar_fixes_main() {
+    Dpr_Field_SwayGrass_RensaTalent::InstallAtOffset(0x019bd110);
+
+    using namespace exl::armv8::inst;
+    using namespace exl::armv8::reg;
+    exl::patch::CodePatcher p(0);
+    auto inst = std::vector {
+        std::make_pair<uint32_t, Instruction>(0x019bd0a4, Movz(W8, 100)), // Catching on ring 4 is 100%
+        std::make_pair<uint32_t, Instruction>(0x019bd098, Movz(W8, 97)),  // Defeating on ring 4 is 97%
+    };
+    p.WriteInst(inst);
+};


### PR DESCRIPTION
Closes #18.

- Ports the Poké Radar fix patches.
- Adjusts the gender-neutral boutique patch to correctly add Cyber Style 2.0 F, and not Cyber Style 2.0 M.