### PR TITLE
Port: Validity Checks (Starlight -> Exlaunch)

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -35,6 +35,7 @@ static constexpr const char* FEATURES[] = {
     "Underground Forms",
     "Wild Forms",
     "Wild Held Item Rates",
+    "Validity Checks",
     "Contest NPC Forms",
 };
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -125,6 +125,9 @@ void exl_ug_forms_main();
 // Repoints Large and DP/Pixel Pokémon sprites to the base ones.
 void exl_uniform_ui_main();
 
+// Removes validity checks.
+void exl_validity_checks_main();
+
 // Adds support for wild Pokémon of any form number.
 void exl_wild_forms_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -70,6 +70,8 @@ void CallFeatureHooks()
         exl_turn_counter_main();
     if (IsActivatedFeature(array_index(FEATURES, "Underground Forms")))
         exl_ug_forms_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Validity Checks")))
+        exl_validity_checks_main();
     if (IsActivatedFeature(array_index(FEATURES, "Wild Forms")))
         exl_wild_forms_main();
     if (IsActivatedFeature(array_index(FEATURES, "Wild Held Item Rates")))
@@ -123,6 +125,7 @@ void exl_features_main() {
     SetActivatedFeature(array_index(FEATURES, "Swarm Forms"));
     SetActivatedFeature(array_index(FEATURES, "Turn Counter"));
     SetActivatedFeature(array_index(FEATURES, "Underground Forms"));
+    SetActivatedFeature(array_index(FEATURES, "Validity Checks"));
     SetActivatedFeature(array_index(FEATURES, "Wild Forms"));
     SetActivatedFeature(array_index(FEATURES, "Wild Held Item Rates"));
     SetActivatedFeature(array_index(FEATURES, "Contest NPC Forms"));

--- a/src/mod/features/validity_checks.cpp
+++ b/src/mod/features/validity_checks.cpp
@@ -1,0 +1,40 @@
+#include "exlaunch.hpp"
+#include "externals/Pml/PokePara/Accessor.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/Pml/PokePara/CoreParam.h"
+
+using namespace Pml::PokePara;
+
+HOOK_DEFINE_REPLACE(GetDprIllegalFlag) {
+    static bool Callback(Accessor *__this) {
+        // Always return valid
+        return false;
+    }
+};
+
+HOOK_DEFINE_REPLACE(IsDuplicatedPokemonParam) {
+    static bool Callback(PokemonParam::Object* pp0, void* checkedParams) {
+        // Always return valid
+        return false;
+    }
+};
+
+HOOK_DEFINE_REPLACE(SetDprIllegalFlag) {
+    static void Callback(Accessor *__this, bool flag) {
+        // *Wiggles index finger side to side*
+    }
+};
+
+HOOK_DEFINE_REPLACE(set_fuseiTamagoFlag) {
+    static void Callback(Accessor *__this, bool value) {
+        // *Wiggles index finger side to side*
+    }
+};
+
+void exl_validity_checks_main() {
+    GetDprIllegalFlag::InstallAtOffset(0x024a8520);
+    IsDuplicatedPokemonParam::InstallAtOffset(0x01997390);
+    SetDprIllegalFlag::InstallAtOffset(0x024a84a0);
+    set_fuseiTamagoFlag::InstallAtOffset(0x02043460);
+}
+


### PR DESCRIPTION
- Ports the validity checks from Starlight to ExLaunch.
- Converted `System_Collections_Generic_List_PokemonParam__o* checkedParams` to `void* checkedParams`
- Since we aren't trampolining or replacing with code that requires access to `*checkedParams`, leaving it as `void*` simplifies the patch while retaining its functionality.