### PR TITLE
UG Forms

### DIFF
--- a/src/mod/externals/Dpr/UnderGround/UgPokeLottery.h
+++ b/src/mod/externals/Dpr/UnderGround/UgPokeLottery.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/XLSXContent/UgEncount.h"
+#include "externals/XLSXContent/UgRandMark.h"
+
+namespace Dpr::UnderGround {
+    struct UgPokeLottery : ILClass<UgPokeLottery, 0x04c655c0> {
+        struct TypeAndSize : ILStruct<TypeAndSize> {
+            struct Fields {
+                int32_t size;
+                uint8_t type;
+                int32_t value;
+            };
+        };
+
+        struct PokeSlot : ILClass<PokeSlot, 0x04c63898> {
+            struct Fields {
+                Pml::PokePara::PokemonParam::Object* param;
+                TypeAndSize::Object ts;
+            };
+        };
+
+        struct Fields {
+            XLSXContent::UgRandMark::Sheettable::Object* randMarkData;
+            XLSXContent::UgEncount::Object* monsData;
+            void* MonsDataIndexs; // System_Collections_Generic_List_KeyValuePair_UgPokeLottery_TypeAndSize__int___o*
+            void* buf_wazaTable; // System_Collections_Generic_List_ushort__o*
+        };
+
+        inline Pml::PokePara::PokemonParam::Object* CreatePokemonParam_by_Tokusei(int32_t monsNo, uint8_t rareTryCount) {
+            return external<Pml::PokePara::PokemonParam::Object*>(0x018bfea0, this, monsNo, rareTryCount);
+        }
+    };
+}
+
+namespace System::Collections::Generic {
+    struct List$$UgPokeLottery_PokeSlot : List<List$$UgPokeLottery_PokeSlot, Dpr::UnderGround::UgPokeLottery::PokeSlot> {
+
+    };
+}

--- a/src/mod/externals/XLSXContent/UgEncount.h
+++ b/src/mod/externals/XLSXContent/UgEncount.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/ScriptableObject.h"
+
+namespace XLSXContent {
+    struct UgEncount : ILClass<UgEncount, 0x04c65798> {
+        struct Sheettable : ILClass<Sheettable> {
+            struct Fields {
+                int32_t monsno;
+                int32_t version;
+                int32_t zukanflag;
+            };
+        };
+
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            Sheettable::Array* table;
+        };
+    };
+}

--- a/src/mod/externals/XLSXContent/UgRandMark.h
+++ b/src/mod/externals/XLSXContent/UgRandMark.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+#include "externals/System/String.h"
+#include "externals/UnityEngine/ScriptableObject.h"
+
+namespace XLSXContent {
+    struct UgRandMark : ILClass<UgRandMark, 0x04c657b0> {
+        struct Sheettable : ILClass<Sheettable> {
+            struct Fields {
+                int32_t id;
+                System::String::Object* FileName;
+                int32_t size;
+                int32_t min;
+                int32_t max;
+                int32_t smax;
+                int32_t mmax;
+                int32_t lmax;
+                int32_t llmax;
+                int32_t watermax;
+                System::Int32_array* typerate;
+            };
+        };
+
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            Sheettable::Array* table;
+        };
+    };
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -101,6 +101,9 @@ void exl_relearn_tms_main();
 // Remaps the controls.
 void exl_remap_main();
 
+// Adds support for integration between the Infinite Repel and normal repels.
+void exl_repel_fix_main();
+
 // Applies patches to support the expansion of many things in the save data.
 void exl_save_data_expansion();
 
@@ -119,11 +122,11 @@ void exl_swarm_forms_main();
 // Makes TMs infinite use.
 void exl_tms_main();
 
+// Allows alternate forms of Pokémon roaming in the Underground.
+void exl_ug_forms_main();
+
 // Adds support for wild Pokémon of any form number.
 void exl_wild_forms_main();
-
-// Adds support for integration between the Infinite Repel and normal repels.
-void exl_repel_fix_main();
 
 // Rewrites the method that sets a wild Pokémon's held item to use consistent rates (50% / 5% / 45%).
 // Also adds "Frisk" as an ability that raises wild Pokémon's held item rate.

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -29,13 +29,14 @@ void exl_features_main() {
     exl_poke_radar_fixes_main();
     exl_poketch_main();
     exl_relearn_tms_main();
+    exl_repel_fix_main();
     exl_save_data_expansion();
     exl_settings_main();
     exl_shiny_rates_main();
     exl_swarm_forms_main();
+    exl_ug_forms_main();
     exl_wild_held_items_main();
     exl_wild_forms_main();
-    exl_repel_fix_main();
 
     // Extra rombase features
     //exl_battle_revolver_main();

--- a/src/mod/features/ug_forms.cpp
+++ b/src/mod/features/ug_forms.cpp
@@ -1,0 +1,41 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/UnderGround/UgPokeLottery.h"
+#include "externals/Pml/Local/Random.h"
+#include "externals/XLSXContent/UgEncount.h"
+
+#include "logger/logger.h"
+
+HOOK_DEFINE_REPLACE(Dpr_UnderGround_UgPokeLottery_LotteryPoke) {
+    static void Callback(Dpr::UnderGround::UgPokeLottery::Object* __this, XLSXContent::UgEncount::Sheettable::Array* origList, System::Collections::Generic::List$$UgPokeLottery_PokeSlot::Object* slots, uint8_t rareTryCount) {
+        system_load_typeinfo(0xa0b3);
+        
+        for (int i=0; i<slots->fields._size; i++)
+        {
+            uint32_t origListIdx = Pml::Local::Random::GetValue() % origList->max_length;
+
+            int32_t inMonsNo = origList->m_Items[origListIdx]->fields.monsno;
+            int32_t monsNo = inMonsNo & 0x0000FFFF;
+            int32_t formNo = (inMonsNo & 0xFFFF0000) >> 16;
+
+            Pml::PokePara::PokemonParam::Object* poke_param = __this->CreatePokemonParam_by_Tokusei(monsNo, rareTryCount);
+
+            if (formNo != 0)
+            {
+                ((Pml::PokePara::CoreParam::Object*)poke_param)->ChangeFormNo((uint16_t)formNo, nullptr);
+            }
+            slots->fields._items->m_Items[i]->fields.param = poke_param;
+        }
+    }
+};
+
+HOOK_DEFINE_TRAMPOLINE(GetUgPokeData) {
+    static void* Callback(int32_t monsNo) {
+        return Orig(monsNo & 0x0000FFFF);
+    }
+};
+
+void exl_ug_forms_main() {
+    Dpr_UnderGround_UgPokeLottery_LotteryPoke::InstallAtOffset(0x018bfa90);
+    GetUgPokeData::InstallAtOffset(0x01b1b540);
+}


### PR DESCRIPTION
Closes #25.

- Adds support for alternate forms of Pokémon in the Underground.
  - Currently uses the base form's UgPokemonData in the RomFS. Eventually this will be changed so each form has its own.