### PR TITLE
Feature activation rework

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -45,6 +45,7 @@ static constexpr const char* DEBUG_FEATURES[] = {
     "IL2CPP Logging",
     "PokemonInfo Logging",
     "Unity Logging",
+    "Feature Logging",
 };
 
 constexpr int DEBUG_FEATURE_COUNT = sizeof(DEBUG_FEATURES) / sizeof(DEBUG_FEATURES[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -76,3 +76,11 @@ static constexpr const char* SMALL_PATCH_FEATURES[] = {
 };
 
 constexpr int SMALL_PATCH_FEATURE_COUNT = sizeof(SMALL_PATCH_FEATURES) / sizeof(SMALL_PATCH_FEATURES[0]);
+
+static constexpr const char* SAVE_FEATURES[] = {
+    "Badge Expansion",
+    "Box Expansion",
+    "Dex Expansion",
+};
+
+constexpr int SAVE_FEATURE_COUNT = sizeof(SAVE_FEATURES) / sizeof(SAVE_FEATURES[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -1,0 +1,78 @@
+#pragma once
+
+static constexpr const char* FEATURES[] = {
+    "Ability Changes",
+    "Alt Starters",
+    "Area/Zone Codes",
+    "Badge Check",
+    "New Poké Balls",
+    "Battle Escape Flag",
+    "Battle Revolver",
+    "Battle Camera Fix",
+    "Color Variations",
+    "Commands",
+    "Encounter Slots",
+    "EV/IV in Summary",
+    "Evolution Methods",
+    "Extended TM Learnsets",
+    "Form Change Held Items",
+    "Gender Neutral Boutique",
+    "Hidden Power UI",
+    "Language Select",
+    "Level Cap",
+    "NPC Collision Audio",
+    "Outfit Neutral UI",
+    "Party Context Menu",
+    "Poké Radar Fixes",
+    "Two-Button Pokétch",
+    "Relearn TMs",
+    "Controls Remap",
+    "New Settings",
+    "Shiny Rates",
+    "Sound Encounters",
+    "Swarm Forms",
+    "Turn Counter",
+    "Underground Forms",
+    "Wild Forms",
+    "Wild Held Item Rates",
+};
+
+constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);
+
+static constexpr const char* DEBUG_FEATURES[] = {
+    "Battle Bundles in UI",
+    "Boutique Models",
+    "IL2CPP Logging",
+    "PokemonInfo Logging",
+    "Unity Logging",
+};
+
+constexpr int DEBUG_FEATURE_COUNT = sizeof(DEBUG_FEATURES) / sizeof(DEBUG_FEATURES[0]);
+
+static constexpr const char* ITEM_FEATURES[] = {
+    "Ability Patch",
+    "Everlasting Candies",
+    "Exp. Share",
+    "Infinite TMs",
+    "Leek",
+    "Infinite Repel",
+};
+
+constexpr int ITEM_FEATURE_COUNT = sizeof(ITEM_FEATURES) / sizeof(ITEM_FEATURES[0]);
+
+static constexpr const char* KEY_ITEM_FEATURES[] = {
+    "Clothing Trunk",
+    "Incense Burner",
+    "Infinite Repel",
+};
+
+constexpr int KEY_ITEM_FEATURE_COUNT = sizeof(KEY_ITEM_FEATURES) / sizeof(KEY_ITEM_FEATURES[0]);
+
+
+static constexpr const char* SMALL_PATCH_FEATURES[] = {
+    "Affection Toggle",
+    "Global Exp. Share Toggle",
+    "Catch Rate Fix",
+};
+
+constexpr int SMALL_PATCH_FEATURE_COUNT = sizeof(SMALL_PATCH_FEATURES) / sizeof(SMALL_PATCH_FEATURES[0]);

--- a/src/mod/data/utils.h
+++ b/src/mod/data/utils.h
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <array>
+#include <string_view>
+#include "common.hpp"
 
 template <int N>
 consteval bool array_contains(const char* const (&arr)[N], const char* element) {

--- a/src/mod/externals/ItemWork.h
+++ b/src/mod/externals/ItemWork.h
@@ -16,4 +16,8 @@ struct ItemWork : ILClass<ItemWork> {
     static inline Dpr::Item::ItemInfo::Object* GetItemInfo(int32_t itemno) {
         return external<Dpr::Item::ItemInfo::Object*>(0x01aea5b0, itemno);
     }
+
+    static inline bool IsWazaMachine(int32_t itemno) {
+        return external<bool>(0x01aeb380, itemno);
+    }
 };

--- a/src/mod/features/activated_features.cpp
+++ b/src/mod/features/activated_features.cpp
@@ -6,6 +6,7 @@ static bool ACTIVATED_FEATURES[FEATURE_COUNT];
 static bool ACTIVATED_DEBUG_FEATURES[DEBUG_FEATURE_COUNT];
 static bool ACTIVATED_ITEM_FEATURES[ITEM_FEATURE_COUNT];
 static bool ACTIVATED_KEY_ITEM_FEATURES[KEY_ITEM_FEATURE_COUNT];
+static bool ACTIVATED_SAVE_FEATURES[SAVE_FEATURE_COUNT];
 static bool ACTIVATED_SMALL_PATCH_FEATURES[SMALL_PATCH_FEATURE_COUNT];
 
 void DisableFeatures()
@@ -29,6 +30,12 @@ void DisableItemFeatures()
 void DisableKeyItemFeatures()
 {
     for (bool & i : ACTIVATED_KEY_ITEM_FEATURES)
+        i = false;
+}
+
+void DisableSaveFeatures()
+{
+    for (bool & i : ACTIVATED_SAVE_FEATURES)
         i = false;
 }
 
@@ -58,6 +65,11 @@ void SetActivatedKeyItemFeature(int feature)
     ACTIVATED_KEY_ITEM_FEATURES[feature] = true;
 }
 
+void SetActivatedSaveFeature(int feature)
+{
+    ACTIVATED_SAVE_FEATURES[feature] = true;
+}
+
 void SetActivatedSmallPatchFeature(int feature)
 {
     ACTIVATED_SMALL_PATCH_FEATURES[feature] = true;
@@ -81,6 +93,11 @@ bool IsActivatedItemFeature(int feature)
 bool IsActivatedKeyItemFeature(int feature)
 {
     return ACTIVATED_KEY_ITEM_FEATURES[feature];
+}
+
+bool IsActivatedSaveFeature(int feature)
+{
+    return ACTIVATED_SAVE_FEATURES[feature];
 }
 
 bool IsActivatedSmallPatchFeature(int feature)

--- a/src/mod/features/activated_features.cpp
+++ b/src/mod/features/activated_features.cpp
@@ -1,0 +1,89 @@
+#include "features/activated_features.h"
+
+#include "data/features.h"
+
+static bool ACTIVATED_FEATURES[FEATURE_COUNT];
+static bool ACTIVATED_DEBUG_FEATURES[DEBUG_FEATURE_COUNT];
+static bool ACTIVATED_ITEM_FEATURES[ITEM_FEATURE_COUNT];
+static bool ACTIVATED_KEY_ITEM_FEATURES[KEY_ITEM_FEATURE_COUNT];
+static bool ACTIVATED_SMALL_PATCH_FEATURES[SMALL_PATCH_FEATURE_COUNT];
+
+void DisableFeatures()
+{
+    for (bool & i : ACTIVATED_FEATURES)
+        i = false;
+}
+
+void DisableDebugFeatures()
+{
+    for (bool & i : ACTIVATED_DEBUG_FEATURES)
+        i = false;
+}
+
+void DisableItemFeatures()
+{
+    for (bool & i : ACTIVATED_ITEM_FEATURES)
+        i = false;
+}
+
+void DisableKeyItemFeatures()
+{
+    for (bool & i : ACTIVATED_KEY_ITEM_FEATURES)
+        i = false;
+}
+
+void DisableSmallPatchFeatures()
+{
+    for (bool & i : ACTIVATED_SMALL_PATCH_FEATURES)
+        i = false;
+}
+
+void SetActivatedFeature(int feature)
+{
+    ACTIVATED_FEATURES[feature] = true;
+}
+
+void SetActivatedDebugFeature(int feature)
+{
+    ACTIVATED_DEBUG_FEATURES[feature] = true;
+}
+
+void SetActivatedItemFeature(int feature)
+{
+    ACTIVATED_ITEM_FEATURES[feature] = true;
+}
+
+void SetActivatedKeyItemFeature(int feature)
+{
+    ACTIVATED_KEY_ITEM_FEATURES[feature] = true;
+}
+
+void SetActivatedSmallPatchFeature(int feature)
+{
+    ACTIVATED_SMALL_PATCH_FEATURES[feature] = true;
+}
+
+bool IsActivatedFeature(int feature)
+{
+    return ACTIVATED_FEATURES[feature];
+}
+
+bool IsActivatedDebugFeature(int feature)
+{
+    return ACTIVATED_DEBUG_FEATURES[feature];
+}
+
+bool IsActivatedItemFeature(int feature)
+{
+    return ACTIVATED_ITEM_FEATURES[feature];
+}
+
+bool IsActivatedKeyItemFeature(int feature)
+{
+    return ACTIVATED_KEY_ITEM_FEATURES[feature];
+}
+
+bool IsActivatedSmallPatchFeature(int feature)
+{
+    return ACTIVATED_SMALL_PATCH_FEATURES[feature];
+}

--- a/src/mod/features/activated_features.h
+++ b/src/mod/features/activated_features.h
@@ -1,0 +1,48 @@
+#pragma once
+
+// Disables all features.
+void DisableFeatures();
+
+// Disables all debug features.
+void DisableDebugFeatures();
+
+// Disables all items.
+void DisableItemFeatures();
+
+// Disables all key items.
+void DisableKeyItemFeatures();
+
+// Disables all small patches.
+void DisableSmallPatchFeatures();
+
+
+// Activate a given feature.
+void SetActivatedFeature(int feature);
+
+// Activate a given debug feature.
+void SetActivatedDebugFeature(int feature);
+
+// Activate a given item.
+void SetActivatedItemFeature(int feature);
+
+// Activate a given key item.
+void SetActivatedKeyItemFeature(int feature);
+
+// Activate a given small patch.
+void SetActivatedSmallPatchFeature(int feature);
+
+
+// Check if a given feature is enabled.
+bool IsActivatedFeature(int feature);
+
+// Check if a given debug feature is enabled.
+bool IsActivatedDebugFeature(int feature);
+
+// Check if a given item is enabled.
+bool IsActivatedItemFeature(int feature);
+
+// Check if a given key item is enabled.
+bool IsActivatedKeyItemFeature(int feature);
+
+// Check if a given small patch is enabled.
+bool IsActivatedSmallPatchFeature(int feature);

--- a/src/mod/features/activated_features.h
+++ b/src/mod/features/activated_features.h
@@ -12,6 +12,9 @@ void DisableItemFeatures();
 // Disables all key items.
 void DisableKeyItemFeatures();
 
+// Disables all save data features.
+void DisableSaveFeatures();
+
 // Disables all small patches.
 void DisableSmallPatchFeatures();
 
@@ -28,6 +31,9 @@ void SetActivatedItemFeature(int feature);
 // Activate a given key item.
 void SetActivatedKeyItemFeature(int feature);
 
+// Activate a given save data feature.
+void SetActivatedSaveFeature(int feature);
+
 // Activate a given small patch.
 void SetActivatedSmallPatchFeature(int feature);
 
@@ -43,6 +49,9 @@ bool IsActivatedItemFeature(int feature);
 
 // Check if a given key item is enabled.
 bool IsActivatedKeyItemFeature(int feature);
+
+// Check if a given save data feature is enabled.
+bool IsActivatedSaveFeature(int feature);
 
 // Check if a given small patch is enabled.
 bool IsActivatedSmallPatchFeature(int feature);

--- a/src/mod/features/debug.cpp
+++ b/src/mod/features/debug.cpp
@@ -1,9 +1,18 @@
+#include "data/features.h"
+#include "data/utils.h"
+
+#include "features/activated_features.h"
 #include "features/debug/debug.h"
 
 void exl_debug_features_main() {
-    exl_battle_bundles_in_ui_main();
-    exl_boutique_model_main();
-    //exl_il2cpp_log_main();
-    exl_pokemoninfo_hooks_main();
-    //exl_unity_log_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Battle Bundles in UI")))
+        exl_battle_bundles_in_ui_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Boutique Models")))
+        exl_boutique_model_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "IL2CPP Logging")))
+        exl_il2cpp_log_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "PokemonInfo Logging")))
+        exl_pokemoninfo_hooks_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Unity Logging")))
+        exl_unity_log_main();
 };

