### PR TITLE
Static Held Items Port (Starlight -> ExLaunch)

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -29,6 +29,7 @@ static constexpr const char* FEATURES[] = {
     "Controls Remap",
     "New Settings",
     "Shiny Rates",
+    "Static Held Items",
     "Sound Encounters",
     "Swarm Forms",
     "Turn Counter",

--- a/src/mod/externals/Dpr/EncountTools.h
+++ b/src/mod/externals/Dpr/EncountTools.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "externals/il2cpp-api.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+
+namespace Dpr {
+    struct EncountTools : ILClass<EncountTools> {
+
+        static inline uint16_t SetWildPokemonItem(Pml::PokePara::PokemonParam* pp, int32_t itemRnd, int32_t rnd1 , int32_t rnd2) {
+            return external<uint16_t>(0x02c3aab0, pp, itemRnd, rnd1, rnd2);
+        }
+
+    };
+}
+
+

--- a/src/mod/externals/Pml/PokePara/Accessor.h
+++ b/src/mod/externals/Pml/PokePara/Accessor.h
@@ -97,5 +97,13 @@ namespace Pml::PokePara {
         inline bool IsFuseiTamago() {
             return external<bool>(0x024a4bc0, this);
         }
+
+        inline int32_t GetMonsNo() {
+            return external<int32_t>(0x024a4e70, this);
+        }
+
+        inline uint16_t GetFormNo() {
+            return external<uint16_t>(0x024a64e0, this);
+        }
     };
 }

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -108,6 +108,9 @@ void exl_settings_main();
 // Reworks the shiny rates.
 void exl_shiny_rates_main();
 
+// Allows static encounters such as Rotom/Legendary Encounters/Honey Trees to have held items.
+void exl_static_held_items_main();
+
 // Adds support for Sigma Platinum-style Sound encounters.
 void exl_sounds_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -62,6 +62,8 @@ void CallFeatureHooks()
         exl_settings_main();
     if (IsActivatedFeature(array_index(FEATURES, "Shiny Rates")))
         exl_shiny_rates_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Static Held Items")))
+        exl_static_held_items_main();
     if (IsActivatedFeature(array_index(FEATURES, "Sound Encounters")))
         exl_sounds_main();
     if (IsActivatedFeature(array_index(FEATURES, "Swarm Forms")))
