### PR TITLE
Bug Fix: Inverted Settings

### DIFF
--- a/src/mod/features/level_cap.cpp
+++ b/src/mod/features/level_cap.cpp
@@ -25,7 +25,8 @@ HOOK_DEFINE_REPLACE(LevelCap) {
         }
 
         // Is Level Cap enabled
-        if (!PlayerWork::GetBool((int32_t)FlagWork_Flag::FLAG_DISABLE_LEVEL_CAP))
+        // Logic: Disabling the level cap means we want vanilla behaviour, therefore return exp.
+        if (PlayerWork::GetBool((int32_t)FlagWork_Flag::FLAG_DISABLE_LEVEL_CAP))
         {
             return (uint32_t) exp;
         }

--- a/src/mod/features/small_patches.cpp
+++ b/src/mod/features/small_patches.cpp
@@ -19,7 +19,7 @@ HOOK_DEFINE_TRAMPOLINE(FriendshipFlag) {
 
 HOOK_DEFINE_REPLACE(ExpShareFlag) {
     static bool Callback() {
-        return FlagWork::GetFlag(FlagWork_Flag::FLAG_DISABLE_EXP_SHARE);
+        return !FlagWork::GetFlag(FlagWork_Flag::FLAG_DISABLE_EXP_SHARE);
     }
 };
 


### PR DESCRIPTION
- Resolved settings inversion on EXP share and Level cap resulting from unaccounted logic changes when unifying flag naming conventions.
- Level Cap now will return vanilla exp values if "Disable Level Cap" is true
- Exp Share will now return `!FlagWork::GetFlag(FlagWork_Flag::FLAG_DISABLE_EXP_SHARE)`.