--- a/src/mod/features/debug.cpp
+++ b/src/mod/features/debug.cpp
@@ -15,4 +15,6 @@ void exl_debug_features_main() {
         exl_pokemoninfo_hooks_main();
     if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Unity Logging")))
         exl_unity_log_main();
+    if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Feature Logging")))
+        exl_feature_log_main();
 };

--- a/src/mod/features/debug/debug.h
+++ b/src/mod/features/debug/debug.h
@@ -8,6 +8,9 @@ void exl_battle_bundles_in_ui_main();
 // Changes the boutique models to one of your choosing in works 4000 and 4001, if sysflag 998 is set.
 void exl_boutique_model_main();
 
+// Outputs all activated features at launch.
+void exl_feature_log_main();
+
 // Reroutes IL2CPP logs to the ExLaunch logger.
 void exl_il2cpp_log_main();
 

--- a/src/mod/features/debug/feature_logging.cpp
+++ b/src/mod/features/debug/feature_logging.cpp
@@ -1,0 +1,3 @@
+void exl_feature_log_main() {
+    // Nothing to do here, the features are logged elsewhere once the logger is initialized.
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -4,6 +4,22 @@
 void exl_features_main();
 
 
+// Activates debug features defined in debug/debug.h.
+void exl_debug_features_main();
+
+// Applies changes to items, defined in items/items.h.
+void exl_items_changes_main();
+
+// Adds new key item functionality.
+void exl_key_items_main();
+
+// Applies patches to support the expansion of many things in the save data.
+void exl_save_data_expansion_main();
+
+// Applies multiple small one-line patches.
+void exl_patches_main();
+
+
 // Applies some basic ability changes.
 void exl_ability_changes_main();
 
@@ -35,9 +51,6 @@ void exl_color_variations_main();
 // Adds support for new ev_script commands.
 void exl_commands_main();
 
-// Activates debug features defined in debug/debug.h.
-void exl_debug_features_main();
-
 // Rewrites the methods that deal with determining a zone's encounter slots.
 // Defaults to changing slots how Luminescent does it.
 void exl_encounter_slots_main();
@@ -61,12 +74,6 @@ void exl_gender_neutral_boutique_main();
 // Replaces every instance of Hidden Power being shown as "Normal" type with its actual type for the Pokémon.
 void exl_hidden_power_ui_main();
 
-// Applies changes to items, defined in items/items.h.
-void exl_items_changes_main();
-
-// Adds new key item functionality.
-void exl_key_items_main();
-
 // Allows configuring the available languages on the language select screen.
 void exl_language_select_main();
 
@@ -78,9 +85,6 @@ void exl_npc_collision_audio_main();
 
 // Changes all UI elements that are outfit and ColorVariation dependent to the default ones.
 void exl_outfit_neutral_ui_main();
-
-// Applies multiple small one-line patches.
-void exl_patches_main();
 
 // Adds nicknaming and move relearning to the party menu.
 void exl_pla_context_menu_main();
@@ -97,9 +101,6 @@ void exl_relearn_tms_main();
 
 // Remaps the controls.
 void exl_remap_main();
-
-// Applies patches to support the expansion of many things in the save data.
-void exl_save_data_expansion();
 
 // Adds support for new settings.
 void exl_settings_main();

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -26,7 +26,7 @@ void exl_battle_escape_flag_main();
 // Makes the battle menu scroll instead of the cursor.
 void exl_battle_revolver_main();
 
-// Forces battle camera transition direct from Wait camera to Attack camera
+// Removes the automatic switch to the default battle camera on certain actions.
 void exl_battle_camera_fix_main();
 
 // Adds support for custom color variations for player and NPCs.
@@ -42,14 +42,11 @@ void exl_debug_features_main();
 // Defaults to changing slots how Luminescent does it.
 void exl_encounter_slots_main();
 
-// Adds EV/IV to Summary UI with number based color gradient
+// Adds EV/IV to Summary UI with number based color gradient.
 void exl_ev_iv_ui_main();
 
-// Rewrites the methods that deal with checking level up evolution methods.
+// Rewrites the methods that deal with checking level up evolution methods and adds new ones.
 void exl_evolution_methods_main();
-
-// Adds functionality to the Exp. Share item.
-void exl_exp_share_main();
 
 // Redirects TM learnsets to external JSON files that contain more data.
 void exl_extended_tm_learnsets_main();
@@ -101,9 +98,6 @@ void exl_relearn_tms_main();
 // Remaps the controls.
 void exl_remap_main();
 
-// Adds support for integration between the Infinite Repel and normal repels.
-void exl_repel_fix_main();
-
 // Applies patches to support the expansion of many things in the save data.
 void exl_save_data_expansion();
 
@@ -118,9 +112,6 @@ void exl_sounds_main();
 
 // Adds support for alternate forms for the field swarm models.
 void exl_swarm_forms_main();
-
-// Makes TMs infinite use.
-void exl_tms_main();
 
 // Assigns a work value to be used as a total turn counter for the last battle. By default, this is work value 449.
 void exl_turn_counter_main();

--- a/src/mod/features/infinite_tms.cpp
+++ b/src/mod/features/infinite_tms.cpp
@@ -1,24 +1,17 @@
 #include "exlaunch.hpp"
 #include "externals/Dpr/UI/UIBag.h"
 
-HOOK_DEFINE_REPLACE(SkipTMBreak) {
+HOOK_DEFINE_REPLACE(UseWazaMachine_SkipTMBreak) {
     static void Callback(Dpr::UI::UIBag::__c__DisplayClass134_0* __this) {
-        // Return to UseWazaMachine proc
+        // Skip the text that mentions single-use TMs
         __this->_UseWazaMachine_b__3(0);
     }
 };
 
-HOOK_DEFINE_REPLACE(DoNothing) {
-    static void Callback() { }
-};
+void exl_items_infinite_tms_main() {
+    UseWazaMachine_SkipTMBreak::InstallAtOffset(0x01be0d40);
 
-void exl_tms_main() {
-    SkipTMBreak::InstallAtOffset(0x01be0d40);
-
-    DoNothing::InstallAtOffset(0x01be1220);  // Dpr.UI.UIBag.<>c__DisplayClass134_0$$<UseWazaMachine>b__5
-    DoNothing::InstallAtOffset(0x01be1460);  // Dpr.UI.UIBag.<>c__DisplayClass134_0$$<UseWazaMachine>b__6
-
-    // Skip closing of text popup for reusing
+    // Skip Dpr.UI.UIMsgWindowController$$CloseMsgWindow call in _UseWazaMachine_b__3
     exl::patch::CodePatcher p(0x01be0fec);
     p.WriteInst(exl::armv8::inst::Nop());
 }

--- a/src/mod/features/items.cpp
+++ b/src/mod/features/items.cpp
@@ -1,7 +1,48 @@
+#include "externals/ItemWork.h"
+
+#include "data/features.h"
+#include "data/items.h"
+#include "data/utils.h"
+
+#include "features/activated_features.h"
 #include "features/items/items.h"
 
+HOOK_DEFINE_INLINE(Infinite_Items) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto itemno = (int32_t)ctx->W[0];
+        auto num = (int32_t)ctx->W[1];
+
+        if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies"))) {
+            if (itemno == array_index(ITEMS, "Everlasting Candy")) {
+                ctx->W[0] = 0;
+                return;
+            }
+        }
+
+        if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite TMs"))) {
+            if (ItemWork::IsWazaMachine(itemno)) {
+                ctx->W[0] = 0;
+                return;
+            }
+        }
+
+        ctx->W[0] = (uint32_t)ItemWork::SubItem(itemno, num);
+    }
+};
+
 void exl_items_changes_main() {
-    exl_items_ability_patch_main();
-    exl_items_everlasting_candies_main();
-    exl_items_leek_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Ability Patch")))
+        exl_items_ability_patch_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies")))
+        exl_items_everlasting_candies_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Exp. Share")))
+        exl_items_exp_share_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite TMs")))
+        exl_items_infinite_tms_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Leek")))
+        exl_items_leek_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite Repel")))
+        exl_items_repel_main();
+
+    Infinite_Items::InstallAtOffset(0x0185eb8c);
 };

