### PR TITLE
Swam forms

### DIFF
--- a/src/mod/externals/Dpr/Message/MessageGlossaryParseDataModel.h
+++ b/src/mod/externals/Dpr/Message/MessageGlossaryParseDataModel.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Dpr::Message {
+    struct MessageGlossaryParseDataModel : ILClass<MessageGlossaryParseDataModel> {
+        struct Fields {
+            void* tagDataList; // System_Collections_Generic_List_MessageTagDataModel__o*
+            void* setupTagRef; // Dpr_Message_SetupTagReference_o*
+            void* msgFormatter; // Dpr_Message_MessageFormatter_o*
+            void* labelData; // Dpr_Message_LabelData_o*
+            int32_t langID;
+            void* textSb; // System_Text_StringBuilder_o*
+            void* attributeInfo; // Dpr_Message_AttributeInfo_o*
+            float strWidth;
+            float fontSize;
+        };
+    };
+}
+

--- a/src/mod/externals/Dpr/Message/MessageManager.h
+++ b/src/mod/externals/Dpr/Message/MessageManager.h
@@ -2,8 +2,8 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Message/MessageGlossaryParseDataModel.h"
 #include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
-
 
 namespace Dpr::Message {
     struct MessageManager : ILClass<MessageManager> {
@@ -20,6 +20,10 @@ namespace Dpr::Message {
 
         inline System::String::Object * GetSimpleMessage(System::String::Object *fileName,System::String::Object *label) {
             return external<System::String::Object *>(0x0210d000, this, fileName, label);
+        }
+
+        inline Dpr::Message::MessageGlossaryParseDataModel::Object* GetNameMessageDataModel(System::String::Object* fileName, int32_t labelIndex) {
+            return external<Dpr::Message::MessageGlossaryParseDataModel::Object*>(0x02109230, this, fileName, labelIndex);
         }
     };
 }

--- a/src/mod/externals/GameData/DataManager.h
+++ b/src/mod/externals/GameData/DataManager.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+
+#include "externals/Pml/Sex.h"
 #include "externals/XLSXContent/CharacterDressData.h"
+#include "externals/XLSXContent/PokemonInfo.h"
 #include "externals/XLSXContent/ShopTable.h"
 
 namespace GameData {
@@ -50,6 +53,10 @@ namespace GameData {
 
         static inline XLSXContent::CharacterDressData::SheetData::Object * GetCharacterDressData(int32_t dressId) {
             return external<XLSXContent::CharacterDressData::SheetData::Object *>(0x02ccd460, dressId);
+        }
+
+        static inline XLSXContent::PokemonInfo::SheetCatalog::Object* GetPokemonCatalog(int32_t monsNo, int32_t formNo, Pml::Sex sex, bool isRare, bool isEgg) {
+            return external<XLSXContent::PokemonInfo::SheetCatalog::Object*>(0x02cc76a0, monsNo, formNo, sex, isRare, isEgg);
         }
     };
 }

--- a/src/mod/externals/Pml/Personal/SexVector.h
+++ b/src/mod/externals/Pml/Personal/SexVector.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Pml::Personal {
+    enum class SexVector : int32_t {
+        ONLY_MALE = 0,
+        RANDOM_MIN = 1,
+        RANDOM_FEMALE_MIN = 1,
+        RANDOM_MAX = 253,
+        RANDOM_MALE_MAX = 253,
+        ONLY_FEMALE = 254,
+        UNKNOWN = 255,
+    };
+}

--- a/src/mod/externals/TairyouHasseiPokeManager.h
+++ b/src/mod/externals/TairyouHasseiPokeManager.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/GameObject.h"
+
+struct TairyouHasseiPokeManager : ILClass<TairyouHasseiPokeManager> {
+    struct Fields {
+        void* _objects; // TairyouHasseiPoke_array*
+        void* _operation; // SmartPoint_AssetAssistant_AssetRequestOperation_o*
+        float _defaultScale;
+        uint8_t _loadingState;
+        UnityEngine::GameObject::Object* _parent;
+        int32_t _targetZone;
+    };
+};

--- a/src/mod/externals/XLSXContent/PokemonInfo.h
+++ b/src/mod/externals/XLSXContent/PokemonInfo.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+#include "externals/System/String.h"
+#include "externals/UnityEngine/ScriptableObject.h"
+#include "externals/UnityEngine/Vector2.h"
+#include "externals/UnityEngine/Vector3.h"
+
+namespace XLSXContent {
+    struct PokemonInfo : ILClass<PokemonInfo> {
+        struct SheetCatalog : ILClass<SheetCatalog> {
+            struct Fields {
+                int32_t UniqueID;
+                int32_t No;
+                int32_t SinnohNo;
+                int32_t MonsNo;
+                int32_t FormNo;
+                uint8_t Sex;
+                bool Rare;
+                System::String::Object* AssetBundleName;
+                float BattleScale;
+                float ContestScale;
+                int32_t ContestSize;
+                float FieldScale;
+                float FieldChikaScale;
+                float StatueScale;
+                float FieldWalkingScale;
+                float FieldFureaiScale;
+                float MenuScale;
+                System::String::Object* ModelMotion;
+                UnityEngine::Vector3::Object ModelOffset;
+                UnityEngine::Vector3::Object ModelRotationAngle;
+                float DistributionScale;
+                System::String::Object* DistributionModelMotion;
+                UnityEngine::Vector3::Object DistributionModelOffset;
+                UnityEngine::Vector3::Object DistributionModelRotationAngle;
+                float VoiceScale;
+                System::String::Object* VoiceModelMotion;
+                UnityEngine::Vector3::Object VoiceModelOffset;
+                UnityEngine::Vector3::Object VoiceModelRotationAngle;
+                UnityEngine::Vector3::Object CenterPointOffset;
+                UnityEngine::Vector2::Object RotationLimitAngle;
+                float StatusScale;
+                System::String::Object* StatusModelMotion;
+                UnityEngine::Vector3::Object StatusModelOffset;
+                UnityEngine::Vector3::Object StatusModelRotationAngle;
+                float BoxScale;
+                System::String::Object* BoxModelMotion;
+                UnityEngine::Vector3::Object BoxModelOffset;
+                UnityEngine::Vector3::Object BoxModelRotationAngle;
+                float CompareScale;
+                System::String::Object* CompareModelMotion;
+                UnityEngine::Vector3::Object CompareModelOffset;
+                UnityEngine::Vector3::Object CompareModelRotationAngle;
+                float BrakeStart;
+                float BrakeEnd;
+                float WalkSpeed;
+                float RunSpeed;
+                float WalkStart;
+                float RunStart;
+                float BodySize;
+                float AppearLimit;
+                int32_t MoveType;
+                bool GroundEffect;
+                bool Waitmoving;
+                int32_t BattleAjustHeight;
+            };
+        };
+
+        struct SheetTrearuki : ILClass<SheetTrearuki> {
+            struct Fields {
+                bool Enable;
+                System::Int32_array* AnimeIndex;
+                void* AnimeDuration; // System::Single_array*
+            };
+        };
+
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            XLSXContent::PokemonInfo::SheetCatalog::Array* Catalog;
+            XLSXContent::PokemonInfo::SheetTrearuki::Array* Trearuki;
+        };
+    };
+}

