### PR TITLE
Trainer Double Battle Port (Starlight -> ExLaunch)

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -33,6 +33,7 @@ static constexpr const char* FEATURES[] = {
     "Shiny Rates",
     "Sound Encounters",
     "Swarm Forms",
+    "Trainer Double Battle",
     "Turn Counter",
     "Underground Forms",
     "Wild Forms",

--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -1767,7 +1767,7 @@ enum class FlagWork_Flag : int32_t {
 
     // Luminescent Flags
     FLAG_INFINITE_REPEL = 2195,
-    
+    FLAG_TRAINER_DOUBLE = 2196,
     FLAG_DISABLE_LEVEL_CAP = 2197,
     FLAG_DISABLE_EXP_SHARE = 2198,
     FLAG_DISABLE_AFFECTION = 2199,

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -120,6 +120,9 @@ void exl_swarm_forms_main();
 // Deposits items obtained by thief directly into the player's bag.
 void exl_thief_patches_main();
 
+// Allows double battles on trainers.
+void exl_trainer_double_battles_main();
+
 // Assigns a work value to be used as a total turn counter for the last battle. By default, this is work value 449.
 void exl_turn_counter_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -56,6 +56,8 @@ void CallFeatureHooks()
         exl_pickup_main();
     if (IsActivatedFeature(array_index(FEATURES, "Thief Deposits to Bag")))
         exl_thief_patches_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Trainer Double Battle")))
+        exl_trainer_double_battles_main();
     if (IsActivatedFeature(array_index(FEATURES, "Two-Button Pokétch")))
         exl_poketch_main();
     if (IsActivatedFeature(array_index(FEATURES, "Relearn TMs")))
@@ -124,6 +126,7 @@ void exl_features_main() {
     SetActivatedFeature(array_index(FEATURES, "Pickup Changes"));
     SetActivatedFeature(array_index(FEATURES, "Poké Radar Fixes"));
     SetActivatedFeature(array_index(FEATURES, "Thief Deposits to Bag"));
+    SetActivatedFeature(array_index(FEATURES, "Trainer Double Battle"));
     SetActivatedFeature(array_index(FEATURES, "Two-Button Pokétch"));
     SetActivatedFeature(array_index(FEATURES, "Relearn TMs"));
     SetActivatedFeature(array_index(FEATURES, "New Settings"));

--- a/src/mod/features/trainer_double_battle.cpp
+++ b/src/mod/features/trainer_double_battle.cpp
@@ -1,0 +1,26 @@
+#include "exlaunch.hpp"
+#include "Logger/logger.h"
+#include "externals/il2cpp-api.h"
+#include "externals/Dpr/Battle/Logic/BATTLE_SETUP_PARAM.h"
+#include "externals/PlayerWork.h"
+
+const int32_t BTL_RULE_SINGLE = 0;
+const int32_t BTL_RULE_DOUBLE = 1;
+
+HOOK_DEFINE_TRAMPOLINE(SetupBattleTrainer) {
+    static void Callback(Dpr::Battle::Logic::BATTLE_SETUP_PARAM::Object *battleSetupParam, int32_t arenaID,
+                         int32_t mapAttrib, int32_t weatherType, int32_t rule, int32_t enemyID0, int32_t enemyID1,
+                         int32_t partnerID, MethodInfo *method)
+    {
+        if (PlayerWork::GetBool(2196))
+        {
+            rule = BTL_RULE_DOUBLE;
+        }
+        Orig(battleSetupParam, arenaID, mapAttrib, weatherType, rule, enemyID0, enemyID1, partnerID, method);
+    }
+
+};
+
+void exl_trainer_double_battles_main() {
+    SetupBattleTrainer::InstallAtOffset(0x02c3b800);
+}

--- a/src/mod/features/trainer_double_battle.cpp
+++ b/src/mod/features/trainer_double_battle.cpp
@@ -3,18 +3,21 @@
 #include "externals/il2cpp-api.h"
 #include "externals/Dpr/Battle/Logic/BATTLE_SETUP_PARAM.h"
 #include "externals/PlayerWork.h"
+#include "externals/Dpr/Battle/Logic/BtlRule.h"
+#include "externals/FlagWork.h"
+#include "externals/FlagWork_Enums.h"
 
-const int32_t BTL_RULE_SINGLE = 0;
-const int32_t BTL_RULE_DOUBLE = 1;
+
+using namespace Dpr::Battle::Logic;
 
 HOOK_DEFINE_TRAMPOLINE(SetupBattleTrainer) {
-    static void Callback(Dpr::Battle::Logic::BATTLE_SETUP_PARAM::Object *battleSetupParam, int32_t arenaID,
+    static void Callback(BATTLE_SETUP_PARAM::Object *battleSetupParam, int32_t arenaID,
                          int32_t mapAttrib, int32_t weatherType, int32_t rule, int32_t enemyID0, int32_t enemyID1,
                          int32_t partnerID, MethodInfo *method)
     {
-        if (PlayerWork::GetBool(2196))
+        if (FlagWork::GetFlag(FlagWork_Flag::FLAG_TRAINER_DOUBLE))
         {
-            rule = BTL_RULE_DOUBLE;
+            rule = (int32_t) BtlRule::BTL_RULE_DOUBLE;
         }
         Orig(battleSetupParam, arenaID, mapAttrib, weatherType, rule, enemyID0, enemyID1, partnerID, method);
     }


### PR DESCRIPTION
- Allows double battles in a 1v1 trainer context if the appropriate flag is set.
- Targeting EncountTools$$SetupBattleTrainer (0x02c3b800) as a trampoline hook rather than in-lining on 0x02c5015c like the original SL patch
![image](https://github.com/TeamLumi/Luminescent_ExLaunch/assets/39507107/ed85beb4-19a9-442a-ac2c-7362e2720b7a)