@@ -122,6 +124,7 @@ void exl_features_main() {
     SetActivatedFeature(array_index(FEATURES, "Relearn TMs"));
     SetActivatedFeature(array_index(FEATURES, "New Settings"));
     SetActivatedFeature(array_index(FEATURES, "Shiny Rates"));
+    SetActivatedFeature(array_index(FEATURES, "Static Held Items"));
     SetActivatedFeature(array_index(FEATURES, "Swarm Forms"));
     SetActivatedFeature(array_index(FEATURES, "Turn Counter"));
     SetActivatedFeature(array_index(FEATURES, "Underground Forms"));

--- a/src/mod/features/static_held_items.cpp
+++ b/src/mod/features/static_held_items.cpp
@@ -20,33 +20,7 @@ using namespace Pml;
 HOOK_DEFINE_INLINE(SetWildPokemonItem) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
 
-        const int32_t ITEM1_BASERATE = 50;
-        const int32_t ITEM1_BOOSTEDRATE = 60;
-        const int32_t ITEM2_BASERATE = 20;
-        const int32_t ITEM2_BOOSTEDRATE = 20;
-
-        int32_t item1Rate;
-        int32_t item2Rate;
-
         system_load_typeinfo(0x3f8c);
-
-        PokeParty::Object *party = PlayerWork::get_playerParty();
-        auto firstPoke = (PokePara::CoreParam *) party->GetMemberPointer(0);
-
-        if (!firstPoke->IsEgg(PokePara::EggCheckType::BOTH_EGG)) {
-            int32_t ability = firstPoke->GetTokuseiNo();
-            switch (ability) {
-                case array_index(ABILITIES, "Super Luck"):
-                case array_index(ABILITIES, "Compound Eyes"):
-                    item1Rate = ITEM1_BOOSTEDRATE;
-                    item2Rate = ITEM2_BOOSTEDRATE;
-                    break;
-                default:
-                    item1Rate = ITEM1_BASERATE;
-                    item2Rate = ITEM2_BASERATE;
-                    break;
-            }
-        }
 
         auto __this = (PokeParty::Object*) ctx->X[0];
         auto idx = (uint32_t) ctx->W[1];
@@ -54,7 +28,7 @@ HOOK_DEFINE_INLINE(SetWildPokemonItem) {
         PokePara::PokemonParam* enemyPoke = __this->GetMemberPointer(0);
         int32_t randomRoll = UnityEngine::Random::Range(0,100);
 
-        uint16_t setItem = Dpr::EncountTools::SetWildPokemonItem(enemyPoke, randomRoll, item1Rate, item2Rate);
+        uint16_t setItem = Dpr::EncountTools::SetWildPokemonItem(enemyPoke, randomRoll, 0, 0);
         Logger::log("[SetWildPokemonItem] Item set to %s\n", ITEMS[setItem]);
 
         ctx->X[0] = (uint64_t) __this->GetMemberPointer(idx);

--- a/src/mod/features/static_held_items.cpp
+++ b/src/mod/features/static_held_items.cpp
@@ -1,4 +1,3 @@
-#include "externals/il2cpp.h"
 #include "exlaunch.hpp"
 #include "externals/Dpr/EncountTools.h"
 #include "externals/PlayerWork.h"
@@ -7,8 +6,9 @@
 #include "externals/Pml/PokeParty.h"
 #include "externals/UnityEngine/Random.h"
 #include "externals/Pml/PokePara/EggCheckType.h"
-#include "externals/XLSXContent/PersonalTable.h"
-#include "externals/Pml/Personal/PersonalSystem.h"
+#include "data/abilities.h"
+#include "data/items.h"
+#include "data/utils.h"
 
 #include "util.h"
 #include "Logger/logger.h"
@@ -17,28 +17,27 @@
 
 using namespace Pml;
 
-HOOK_DEFINE_REPLACE(SetWildPokemonItem) {
-    static uint16_t Callback(PokePara::PokemonParam::Object* pp, int32_t itemRnd, int32_t rnd1, int32_t rnd2) {
-
-        const int32_t SUPERLUCK_ABILITYNO = 105;
-        const int32_t COMPOUNDEYES_ABILITYNO = 14;
+HOOK_DEFINE_INLINE(SetWildPokemonItem) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
 
         const int32_t ITEM1_BASERATE = 50;
         const int32_t ITEM1_BOOSTEDRATE = 60;
         const int32_t ITEM2_BASERATE = 20;
         const int32_t ITEM2_BOOSTEDRATE = 20;
 
+        int32_t item1Rate;
+        int32_t item2Rate;
+
         system_load_typeinfo(0x3f8c);
-        int32_t item1Rate = ITEM1_BASERATE;
-        int32_t item2Rate = ITEM2_BASERATE;
+
         PokeParty::Object *party = PlayerWork::get_playerParty();
         auto firstPoke = (PokePara::CoreParam *) party->GetMemberPointer(0);
 
         if (!firstPoke->IsEgg(PokePara::EggCheckType::BOTH_EGG)) {
             int32_t ability = firstPoke->GetTokuseiNo();
             switch (ability) {
-                case SUPERLUCK_ABILITYNO:
-                case COMPOUNDEYES_ABILITYNO:
+                case array_index(ABILITIES, "Super Luck"):
+                case array_index(ABILITIES, "Compound Eyes"):
                     item1Rate = ITEM1_BOOSTEDRATE;
                     item2Rate = ITEM2_BOOSTEDRATE;
                     break;
@@ -49,36 +48,21 @@ HOOK_DEFINE_REPLACE(SetWildPokemonItem) {
             }
         }
 
-        system_load_typeinfo(0x3f54);
-        auto ppCore = (PokePara::CoreParam::Object*) pp;
-        uint16_t setItem = 0;
-        uint16_t getItem = ppCore->GetItem();
+        auto __this = (PokeParty::Object*) ctx->X[0];
+        auto idx = (uint32_t) ctx->W[1];
 
-        if ((-1 < itemRnd) && (getItem == 0)) {
+        PokePara::PokemonParam* enemyPoke = __this->GetMemberPointer(0);
+        int32_t randomRoll = UnityEngine::Random::Range(0,100);
 
-            int32_t monsno = ppCore->GetMonsNo();
-            uint16_t formno = ppCore->GetFormNo();
+        uint16_t setItem = Dpr::EncountTools::SetWildPokemonItem(enemyPoke, randomRoll, item1Rate, item2Rate);
+        Logger::log("[SetWildPokemonItem] Item set to %s\n", ITEMS[setItem]);
 
-
-            XLSXContent::PersonalTable::SheetPersonal::Object* personalData = Personal::PersonalSystem::GetPersonalData(monsno, formno);
-
-            if (itemRnd < rnd1) {
-                setItem = personalData->fields.item1;
-            }
-
-            else if (itemRnd < rnd2 + rnd1) {
-                setItem = personalData->fields.item2;
-            }
-
-            else {
-                setItem = personalData->fields.item3;
-            }
-
-            ppCore->SetItem(setItem);
-
-        }
-        return setItem;
+        ctx->X[0] = (uint64_t) __this->GetMemberPointer(idx);
     }
 };
+
+void exl_static_held_items_main() {
+    SetWildPokemonItem::InstallAtOffset(0x0179f85c);
+}
 
 

--- a/src/mod/features/static_held_items.cpp
+++ b/src/mod/features/static_held_items.cpp
@@ -1,0 +1,84 @@
+#include "externals/il2cpp.h"
+#include "exlaunch.hpp"
+#include "externals/Dpr/EncountTools.h"
+#include "externals/PlayerWork.h"
+#include "externals/Pml/PokePara/CoreParam.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/Pml/PokeParty.h"
+#include "externals/UnityEngine/Random.h"
+#include "externals/Pml/PokePara/EggCheckType.h"
+#include "externals/XLSXContent/PersonalTable.h"
+#include "externals/Pml/Personal/PersonalSystem.h"
+
+#include "util.h"
+#include "Logger/logger.h"
+
+
+
+using namespace Pml;
+
+HOOK_DEFINE_REPLACE(SetWildPokemonItem) {
+    static uint16_t Callback(PokePara::PokemonParam::Object* pp, int32_t itemRnd, int32_t rnd1, int32_t rnd2) {
+
+        const int32_t SUPERLUCK_ABILITYNO = 105;
+        const int32_t COMPOUNDEYES_ABILITYNO = 14;
+
+        const int32_t ITEM1_BASERATE = 50;
+        const int32_t ITEM1_BOOSTEDRATE = 60;
+        const int32_t ITEM2_BASERATE = 20;
+        const int32_t ITEM2_BOOSTEDRATE = 20;
+
+        system_load_typeinfo(0x3f8c);
+        int32_t item1Rate = ITEM1_BASERATE;
+        int32_t item2Rate = ITEM2_BASERATE;
+        PokeParty::Object *party = PlayerWork::get_playerParty();
+        auto firstPoke = (PokePara::CoreParam *) party->GetMemberPointer(0);
+
+        if (!firstPoke->IsEgg(PokePara::EggCheckType::BOTH_EGG)) {
+            int32_t ability = firstPoke->GetTokuseiNo();
+            switch (ability) {
+                case SUPERLUCK_ABILITYNO:
+                case COMPOUNDEYES_ABILITYNO:
+                    item1Rate = ITEM1_BOOSTEDRATE;
+                    item2Rate = ITEM2_BOOSTEDRATE;
+                    break;
+                default:
+                    item1Rate = ITEM1_BASERATE;
+                    item2Rate = ITEM2_BASERATE;
+                    break;
+            }
+        }
+
+        system_load_typeinfo(0x3f54);
+        auto ppCore = (PokePara::CoreParam::Object*) pp;
+        uint16_t setItem = 0;
+        uint16_t getItem = ppCore->GetItem();
+
+        if ((-1 < itemRnd) && (getItem == 0)) {
+
+            int32_t monsno = ppCore->GetMonsNo();
+            uint16_t formno = ppCore->GetFormNo();
+
+
+            XLSXContent::PersonalTable::SheetPersonal::Object* personalData = Personal::PersonalSystem::GetPersonalData(monsno, formno);
+
+            if (itemRnd < rnd1) {
+                setItem = personalData->fields.item1;
+            }
+
+            else if (itemRnd < rnd2 + rnd1) {
+                setItem = personalData->fields.item2;
+            }
+
+            else {
+                setItem = personalData->fields.item3;
+            }
+
+            ppCore->SetItem(setItem);
+
+        }
+        return setItem;
+    }
+};
+
+

--- a/src/mod/features/wild_held_items.cpp
+++ b/src/mod/features/wild_held_items.cpp
@@ -36,19 +36,22 @@ HOOK_DEFINE_REPLACE(WildHeldItems) {
 
             auto firstPokemonCoreParam = reinterpret_cast<Pml::PokePara::CoreParam::Object *>(firstPartyPokemon);
 
-            auto abilityNo = firstPokemonCoreParam->GetTokuseiNo();
-
 
             int32_t firstRate = 0;
             int32_t secondRate = 0;
 
-            if (abilityNo == array_index(ABILITIES, "Frisk")
-            || abilityNo == array_index(ABILITIES, "Compound Eyes")
-            || abilityNo == array_index(ABILITIES, "Super Luck"))
-            {
-                firstRate = 60;
-                secondRate = 20;
+            if (!firstPokemonCoreParam->IsEgg(Pml::PokePara::EggCheckType::BOTH_EGG)) {
+                auto abilityNo = firstPokemonCoreParam->GetTokuseiNo();
+
+                if (abilityNo == array_index(ABILITIES, "Frisk")
+                    || abilityNo == array_index(ABILITIES, "Compound Eyes")
+                    || abilityNo == array_index(ABILITIES, "Super Luck"))
+                {
+                    firstRate = 60;
+                    secondRate = 20;
+                }
             }
+
             else
             {
                 firstRate = 50;


### PR DESCRIPTION
- Allows static encounters to have held items + modifies item rates based on if the player's first pokemon has the ability super luck or compound eyes.
- Changed the 'magic number' declaration of the aforementioned abilities in the SL patch to instead be calculated through array_indexing from items.h. e.g `array_index(ABILITIES, "Super Luck")`
- `if (!firstPoke->IsEgg(2, nullptr))` updated to use the EggCheckType enum: `PokePara::EggCheckType::BOTH_EGG` from `EggCheckType.h`

- Misc Change: I added the functions `GetMonsNo()` and `GetFormNo()` to `Accessor.h`. They don't contribute to this issue but may as well merge them in for future usage.

**Rotom Battle:**
![image](https://github.com/TeamLumi/Luminescent_ExLaunch/assets/39507107/1f24f50d-25d7-4167-be26-045df6d33d74)