--- a/src/mod/externals/ZoneWork.h
+++ b/src/mod/externals/ZoneWork.h
@@ -2,6 +2,8 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/MonsLv.h"
+
 struct ZoneWork : ILClass<ZoneWork> {
     static inline int32_t TairyouHassei_ZoneID() {
         return external<int32_t>(0x017da6f0);
@@ -17,5 +19,9 @@ struct ZoneWork : ILClass<ZoneWork> {
     
     static inline bool IsHillBackZone(int32_t zone_id) {
         return external<bool>(0x017da610, zone_id);
+    }
+
+    static inline MonsLv::Array* TairyouHassei_MonsLv(int32_t zoneid) {
+        return external<MonsLv::Array*>(0x017da780, zoneid);
     }
 };

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -104,6 +104,9 @@ void exl_shiny_rates_main();
 // Adds support for Sigma Platinum-style Sound encounters.
 void exl_sounds_main();
 
+// Adds support for alternate forms for the field swarm models.
+void exl_swarm_forms_main();
+
 // Makes TMs infinite use.
 void exl_tms_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -28,6 +28,7 @@ void exl_features_main() {
     exl_save_data_expansion();
     exl_settings_main();
     exl_shiny_rates_main();
+    exl_swarm_forms_main();
     exl_wild_held_items_main();
     exl_wild_forms_main();
 

--- a/src/mod/features/swarm_forms.cpp
+++ b/src/mod/features/swarm_forms.cpp
@@ -1,0 +1,76 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Message/MessageManager.h"
+#include "externals/GameData/DataManager.h"
+#include "externals/MonsLv.h"
+#include "externals/Pml/Personal/PersonalSystem.h"
+#include "externals/Pml/Personal/SexVector.h"
+#include "externals/Pml/Sex.h"
+#include "externals/System/String.h"
+#include "externals/TairyouHasseiPokeManager.h"
+#include "externals/XLSXContent/PersonalTable.h"
+#include "externals/XLSXContent/PokemonInfo.h"
+
+HOOK_DEFINE_INLINE(TairyouHasseiPokeManager_Loading) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto pokeManager = (TairyouHasseiPokeManager::Object*)ctx->X[19];
+        auto monsLv = (MonsLv::Array*)ctx->X[20];
+
+        int32_t monsNo = (monsLv->m_Items[0].fields.monsNo) & 0x0000FFFF;
+        int32_t formNo = ((monsLv->m_Items[0].fields.monsNo) & 0xFFFF0000) >> 16;
+
+        XLSXContent::PersonalTable::SheetPersonal::Object* personal = Pml::Personal::PersonalSystem::GetPersonalData(monsNo, formNo);
+        uint8_t sexRate = personal->fields.sex;
+        Pml::Sex sex;
+        switch (sexRate)
+        {
+            case (uint8_t)Pml::Personal::SexVector::ONLY_FEMALE:
+                sex = Pml::Sex::FEMALE;
+                break;
+
+            case (uint8_t)Pml::Personal::SexVector::UNKNOWN:
+                sex = Pml::Sex::UNKNOWN;
+                break;
+
+            default:
+                sex = Pml::Sex::MALE;
+                break;
+        }
+
+        bool isRare = false;
+        bool isEgg = false;
+
+        XLSXContent::PokemonInfo::SheetCatalog::Object* catalog = GameData::DataManager::GetPokemonCatalog(monsNo, formNo, sex, isRare, isEgg);
+        System::String::Object* assetBundleName = catalog->fields.AssetBundleName;
+
+        System::String::Object* fullPath = System::String::Concat(System::String::Create("pokemons/field/"), assetBundleName);
+
+        ctx->X[0] = (uint64_t)fullPath;
+    }
+};
+
+HOOK_DEFINE_INLINE(Dpr_Message_MessageWordSetHelper_SetMonsNameWord) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto messageManager = (Dpr::Message::MessageManager::Object*)ctx->X[0];
+        auto fileName = (System::String::Object*)ctx->X[1];
+        auto fullMonsNo = (int32_t)ctx->W[2];
+
+        uint16_t monsNo = fullMonsNo & 0x0000FFFF;
+        uint16_t formNo = (fullMonsNo & 0xFFFF0000) >> 16;
+
+        ctx->X[0] = (uint64_t)messageManager->GetNameMessageDataModel(fileName, monsNo);
+    }
+};
+
+HOOK_DEFINE_TRAMPOLINE(Fix_Swarm_Zone) {
+    static int32_t Callback() {
+        Orig();
+        return 385;
+    }
+};
+
+void exl_swarm_forms_main() {
+    TairyouHasseiPokeManager_Loading::InstallAtOffset(0x02caee94);
+    Dpr_Message_MessageWordSetHelper_SetMonsNameWord::InstallAtOffset(0x01f9a0e0);
+    Fix_Swarm_Zone::InstallAtOffset(0x017da6f0);
+}


### PR DESCRIPTION
Closes #21.

- Ports the Starlight patch that allows alternate forms as field swarm models.
- Fixes a small visual bug when getting a Pokémon's name when the monsno includes the formno in the top 16 bits.