### PR TITLE
Turn Counter

### DIFF
--- a/src/mod/externals/Dpr/Battle/Logic/BattleCounter.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BattleCounter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+#include "externals/System/Primitives.h"
+
+namespace Dpr::Battle::Logic {
+    struct BattleCounter : ILClass<BattleCounter> {
+        struct Fields {
+            void* m_uniqueCount; // System_UInt64_array*
+            void* m_clientCount; // System_UInt64_array_array*
+            void* m_sideCount; // System_UInt64_array_array*
+        };
+
+        inline uint64_t Get(uint8_t counterID) {
+            return external<uint64_t>(0x018794a0, this, counterID);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/Battle/Logic/BattleEnv.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BattleEnv.h
@@ -1,31 +1,32 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+#include "externals/Dpr/Battle/Logic/BattleCounter.h"
 #include "externals/Dpr/Battle/Logic/POKECON.h"
 
 namespace Dpr::Battle::Logic {
     struct BattleEnv : ILClass<BattleEnv> {
         struct Fields {
             Dpr::Battle::Logic::POKECON::Object* m_pokecon;
-            void* m_fieldStatus; // Dpr_Battle_Logic_FieldStatus_o
-            void* m_sideEffectManager; // Dpr_Battle_Logic_SideEffectManager_o
-            void* m_posEffectManager; // Dpr_Battle_Logic_PosEffectManager_o
-            void* m_eventFactorContainer; // Dpr_Battle_Logic_EventFactorContainer_o
-            void* m_posPoke; // Dpr_Battle_Logic_PosPoke_o
-            void* m_deadRec; // Dpr_Battle_Logic_DeadRec_o
-            void* m_wazaRec; // Dpr_Battle_Logic_WazaRec_o
-            void* m_affCounter; // Dpr_Battle_Logic_AffCounter_o
-            void* m_actionRecorder; // Dpr_Battle_Logic_ActionRecorder_o
-            void* m_actionSerialNoManager; // Dpr_Battle_Logic_ActionSerialNoManager_o
-            void* m_timeLimit; // Dpr_Battle_Logic_TimeLimit_o
-            void* m_gRightsManager; // Dpr_Battle_Logic_GRightsManager_o
-            void* m_gGauge; // Dpr_Battle_Logic_GGauge_array
-            void* m_raidBattleStatus; // Dpr_Battle_Logic_RaidBattleStatus_o
-            void* m_flags; // Dpr_Battle_Logic_BattleFlags_o
-            void* m_counter; // Dpr_Battle_Logic_BattleCounter_o
-            void* m_escapeInfo; // Dpr_Battle_Logic_EscapeInfo_o
-            void* m_lastExecutedWaza; // Dpr_Battle_Logic_WazaParam_o
-            void* m_tamaHiroiData; // Dpr_Battle_Logic_TamaHiroiData_o
+            void* m_fieldStatus; // Dpr_Battle_Logic_FieldStatus_o*
+            void* m_sideEffectManager; // Dpr_Battle_Logic_SideEffectManager_o*
+            void* m_posEffectManager; // Dpr_Battle_Logic_PosEffectManager_o*
+            void* m_eventFactorContainer; // Dpr_Battle_Logic_EventFactorContainer_o*
+            void* m_posPoke; // Dpr_Battle_Logic_PosPoke_o*
+            void* m_deadRec; // Dpr_Battle_Logic_DeadRec_o*
+            void* m_wazaRec; // Dpr_Battle_Logic_WazaRec_o*
+            void* m_affCounter; // Dpr_Battle_Logic_AffCounter_o*
+            void* m_actionRecorder; // Dpr_Battle_Logic_ActionRecorder_o*
+            void* m_actionSerialNoManager; // Dpr_Battle_Logic_ActionSerialNoManager_o*
+            void* m_timeLimit; // Dpr_Battle_Logic_TimeLimit_o*
+            void* m_gRightsManager; // Dpr_Battle_Logic_GRightsManager_o*
+            void* m_gGauge; // Dpr_Battle_Logic_GGauge_array*
+            void* m_raidBattleStatus; // Dpr_Battle_Logic_RaidBattleStatus_o*
+            void* m_flags; // Dpr_Battle_Logic_BattleFlags_o*
+            Dpr::Battle::Logic::BattleCounter::Object* m_counter; // Dpr_Battle_Logic_BattleCounter_o*
+            void* m_escapeInfo; // Dpr_Battle_Logic_EscapeInfo_o*
+            void* m_lastExecutedWaza; // Dpr_Battle_Logic_WazaParam_o*
+            void* m_tamaHiroiData; // Dpr_Battle_Logic_TamaHiroiData_o*
         };
     };
 }

--- a/src/mod/externals/Dpr/Battle/Logic/MainModule.h
+++ b/src/mod/externals/Dpr/Battle/Logic/MainModule.h
@@ -9,6 +9,7 @@
 #include "externals/Dpr/Battle/Logic/BtlRule.h"
 #include "externals/Dpr/Battle/Logic/MyStatus.h"
 #include "externals/Pml/PokeParty.h"
+#include "externals/System/Collections/IEnumerator.h"
 #include "externals/System/Primitives.h"
 
 namespace Dpr::Battle::Logic {
@@ -83,6 +84,10 @@ namespace Dpr::Battle::Logic {
 
         inline Pml::PokeParty::Object* GetSrcParty(uint8_t clientID, bool fForServer) {
             return external<Pml::PokeParty::Object*>(0x020325a0, this, clientID, fForServer);
+        }
+
+        inline System::Collections::IEnumerator::Object* LeavenOnErrorCoroutine() {
+            return external<System::Collections::IEnumerator::Object*>(0x0202e6b0, this);
         }
     };
 }

--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -3240,6 +3240,7 @@ enum class FlagWork_Work : int32_t {
     SCWK_WK_END = 437,
 
     // Luminescent Works
+    WK_LAST_BATTLE_TURN_COUNTER = 449,
     WK_INCENSE_SLOT = 495,
     SCWK_WK_SAVE_SIZE = 500,
 

--- a/src/mod/externals/System/Collections/IEnumerator.h
+++ b/src/mod/externals/System/Collections/IEnumerator.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace System::Collections {
+    struct IEnumerator : ILClass<IEnumerator> {
+        struct Fields {};
+    };
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -122,6 +122,9 @@ void exl_swarm_forms_main();
 // Makes TMs infinite use.
 void exl_tms_main();
 
+// Assigns a work value to be used as a total turn counter for the last battle. By default, this is work value 449.
+void exl_turn_counter_main();
+
 // Allows alternate forms of Pokémon roaming in the Underground.
 void exl_ug_forms_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -34,6 +34,7 @@ void exl_features_main() {
     exl_settings_main();
     exl_shiny_rates_main();
     exl_swarm_forms_main();
+    exl_turn_counter_main();
     exl_ug_forms_main();
     exl_wild_held_items_main();
     exl_wild_forms_main();

--- a/src/mod/features/turn_counter.cpp
+++ b/src/mod/features/turn_counter.cpp
@@ -1,0 +1,29 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Battle/Logic/MainModule.h"
+#include "externals/FlagWork.h"
+#include "externals/PlayerWork.h"
+
+#include "logger/logger.h"
+
+const FlagWork_Work TURN_COUNTER_WORK = FlagWork_Work::WK_LAST_BATTLE_TURN_COUNTER;
+
+HOOK_DEFINE_INLINE(BattleProc_FinalizeCoroutine__EndOfBattleTurnCounter) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("BattleProc_FinalizeCoroutine__EndOfBattleTurnCounter\n");
+        auto mainModule = (Dpr::Battle::Logic::MainModule::Object*)ctx->X[0];
+
+        Logger::log("Getting turn count...\n");
+        int32_t turnCount = mainModule->fields.m_battleEnvForServer->fields.m_counter->Get(0);
+        Logger::log("Turn count is %d\n", turnCount);
+        PlayerWork::SetInt((int32_t)TURN_COUNTER_WORK, turnCount);
+
+        Logger::log("Calling original line of code\n");
+        ctx->X[0] = (uint64_t)mainModule->LeavenOnErrorCoroutine();
+        Logger::log("BattleProc_FinalizeCoroutine__EndOfBattleTurnCounter done!\n");
+    }
+};
+
+void exl_turn_counter_main() {
+    BattleProc_FinalizeCoroutine__EndOfBattleTurnCounter::InstallAtOffset(0x0187e22c);
+}

--- a/src/mod/ui/tools/variables_tool.h
+++ b/src/mod/ui/tools/variables_tool.h
@@ -26,7 +26,14 @@ namespace ui {
                 _.Button([flagSelector, flagValue](Button &_) {
                     _.label = "Set Flag State";
                     _.onClick = [flagSelector, flagValue]() {
-                        FlagWork::SetSysFlag(flagSelector->value, flagValue->enabled);
+                        FlagWork::SetFlag(flagSelector->value, flagValue->enabled);
+                    };
+                });
+
+                _.Button([flagSelector, flagValue](Button &_) {
+                    _.label = "Load Flag State";
+                    _.onClick = [flagSelector, flagValue]() {
+                        flagValue->enabled = FlagWork::GetFlag(flagSelector->value);
                     };
                 });
 
@@ -51,6 +58,13 @@ namespace ui {
                     };
                 });
 
+                _.Button([sysFlagSelector, sysFlagValue](Button &_) {
+                    _.label = "Load System Flag State";
+                    _.onClick = [sysFlagSelector, sysFlagValue]() {
+                        sysFlagValue->enabled = FlagWork::GetSysFlag(sysFlagSelector->value);
+                    };
+                });
+
                 _.Spacing();
 
                 auto *workSelector = _.InputInt([](InputInt &_) {
@@ -71,6 +85,13 @@ namespace ui {
                     _.label = "Set Work Value";
                     _.onClick = [workSelector, workValue]() {
                         FlagWork::SetWork(workSelector->value, workValue->value);
+                    };
+                });
+
+                _.Button([workSelector, workValue](Button &_) {
+                    _.label = "Load Work Value";
+                    _.onClick = [workSelector, workValue]() {
+                        workValue->value = FlagWork::GetWork(workSelector->value);
                     };
                 });
             });


### PR DESCRIPTION
- Ported the Turn Counter code from Starlight.
  - It's not really a port as much as it is a re-write of it. Now instead of separately counting the turns in a static variable, we just take the game's internal turn counter post-battle.
- Added a button to load the value of a flag, sysflag, or work in the Variables Tool.
- Fixed a bug where the flag section of the Variables Tool was setting sysflag values instead.