--- a/src/mod/features/items/everlasting_candies.cpp
+++ b/src/mod/features/items/everlasting_candies.cpp
@@ -2,16 +2,17 @@
 #include "externals/Dpr/Item/ItemInfo.h"
 #include "externals/Dpr/UI/UIBag.h"
 #include "externals/PlayerWork.h"
-#include "externals/ItemWork.h"
 #include "externals/FlagWork.h"
 #include "data/utils.h"
 #include "data/items.h"
+#include "data/features.h"
+#include "features/activated_features.h"
 #include "romdata/romdata.h"
 
 uint32_t isValidRareCandy(uint32_t level, Dpr::UI::UIBag::Object *bagRef) {
-
     // Is Level Cap enabled
-    if (!PlayerWork::GetBool((int32_t) FlagWork_Flag::FLAG_DISABLE_LEVEL_CAP)) {
+    if (!IsActivatedFeature(array_index(FEATURES, "Level Cap")) ||
+        !PlayerWork::GetBool((int32_t) FlagWork_Flag::FLAG_DISABLE_LEVEL_CAP)) {
         return 100 - level;
     }
 
@@ -30,14 +31,6 @@ uint32_t isValidRareCandy(uint32_t level, Dpr::UI::UIBag::Object *bagRef) {
     }
 }
 
-int32_t ItemWork_SubItem(int32_t itemno, int32_t num) {
-    if (itemno != array_index(ITEMS, "Everlasting Candy")) {
-        return ItemWork::SubItem(itemno, num);
-    }
-
-    return 0;
-}
-
 void exl_items_everlasting_candies_main(){
     using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;
@@ -50,7 +43,4 @@ void exl_items_everlasting_candies_main(){
     p.WriteInst(Nop());
     p.WriteInst(Nop());
     p.WriteInst(Nop());
-
-    p.Seek(0x0185eb8c);
-    p.BranchLinkInst((void*)&ItemWork_SubItem);
 };

--- a/src/mod/features/items/exp_share_item.cpp
+++ b/src/mod/features/items/exp_share_item.cpp
@@ -53,6 +53,6 @@ HOOK_DEFINE_REPLACE(CalcExp) {
     }
 };
 
-void exl_exp_share_main() {
+void exl_items_exp_share_main() {
     CalcExp::InstallAtOffset(0x018f8c10);
 }

--- a/src/mod/features/items/items.h
+++ b/src/mod/features/items/items.h
@@ -8,5 +8,14 @@ void exl_items_ability_patch_main();
 // Implements the Everlasting Candies.
 void exl_items_everlasting_candies_main();
 
+// Adds functionality to the Exp. Share item.
+void exl_items_exp_share_main();
+
 // Adds Sirfetch'd as a Pokémon that can use the Leek.
 void exl_items_leek_main();
+
+// Makes TMs infinite use.
+void exl_items_infinite_tms_main();
+
+// Adds support for integration between the Infinite Repel and normal repels.
+void exl_items_repel_main();

--- a/src/mod/features/items/repel_fix.cpp
+++ b/src/mod/features/items/repel_fix.cpp
@@ -42,7 +42,7 @@ HOOK_DEFINE_TRAMPOLINE(IsUseSpray){
 };
 
 
-void exl_repel_fix_main(){
+void exl_items_repel_main(){
     RepelInventoryOverride::InstallAtOffset(0x02c550b8);
     EncDataSave_CanUseSpray::InstallAtOffset(0x01f08ac0);
     IsUseSpray::InstallAtOffset(0x01aeb720);

--- a/src/mod/features/key_items.cpp
+++ b/src/mod/features/key_items.cpp
@@ -1,13 +1,13 @@
 #include "exlaunch.hpp"
 
+#include "data/features.h"
 #include "data/items.h"
 #include "data/utils.h"
 
-#include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/Dpr/UI/UIBag.h"
 #include "externals/FieldManager.h"
-#include "externals/FlagWork.h"
 
+#include "features/activated_features.h"
 #include "features/key_items/key_items.h"
 
 #include "logger/logger.h"
@@ -15,10 +15,14 @@
 bool CanUseRegisteredCustomItem(uint16_t itemno)
 {
     switch(itemno) {
-        case array_index(ITEMS, "Clothing Trunk"):
-        case array_index(ITEMS, "Incense Burner"):
+        case array_index(ITEMS, "Clothing Trunk"): {
+            return IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Clothing Trunk"));
+        }
+        case array_index(ITEMS, "Incense Burner"): {
+            return IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Incense Burner"));
+        }
         case array_index(ITEMS, "Infinite Repel"): {
-            return true;
+            return IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Infinite Repel"));
         }
         default: {
             return false;
@@ -29,16 +33,25 @@ bool CanUseRegisteredCustomItem(uint16_t itemno)
 bool CustomItemBehavior(int32_t itemId, bool fromBag, Dpr::UI::UIBag::__c__DisplayClass127_1::Object* bagDisplayClass) {
     switch(itemId) {
         case array_index(ITEMS, "Clothing Trunk"): {
-            UseClothingTrunk(itemId, fromBag, bagDisplayClass);
-            return true;
+            if (IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Clothing Trunk"))) {
+                UseClothingTrunk(itemId, fromBag, bagDisplayClass);
+                return true;
+            }
+            return false;
         }
         case array_index(ITEMS, "Incense Burner"): {
-            UseIncenseBurner(itemId, fromBag, bagDisplayClass);
-            return true;
+            if (IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Incense Burner"))) {
+                UseIncenseBurner(itemId, fromBag, bagDisplayClass);
+                return true;
+            }
+            return false;
         }
         case array_index(ITEMS, "Infinite Repel"): {
-            UseInfiniteRepel(itemId, fromBag, bagDisplayClass);
-            return true;
+            if (IsActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Infinite Repel"))) {
+                UseInfiniteRepel(itemId, fromBag, bagDisplayClass);
+                return true;
+            }
+            return false;
         }
         default: {
             return false;

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -78,6 +78,7 @@ void CallFeatureHooks()
     exl_debug_features_main();
     exl_items_changes_main();
     exl_key_items_main();
+    exl_save_data_expansion_main();
     exl_patches_main();
 }
 
@@ -87,6 +88,7 @@ void exl_features_main() {
     DisableDebugFeatures();
     DisableItemFeatures();
     DisableKeyItemFeatures();
+    DisableSaveFeatures();
     DisableSmallPatchFeatures();
 
     // Select which new features are activated
@@ -137,6 +139,8 @@ void exl_features_main() {
     SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Clothing Trunk"));
     SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Incense Burner"));
     SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Infinite Repel"));
+
+    SetActivatedSaveFeature(array_index(SAVE_FEATURES, "Dex Expansion"));
 
     SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Affection Toggle"));
     SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Global Exp. Share Toggle"));

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -1,51 +1,147 @@
-#include "features.h"
+#include "data/features.h"
+#include "data/utils.h"
 
-void exl_features_main() {
-    // Activated features for Luminescent
-    exl_ability_changes_main();
-    exl_alt_starters_main();
-    exl_area_zone_codes_main();
-    exl_badge_check_main();
-    exl_balls_main();
-    exl_battle_camera_fix_main();
-    exl_battle_escape_flag_main();
-    exl_color_variations_main();
-    exl_commands_main();
-    exl_encounter_slots_main();
-    exl_ev_iv_ui_main();
-    exl_evolution_methods_main();
-    exl_extended_tm_learnsets_main();
-    exl_form_change_held_items_main();
-    exl_gender_neutral_boutique_main();
-    exl_hidden_power_ui_main();
+#include "features/activated_features.h"
+#include "features/features.h"
+
+void CallFeatureHooks()
+{
+    if (IsActivatedFeature(array_index(FEATURES, "Ability Changes")))
+        exl_ability_changes_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Alt Starters")))
+        exl_alt_starters_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Area/Zone Codes")))
+        exl_area_zone_codes_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Badge Check")))
+        exl_badge_check_main();
+    if (IsActivatedFeature(array_index(FEATURES, "New Poké Balls")))
+        exl_balls_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Battle Escape Flag")))
+        exl_battle_escape_flag_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Battle Revolver")))
+        exl_battle_revolver_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Battle Camera Fix")))
+        exl_battle_camera_fix_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Color Variations")))
+        exl_color_variations_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Commands")))
+        exl_commands_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Encounter Slots")))
+        exl_encounter_slots_main();
+    if (IsActivatedFeature(array_index(FEATURES, "EV/IV in Summary")))
+        exl_ev_iv_ui_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Evolution Methods")))
+        exl_evolution_methods_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Extended TM Learnsets")))
+        exl_extended_tm_learnsets_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Form Change Held Items")))
+        exl_form_change_held_items_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Gender Neutral Boutique")))
+        exl_gender_neutral_boutique_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Hidden Power UI")))
+        exl_hidden_power_ui_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Language Select")))
+        exl_language_select_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Level Cap")))
+        exl_level_cap_main();
+    if (IsActivatedFeature(array_index(FEATURES, "NPC Collision Audio")))
+        exl_npc_collision_audio_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Outfit Neutral UI")))
+        exl_outfit_neutral_ui_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Party Context Menu")))
+        exl_pla_context_menu_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Poké Radar Fixes")))
+        exl_poke_radar_fixes_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Two-Button Pokétch")))
+        exl_poketch_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Relearn TMs")))
+        exl_relearn_tms_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Controls Remap")))
+        exl_remap_main();
+    if (IsActivatedFeature(array_index(FEATURES, "New Settings")))
+        exl_settings_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Shiny Rates")))
+        exl_shiny_rates_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Sound Encounters")))
+        exl_sounds_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Swarm Forms")))
+        exl_swarm_forms_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Turn Counter")))
+        exl_turn_counter_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Underground Forms")))
+        exl_ug_forms_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Wild Forms")))
+        exl_wild_forms_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Wild Held Item Rates")))
+        exl_wild_held_items_main();
+
+    exl_debug_features_main();
     exl_items_changes_main();
     exl_key_items_main();
-    exl_language_select_main();
-    exl_level_cap_main();
-    exl_npc_collision_audio_main();
-    exl_outfit_neutral_ui_main();
     exl_patches_main();
-    exl_pla_context_menu_main();
-    exl_poke_radar_fixes_main();
-    exl_poketch_main();
-    exl_relearn_tms_main();
-    exl_repel_fix_main();
-    exl_save_data_expansion();
-    exl_settings_main();
-    exl_shiny_rates_main();
-    exl_swarm_forms_main();
-    exl_turn_counter_main();
-    exl_ug_forms_main();
-    exl_wild_held_items_main();
-    exl_wild_forms_main();
+}
 
-    // Extra rombase features
-    //exl_battle_revolver_main();
-    //exl_exp_share_main();
-    //exl_remap_main();
-    //exl_sounds_main();
-    //exl_tms_main();
+void exl_features_main() {
+    // First disables all features
+    DisableFeatures();
+    DisableDebugFeatures();
+    DisableItemFeatures();
+    DisableKeyItemFeatures();
+    DisableSmallPatchFeatures();
 
-    // Debug features
-    exl_debug_features_main();
+    // Select which new features are activated
+    SetActivatedFeature(array_index(FEATURES, "Ability Changes"));
+    SetActivatedFeature(array_index(FEATURES, "Alt Starters"));
+    SetActivatedFeature(array_index(FEATURES, "Area/Zone Codes"));
+    SetActivatedFeature(array_index(FEATURES, "Badge Check"));
+    SetActivatedFeature(array_index(FEATURES, "New Poké Balls"));
+    SetActivatedFeature(array_index(FEATURES, "Battle Escape Flag"));
+    SetActivatedFeature(array_index(FEATURES, "Battle Camera Fix"));
+    SetActivatedFeature(array_index(FEATURES, "Color Variations"));
+    SetActivatedFeature(array_index(FEATURES, "Commands"));
+    SetActivatedFeature(array_index(FEATURES, "Encounter Slots"));
+    SetActivatedFeature(array_index(FEATURES, "EV/IV in Summary"));
+    SetActivatedFeature(array_index(FEATURES, "Evolution Methods"));
+    SetActivatedFeature(array_index(FEATURES, "Extended TM Learnsets"));
+    SetActivatedFeature(array_index(FEATURES, "Form Change Held Items"));
+    SetActivatedFeature(array_index(FEATURES, "Gender Neutral Boutique"));
+    SetActivatedFeature(array_index(FEATURES, "Hidden Power UI"));
+    SetActivatedFeature(array_index(FEATURES, "Language Select"));
+    SetActivatedFeature(array_index(FEATURES, "Level Cap"));
+    SetActivatedFeature(array_index(FEATURES, "NPC Collision Audio"));
+    SetActivatedFeature(array_index(FEATURES, "Outfit Neutral UI"));
+    SetActivatedFeature(array_index(FEATURES, "Party Context Menu"));
+    SetActivatedFeature(array_index(FEATURES, "Poké Radar Fixes"));
+    SetActivatedFeature(array_index(FEATURES, "Two-Button Pokétch"));
+    SetActivatedFeature(array_index(FEATURES, "Relearn TMs"));
+    SetActivatedFeature(array_index(FEATURES, "New Settings"));
+    SetActivatedFeature(array_index(FEATURES, "Shiny Rates"));
+    SetActivatedFeature(array_index(FEATURES, "Swarm Forms"));
+    SetActivatedFeature(array_index(FEATURES, "Turn Counter"));
+    SetActivatedFeature(array_index(FEATURES, "Underground Forms"));
+    SetActivatedFeature(array_index(FEATURES, "Wild Forms"));
+    SetActivatedFeature(array_index(FEATURES, "Wild Held Item Rates"));
+
+    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Battle Bundles in UI"));
+    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Boutique Models"));
+    //SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "IL2CPP Logging"));
+    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "PokemonInfo Logging"));
+    //SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Unity Logging"));
+
+    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Ability Patch"));
+    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies"));
+    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite TMs"));
+    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Leek"));
+    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite Repel"));
+
+    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Clothing Trunk"));
+    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Incense Burner"));
+    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Infinite Repel"));
+
+    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Affection Toggle"));
+    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Global Exp. Share Toggle"));
+    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Catch Rate Fix"));
+
+    // Install all activated hooks
+    CallFeatureHooks();
 }

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -129,6 +129,7 @@ void exl_features_main() {
     //SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "IL2CPP Logging"));
     SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "PokemonInfo Logging"));
     //SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Unity Logging"));
+    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Feature Logging"));
 
     SetActivatedItemFeature(array_index(ITEM_FEATURES, "Ability Patch"));
     SetActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies"));

--- a/src/mod/features/save_data.cpp
+++ b/src/mod/features/save_data.cpp
@@ -1,7 +1,14 @@
+#include "data/features.h"
+#include "data/utils.h"
+
+#include "features/activated_features.h"
 #include "features/save_data/save_data.h"
 
-void exl_save_data_expansion() {
-    //exl_save_badges_expansion_main();
-    //exl_save_box_expansion_main();
-    exl_save_dex_expansion_main();
+void exl_save_data_expansion_main() {
+    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Badge Expansion")))
+        exl_save_badges_expansion_main();
+    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Box Expansion")))
+        exl_save_box_expansion_main();
+    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Dex Expansion")))
+        exl_save_dex_expansion_main();
 };

--- a/src/mod/features/save_data.cpp
+++ b/src/mod/features/save_data.cpp
@@ -5,10 +5,10 @@
 #include "features/save_data/save_data.h"
 
 void exl_save_data_expansion_main() {
-    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Badge Expansion")))
+    if (IsActivatedSaveFeature(array_index(SAVE_FEATURES, "Badge Expansion")))
         exl_save_badges_expansion_main();
-    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Box Expansion")))
+    if (IsActivatedSaveFeature(array_index(SAVE_FEATURES, "Box Expansion")))
         exl_save_box_expansion_main();
-    if (IsActivatedDebugFeature(array_index(SAVE_FEATURES, "Dex Expansion")))
+    if (IsActivatedSaveFeature(array_index(SAVE_FEATURES, "Dex Expansion")))
         exl_save_dex_expansion_main();
 };

--- a/src/mod/features/small_patches.cpp
+++ b/src/mod/features/small_patches.cpp
@@ -1,7 +1,10 @@
 #include "exlaunch.hpp"
 
+#include "data/features.h"
 #include "data/items.h"
+#include "data/utils.h"
 #include "externals/FlagWork.h"
+#include "features/activated_features.h"
 
 HOOK_DEFINE_REPLACE(FriendshipFlag) {
     static bool Callback() {
@@ -16,15 +19,24 @@ HOOK_DEFINE_REPLACE(ExpShareFlag) {
 };
 
 void exl_patches_main() {
-    FriendshipFlag::InstallAtOffset(0x020378d0);
-    ExpShareFlag::InstallAtOffset(0x020397f0);
-
-    // Assembly Patches
     using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;
     exl::patch::CodePatcher p(0);
+
+    if (IsActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Affection Toggle")))
+        FriendshipFlag::InstallAtOffset(0x020378d0);
+
+    if (IsActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Global Exp. Share Toggle")))
+        ExpShareFlag::InstallAtOffset(0x020397f0);
+
+    if (IsActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Catch Rate Fix")))
+    {
+        p.Seek(0x02177394);
+        p.WriteInst(Branch(0x44));
+    }
+
+    // Always-on Patches
     auto inst = nn::vector<exl::patch::Instruction> {
-        { 0x02177394, Branch(0x44) },                   // Catch Rate fix (No high level debuff)
         { 0x02053b24, CmpImmediate(W8, 0x7) },          // Allow 6IV Pokémon
         { 0x0202c140, CmpImmediate(W19, ITEM_COUNT) },  // Make the battle check for if you own balls that go past 1822 items
     };

--- a/src/mod/main.cpp
+++ b/src/mod/main.cpp
@@ -8,7 +8,47 @@
 #include "features/features.h"
 #include "save/save.h"
 #include "nn/err.h"
-#include "memory/nn_allocator.h"
+#include "features/activated_features.h"
+#include "data/features.h"
+#include "data/utils.h"
+
+void logFeatures() {
+    Logger::log("Main Features:\n");
+    for (int i=0; i<FEATURE_COUNT; i++)
+        if (IsActivatedFeature(i))
+            Logger::log(" %s\n", FEATURES[i]);
+    Logger::log("\n");
+
+    Logger::log("Debug Features:\n");
+    for (int i=0; i<DEBUG_FEATURE_COUNT; i++)
+        if (IsActivatedDebugFeature(i))
+            Logger::log(" %s\n", DEBUG_FEATURES[i]);
+    Logger::log("\n");
+
+    Logger::log("Item Features:\n");
+    for (int i=0; i<ITEM_FEATURE_COUNT; i++)
+        if (IsActivatedItemFeature(i))
+            Logger::log(" %s\n", ITEM_FEATURES[i]);
+    Logger::log("\n");
+
+    Logger::log("Key Item Features:\n");
+    for (int i=0; i<KEY_ITEM_FEATURE_COUNT; i++)
+        if (IsActivatedKeyItemFeature(i))
+            Logger::log(" %s\n", KEY_ITEM_FEATURES[i]);
+    Logger::log("\n");
+
+    Logger::log("Small Patch Features:\n");
+    for (int i=0; i<SMALL_PATCH_FEATURE_COUNT; i++)
+        if (IsActivatedSmallPatchFeature(i))
+            Logger::log(" %s\n", SMALL_PATCH_FEATURES[i]);
+    Logger::log("\n");
+
+    Logger::log("Save Data Features:\n");
+    for (int i=0; i<SAVE_FEATURE_COUNT; i++)
+        if (IsActivatedSaveFeature(i))
+            Logger::log(" %s\n", SAVE_FEATURES[i]);
+    Logger::log("\n");
+}
 
 static Socket gSocket {};
 HOOK_DEFINE_TRAMPOLINE(MainInitHook){
@@ -28,6 +68,9 @@ HOOK_DEFINE_TRAMPOLINE(MainInitHook){
         nn::oe::DisplayVersion display_version{};
         nn::oe::GetDisplayVersion(&display_version);
         Logger::log("Detected version: %s\n", display_version.name);
+
+        if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Feature Logging")))
+            logFeatures();
 
         Orig();
     }

--- a/src/mod/ui/tools/misc_tool.h
+++ b/src/mod/ui/tools/misc_tool.h
@@ -44,6 +44,7 @@ namespace ui {
                             ZukanWork::SetPoke(i, 3, 1, 0, false);
                             ZukanWork::AddLangFlag(i, 4);
                             ZukanWork::AddLangFlag(i, 3);
+                            ZukanWork::AddLangFlag(i, 2);
                         }
                     };
                 });


### PR DESCRIPTION
- Reworked the way to activate features.
  - A data file was added with name for each feature that you can use to mark them as activated in main.cpp.
  - This allows to check for if a feature is activated from anywhere in the code by including features/activated_features.h.
- Activates the Infinite TMs patch and slightly alters it to use the same method as Everlasting Candies to prevent the item removal.
- More clearly shows which Debug, Item, Key Item, and Small Patch features are active.