### PR TITLE
Bug fix: Language select no longer hangs when launched on a non-English console

### DIFF
--- a/src/mod/externals/Dpr/Message/MessageEnumData.h
+++ b/src/mod/externals/Dpr/Message/MessageEnumData.h
@@ -2,17 +2,19 @@
 
 #include "externals/il2cpp-api.h"
 
-struct MessageEnumData : ILClass<MessageEnumData> {
-    enum class MsgLangId : int32_t {
-        JPN = 1,
-        USA = 2,
-        FRA = 3,
-        ITA = 4,
-        DEU = 5,
-        ESP = 7,
-        KOR = 8,
-        SCH = 9,
-        TCH = 10,
-        Num = 11,
+namespace Dpr::Message {
+    struct MessageEnumData : ILClass<MessageEnumData> {
+        enum class MsgLangId : int32_t {
+            JPN = 1,
+            USA = 2,
+            FRA = 3,
+            ITA = 4,
+            DEU = 5,
+            ESP = 7,
+            KOR = 8,
+            SCH = 9,
+            TCH = 10,
+            Num = 11,
+        };
     };
-};
+}

--- a/src/mod/externals/Dpr/Message/MessageEnumData.h
+++ b/src/mod/externals/Dpr/Message/MessageEnumData.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+struct MessageEnumData : ILClass<MessageEnumData> {
+    enum class MsgLangId : int32_t {
+        JPN = 1,
+        USA = 2,
+        FRA = 3,
+        ITA = 4,
+        DEU = 5,
+        ESP = 7,
+        KOR = 8,
+        SCH = 9,
+        TCH = 10,
+        Num = 11,
+    };
+};

--- a/src/mod/features/small_patches.cpp
+++ b/src/mod/features/small_patches.cpp
@@ -5,6 +5,7 @@
 #include "data/utils.h"
 #include "externals/FlagWork.h"
 #include "features/activated_features.h"
+#include "externals/Dpr/Message/MessageEnumData.h"
 
 HOOK_DEFINE_REPLACE(FriendshipFlag) {
     static bool Callback() {
@@ -15,6 +16,12 @@ HOOK_DEFINE_REPLACE(FriendshipFlag) {
 HOOK_DEFINE_REPLACE(ExpShareFlag) {
     static bool Callback() {
         return FlagWork::GetFlag(FlagWork_Flag::FLAG_DISABLE_EXP_SHARE);
+    }
+};
+
+HOOK_DEFINE_REPLACE(GetMessageLangIdFromIetfCode) {
+    static int32_t Callback() {
+        return static_cast<int32_t>(MessageEnumData::MsgLangId::USA);
     }
 };
 
@@ -41,4 +48,6 @@ void exl_patches_main() {
         { 0x0202c140, CmpImmediate(W19, ITEM_COUNT) },  // Make the battle check for if you own balls that go past 1822 items
     };
     p.WriteInst(inst);
+
+    GetMessageLangIdFromIetfCode::InstallAtOffset(0x017c21f0); // Always returns language as English
 }


### PR DESCRIPTION
![image](https://github.com/TeamLumi/Luminescent_ExLaunch/assets/39507107/fdf56c67-3a03-431a-9664-76bf6dc5e0ed)

- Replace hooks `Dpr::UI::UIManager::GetMessageLangIdFromIetfCode()` to always return `MessageEnumData::MsgLangId::USA`
- Implements `MessageEnumData.h` with the enum `MsgLangID`
