### PR TITLE
Allocation issues + PID generation bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build directory
 build/
+build-release/
 .cache/
 cmake-build-*/
 

--- a/cmake/toolchain.cmake
+++ b/cmake/toolchain.cmake
@@ -81,7 +81,7 @@ add_definitions(-DSWITCH -D__SWITCH__ -D__RTLD_6XX__)
 
 set(ARCH "-march=armv8-a+crc+crypto -mtune=cortex-a57 -mtp=soft -fpic -fvisibility=hidden")
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -ffunction-sections -fdata-sections ${ARCH}" CACHE STRING "C flags")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -g -Wall -ffunction-sections -fdata-sections ${ARCH}" CACHE STRING "C flags")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_C_FLAGS} -Wno-invalid-offsetof -Wno-volatile -Wno-unused-function -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -fno-rtti -fno-threadsafe-statics" CACHE STRING "C++ flags")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -x assembler-with-cpp -g ${ARCH}" CACHE STRING "ASM flags")
 # These flags are purposefully empty to use the default flags when invoking the

--- a/config.cmake.template
+++ b/config.cmake.template
@@ -40,4 +40,5 @@ add_compile_definitions(
     PEARL=0x010018E011D92000
     # Disable saving to test save migration and changelog
     #DEBUG_DISABLE_SAVE
+    DEBUG_BUILD=$<CONFIG:Debug>
 )

