### PR TITLE
Bug fix: IVs displaying 0/31 on Hyper Trained stats

### DIFF
--- a/src/mod/features/ev_iv_ui.cpp
+++ b/src/mod/features/ev_iv_ui.cpp
@@ -20,7 +20,7 @@ System::String::Object* GetIVLabel(Pml::PokePara::CoreParam::Object* pokemonPara
 
     if (trainingDone)
     {
-        return System::String::Create("SS_box_590");
+        return System::String::Create("SS_box_577");
     }
     else
     {


### PR DESCRIPTION
![image](https://github.com/TeamLumi/Luminescent_ExLaunch/assets/39507107/32c659a9-2a7e-40b5-8aeb-6d9c58c0bc5f)

- Changed `return System::String::Create("SS_box_590");` to `return System::String::Create("SS_box_577");`
- `SS_box_590` is the 0/31 IV label which was incorrectly assigned to `if (trainingDone)`