--- a/src/common/exlaunch/setting.hpp
+++ b/src/common/exlaunch/setting.hpp
@@ -15,7 +15,7 @@
 
 namespace exl::setting {
     /* How large the fake .bss heap will be. */
-    constexpr size_t HeapSize = 0x5000;
+    constexpr size_t HeapSize = 0x100000;
 
     /* How large the JIT area will be for hooks. */
     constexpr size_t JitSize = 0x10000;

--- a/src/common/exlaunch/util/sys/cur_proc_handle.cpp
+++ b/src/common/exlaunch/util/sys/cur_proc_handle.cpp
@@ -60,7 +60,9 @@ namespace exl::util::proc_handle {
         }
 
         Result GetViaMesosphere() {
-            R_TRY(svcGetInfo((u64*)&s_Handle, InfoType_MesosphereCurrentProcess, INVALID_HANDLE, 0));
+            u64 handle;
+            R_TRY(svcGetInfo(&handle, InfoType_MesosphereCurrentProcess, INVALID_HANDLE, 0));
+            s_Handle = handle;
 
             return result::Success;
         }

--- a/src/common/helpers/fsHelper.cpp
+++ b/src/common/helpers/fsHelper.cpp
@@ -5,6 +5,11 @@
 #include "imgui.h"
 
 namespace FsHelper {
+    LoadData::~LoadData() {
+        if(buffer != nullptr)
+            nn_free(buffer);
+    }
+
     nn::Result writeFileToPath(void *buf, size_t size, const char *path) {
         nn::fs::FileHandle handle{};
 
@@ -88,9 +93,6 @@ namespace FsHelper {
 
             nn::string strBuffer((char*)data.buffer, data.bufSize);
             nn::json j = nn::json::parse(strBuffer);
-
-            // Free buffer
-            nn_free(data.buffer);
 
             return j;
         }

--- a/src/common/helpers/fsHelper.cpp
+++ b/src/common/helpers/fsHelper.cpp
@@ -44,7 +44,7 @@ namespace FsHelper {
         long size = 0;
         nn::fs::GetFileSize(&size, handle);
         long alignedSize = ALIGN_UP(std::max(size, loadData.bufSize), loadData.alignment);
-        loadData.buffer = IM_ALLOC(alignedSize);
+        loadData.buffer = nn_malloc(alignedSize);
         loadData.bufSize = alignedSize;
 
         EXL_ASSERT(loadData.buffer, "Failed to Allocate Buffer! File Size: %ld", size);
@@ -90,7 +90,7 @@ namespace FsHelper {
             nn::json j = nn::json::parse(strBuffer);
 
             // Free buffer
-            IM_FREE(data.buffer);
+            nn_free(data.buffer);
 
             return j;
         }

--- a/src/common/helpers/fsHelper.h
+++ b/src/common/helpers/fsHelper.h
@@ -11,6 +11,8 @@ namespace FsHelper {
         int alignment = 8;
         void *buffer;
         long bufSize;
+
+        ~LoadData();
     };
 
     nn::Result writeFileToPath(void *buf, size_t size, const char *path);

--- a/src/common/memory/nn_allocator.cpp
+++ b/src/common/memory/nn_allocator.cpp
@@ -1,0 +1,20 @@
+#include "nn_allocator.h"
+#include "ro.h"
+
+static unsigned long mallocFuncPtr;
+static unsigned long freeFuncPtr;
+
+void loadAllocators() {
+    nn::ro::LookupSymbol(&mallocFuncPtr, "malloc");
+    nn::ro::LookupSymbol(&freeFuncPtr, "free");
+}
+
+void* nn_malloc(std::size_t size) {
+    void* (*func)(size_t _size) = reinterpret_cast<void *(*)(size_t)>(mallocFuncPtr);
+    return func(size);
+}
+
+void nn_free(void *ptr) {
+    void (*func)(void *_ptr) = reinterpret_cast<void (*)(void *)>(freeFuncPtr);
+    func(ptr);
+}

--- a/src/common/memory/nn_allocator.cpp
+++ b/src/common/memory/nn_allocator.cpp
@@ -3,18 +3,26 @@
 
 static unsigned long mallocFuncPtr;
 static unsigned long freeFuncPtr;
+static bool allocatorsLoaded = false;
 
 void loadAllocators() {
     nn::ro::LookupSymbol(&mallocFuncPtr, "malloc");
     nn::ro::LookupSymbol(&freeFuncPtr, "free");
+    allocatorsLoaded = true;
 }
 
 void* nn_malloc(std::size_t size) {
+    if (!allocatorsLoaded)
+        loadAllocators();
+
     void* (*func)(size_t _size) = reinterpret_cast<void *(*)(size_t)>(mallocFuncPtr);
     return func(size);
 }
 
 void nn_free(void *ptr) {
+    if (!allocatorsLoaded)
+        loadAllocators();
+
     void (*func)(void *_ptr) = reinterpret_cast<void (*)(void *)>(freeFuncPtr);
     func(ptr);
 }

--- a/src/common/memory/nn_allocator.h
+++ b/src/common/memory/nn_allocator.h
@@ -3,9 +3,13 @@
 #include <limits>
 
 namespace ImGui {
-    void* MemAlloc(size_t size);
+    void* MemAlloc(std::size_t size);
     void MemFree(void* ptr);
 }
+
+void loadAllocators();
+void* nn_malloc(std::size_t size);
+void nn_free(void *ptr);
 
 template<class T>
 struct nn_allocator

--- a/src/common/memory/nn_allocator.h
+++ b/src/common/memory/nn_allocator.h
@@ -2,11 +2,6 @@
 
 #include <limits>
 
-namespace ImGui {
-    void* MemAlloc(std::size_t size);
-    void MemFree(void* ptr);
-}
-
 void loadAllocators();
 void* nn_malloc(std::size_t size);
 void nn_free(void *ptr);
@@ -43,7 +38,7 @@ struct nn_allocator
             //throw std::bad_array_new_length();
         }
 
-        if (auto p = static_cast<T*>(ImGui::MemAlloc(n * sizeof(T))))
+        if (auto p = static_cast<T*>(nn_malloc(n * sizeof(T))))
         {
             report(p, n);
             return p;
@@ -56,7 +51,7 @@ struct nn_allocator
     void deallocate(T* p, std::size_t n) noexcept
     {
         report(p, n, 0);
-        ImGui::MemFree(p);
+        nn_free(p);
     }
 
     [[nodiscard]] inline size_type max_size() const {

--- a/src/common/socket/Socket.cpp
+++ b/src/common/socket/Socket.cpp
@@ -111,7 +111,7 @@ const char *Socket::receiveMessage() {
         }
     }
 
-    char* ptr = (char*)IM_ALLOC(message.length() * sizeof(char));
+    char* ptr = (char*)nn_malloc(message.length() * sizeof(char));
     strcpy(ptr, message.c_str());
 
     return ptr;

--- a/src/mod/externals/il2cpp.h
+++ b/src/mod/externals/il2cpp.h
@@ -2,7 +2,7 @@
 
 #include <cstdint>
 #include <cstddef>
-#include "imgui.h"
+#include "memory/nn_allocator.h"
 #include "exlaunch.hpp"
 
 typedef void(*Il2CppMethodPointer)();
@@ -37,7 +37,7 @@ struct MethodInfo {
     uint8_t bitflags;
 
     MethodInfo* copyWith(Il2CppMethodPointer method) {
-        auto m = new MethodInfo;
+        auto m = (MethodInfo*)nn_malloc(sizeof(MethodInfo));
         memcpy(m, this, sizeof(MethodInfo));
         m->methodPointer = method;
         return m;

--- a/src/mod/main.cpp
+++ b/src/mod/main.cpp
@@ -8,6 +8,7 @@
 #include "features/features.h"
 #include "save/save.h"
 #include "nn/err.h"
+#include "memory/nn_allocator.h"
 
 static Socket gSocket {};
 HOOK_DEFINE_TRAMPOLINE(MainInitHook){
@@ -59,7 +60,10 @@ extern "C" void exl_main(void* x0, void* x1) {
 
     MainInitHook::InstallAtSymbol("nnMain");
 
-#if CMAKE_BUILD_TYPE == Debug
+    // Get allocators
+    loadAllocators();
+
+#if DEBUG_BUILD
     exl_imgui_main();
     exl_debug_menu_main();
 #endif

--- a/src/mod/main.cpp
+++ b/src/mod/main.cpp
@@ -60,9 +60,6 @@ extern "C" void exl_main(void* x0, void* x1) {
 
     MainInitHook::InstallAtSymbol("nnMain");
 
-    // Get allocators
-    loadAllocators();
-
 #if DEBUG_BUILD
     exl_imgui_main();
     exl_debug_menu_main();

--- a/src/mod/ui/ui.cpp
+++ b/src/mod/ui/ui.cpp
@@ -98,16 +98,16 @@ static Window mainWindow = Window::single([](Window &_) {
 
     _.ItemTool();
     _.PokemonTool();
-    //_.ArenaTool();
+    _.ArenaTool();
     _.WarpTool();
     _.VariablesTool();
-    //_.MaterialTool();
+    _.MaterialTool();
     _.ColorVariationTool();
-    //_.SaveTool();
-    //_.AnimationTool();
+    _.SaveTool();
+    _.AnimationTool();
     _.ModelTool();
-    //_.PokemonInfoTool();
-    //_.PoffinTool();
+    _.PokemonInfoTool();
+    _.PoffinTool();
     _.MiscTool();
 });
 


### PR DESCRIPTION
Closes #74 and #75.

- "Fixes" our memory allocation issues with ExLaunch.
  - Whenever malloc or free would be used, replaces their usage with nn_malloc and nn_free.
    - These directly call the game's allocation functions. If we ever run into more issues with these, possibly take a look into replacing the implementation with just malloc and free.
  - Increases the fake heap size from 0x5000 to 0x100000, which also works on console.
  - Added the -O3 flag to the build command.
- Brought over a fix for an ExLaunch bug, thanks to Shadów.
- Fully decoupled imgui from the rest of the project.
  - Replaced all instances of IM_ALLOC with nn_malloc.
  - Made it possible to build the project without imgui by making a build of type "Release".
- Rewrote our shiny rates hooks.
  - Instead of rolling for a shiny ourselves, we let the game do it itself. We simply start an InitialSpec with a rareTryCount that matches the proper amount of rolls.
  - This fixes the FFFFFFFF PID issue.