### PR TITLE
Array overhaul

### DIFF
--- a/src/mod/externals/DPData/GET_STATUS.h
+++ b/src/mod/externals/DPData/GET_STATUS.h
@@ -3,8 +3,5 @@
 namespace DPData {
     typedef int32_t GET_STATUS;
 
-    PRIMITIVE_ARRAY(GET_STATUS);
-    static Il2CppClass* GET_STATUS_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c5a5a8));
-    }
+    PRIMITIVE_ARRAY(GET_STATUS, 0x04c5a5a8)
 }

--- a/src/mod/externals/DPData/KinomiGrow.h
+++ b/src/mod/externals/DPData/KinomiGrow.h
@@ -3,7 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 namespace DPData {
-    struct KinomiGrow : ILStruct<KinomiGrow> {
+    struct KinomiGrow : ILStruct<KinomiGrow, 0x04c5a4b0> {
         struct Fields {
             int32_t tagNo;
             int32_t harvestCount;
@@ -14,8 +14,4 @@ namespace DPData {
             uint8_t _padding1;
         };
     };
-
-    static Il2CppClass* KinomiGrow_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c5a4b0));
-    }
 }

--- a/src/mod/externals/DPData/TR_BATTLE_DATA.h
+++ b/src/mod/externals/DPData/TR_BATTLE_DATA.h
@@ -3,14 +3,10 @@
 #include "externals/il2cpp.h"
 
 namespace DPData {
-    struct TR_BATTLE_DATA : ILStruct<TR_BATTLE_DATA> {
+    struct TR_BATTLE_DATA : ILStruct<TR_BATTLE_DATA, 0x04c64da8> {
         struct Fields {
             bool IsWin;
             bool IsBattleSearcher;
         };
     };
-
-    static Il2CppClass* TR_BATTLE_DATA_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c64da8));
-    }
 }

--- a/src/mod/externals/Dpr/Battle/Logic/Handler/Field.h
+++ b/src/mod/externals/Dpr/Battle/Logic/Handler/Field.h
@@ -15,7 +15,7 @@ namespace Dpr::Battle::Logic::Handler {
             }
         };
 
-        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM> {
+        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM, 0x04c5b188> {
             struct Fields {
                 int32_t effect;
                 HandlerGetFunc::Object* func;

--- a/src/mod/externals/Dpr/Battle/Logic/Handler/Side.h
+++ b/src/mod/externals/Dpr/Battle/Logic/Handler/Side.h
@@ -15,7 +15,7 @@ namespace Dpr::Battle::Logic::Handler {
             }
         };
 
-        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM> {
+        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM, 0x04c5b2a0> {
             struct Fields {
                 int32_t effect;
                 HandlerGetFunc::Object* func;

--- a/src/mod/externals/Dpr/Battle/Logic/Handler/Waza.h
+++ b/src/mod/externals/Dpr/Battle/Logic/Handler/Waza.h
@@ -18,7 +18,7 @@ namespace Dpr::Battle::Logic::Handler {
             }
         };
 
-        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM> {
+        struct GET_FUNC_TABLE_ELEM : ILStruct<GET_FUNC_TABLE_ELEM, 0x04c5b440> {
             struct Fields {
                 int32_t waza;
                 HandlerGetFunc::Object* func;

--- a/src/mod/externals/Dpr/Box/SaveBoxData.h
+++ b/src/mod/externals/Dpr/Box/SaveBoxData.h
@@ -6,7 +6,7 @@
 
 namespace Dpr::Box {
     struct SaveBoxData : ILStruct<SaveBoxData> {
-        struct _STR17 : ILStruct<_STR17> {
+        struct _STR17 : ILStruct<_STR17, 0x04c5ddb0> {
             struct Fields {
                 System::String::Object* str;
             };
@@ -15,10 +15,6 @@ namespace Dpr::Box {
                 return 17*2;
             }
         };
-
-        static Il2CppClass* _STR17_array_TypeInfo() {
-            return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c5ddb0));
-        }
 
         struct _STR11 : ILStruct<_STR11> {
             struct Fields {

--- a/src/mod/externals/Dpr/Box/SaveBoxTrayData.h
+++ b/src/mod/externals/Dpr/Box/SaveBoxTrayData.h
@@ -5,7 +5,7 @@
 #include "externals/Pml/PokePara/SerializedPokemonFull.h"
 
 namespace Dpr::Box {
-    struct SaveBoxTrayData : ILStruct<SaveBoxTrayData> {
+    struct SaveBoxTrayData : ILStruct<SaveBoxTrayData, 0x04c64da0> {
         struct Fields {
             Pml::PokePara::SerializedPokemonFull::Array* pokemonParam;
         };
@@ -14,8 +14,4 @@ namespace Dpr::Box {
             return Pml::PokePara::SerializedPokemonFull::GetByteCount()*30;
         }
     };
-
-    static Il2CppClass* SaveBoxTrayData_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c64da0));
-    }
 }

--- a/src/mod/externals/Dpr/Item/SaveItem.h
+++ b/src/mod/externals/Dpr/Item/SaveItem.h
@@ -3,7 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 namespace Dpr::Item {
-    struct SaveItem : ILStruct<SaveItem> {
+    struct SaveItem : ILStruct<SaveItem, 0x04c64d90> {
         struct Fields {
             int32_t Count;
             bool VanishNew;
@@ -14,8 +14,4 @@ namespace Dpr::Item {
             uint16_t SortNumber;
         };
     };
-
-    static Il2CppClass* SaveItem_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c64d90));
-    }
 }

--- a/src/mod/externals/MonsLv.h
+++ b/src/mod/externals/MonsLv.h
@@ -2,14 +2,10 @@
 
 #include "externals/il2cpp-api.h"
 
-struct MonsLv : ILStruct<MonsLv> {
+struct MonsLv : ILStruct<MonsLv, 0x04c5f208> {
     struct Fields {
         int32_t maxlv;
         int32_t minlv;
         int32_t monsNo;
     };
-
-    static Il2CppClass* Array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c5f208));
-    }
 };

--- a/src/mod/externals/Pml/MonsNo.h
+++ b/src/mod/externals/Pml/MonsNo.h
@@ -5,4 +5,4 @@
 
 typedef int32_t Pml_MonsNo;
 
-PRIMITIVE_ARRAY(Pml_MonsNo);
+PRIMITIVE_ARRAY(Pml_MonsNo, 0x04c5e6e8)

--- a/src/mod/externals/Pml/PokePara/SerializedPokemonFull.h
+++ b/src/mod/externals/Pml/PokePara/SerializedPokemonFull.h
@@ -5,7 +5,7 @@
 #include "externals/System/Primitives.h"
 
 namespace Pml::PokePara {
-    struct SerializedPokemonFull : ILStruct<SerializedPokemonFull> {
+    struct SerializedPokemonFull : ILStruct<SerializedPokemonFull, 0x04c59c08> {
         struct Fields {
             System::Byte_array* buffer;
         };
@@ -18,9 +18,4 @@ namespace Pml::PokePara {
             external<void>(0x020558c0, this);
         }
     };
-
-    static Il2CppClass* SerializedPokemonFull_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c59c08));
-    }
-
 }

--- a/src/mod/externals/Pml/WazaNo.h
+++ b/src/mod/externals/Pml/WazaNo.h
@@ -6,7 +6,7 @@
 
 typedef int32_t Pml_WazaNo;
 
-PRIMITIVE_ARRAY(Pml_WazaNo);
+PRIMITIVE_ARRAY(Pml_WazaNo, 0x04c5c7e8)
 
 namespace System::Collections::Generic {
     struct HashSet$$Pml_WazaNo : HashSet<HashSet$$Pml_WazaNo, Pml_WazaNo> {

--- a/src/mod/externals/System/Primitives.h
+++ b/src/mod/externals/System/Primitives.h
@@ -13,21 +13,12 @@ namespace System {
     typedef int64_t Int64;
     typedef float Single;
 
-    PRIMITIVE_ARRAY(Boolean);
-    static Il2CppClass* Boolean_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c55920));
-    }
-    PRIMITIVE_ARRAY(Byte);
-    static Il2CppClass* Byte_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c552e0));
-    }
-    PRIMITIVE_ARRAY(Char);
-    PRIMITIVE_ARRAY(UInt16);
-    PRIMITIVE_ARRAY(Int32);
-    static Il2CppClass* Int32_array_TypeInfo() {
-        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(0x04c553e0));
-    }
-    PRIMITIVE_ARRAY(UInt32);
-    PRIMITIVE_ARRAY(Int64);
-    PRIMITIVE_ARRAY(Single);
+    PRIMITIVE_ARRAY(Boolean, 0x04c55920)
+    PRIMITIVE_ARRAY(Byte, 0x04c552e0)
+    PRIMITIVE_ARRAY(Char, 0x04c55340)
+    PRIMITIVE_ARRAY(UInt16, 0x04c559e8)
+    PRIMITIVE_ARRAY(Int32, 0x04c553e0)
+    PRIMITIVE_ARRAY(UInt32, 0x04c558c8)
+    PRIMITIVE_ARRAY(Int64, 0x04c56388)
+    PRIMITIVE_ARRAY(Single, 0x04c56398)
 }

--- a/src/mod/externals/System/String.h
+++ b/src/mod/externals/System/String.h
@@ -62,7 +62,7 @@ namespace System {
         }
 
         static inline System::String::Object* fromUnicodeBytes(void* bytes, long count) {
-            auto byteArray = (System::Byte_array*)system_array_new(System::Byte_array_TypeInfo(), count);
+            auto byteArray = System::Byte_array::newArray(count);
             memcpy((void*)byteArray->m_Items, bytes, count);
             return fromUnicodeBytes(byteArray);
         }
@@ -71,7 +71,7 @@ namespace System {
             System::String::Object* str = this->instance();
             System::Text::UTF8Encoding::Object* encoding = System::Text::Encoding::get_UTF8();
             uint32_t size = encoding->GetByteCount(str);
-            auto arr = reinterpret_cast<System::Byte_array *>(system_array_new(System::Byte_array_TypeInfo(), size+1));
+            auto arr = System::Byte_array::newArray(size+1);
             encoding->GetBytes(str, 0, str->fields.m_stringLength, arr, 0);
             arr->m_Items[size] = 0;
             auto res = nn::string((char*)&arr->m_Items[0]);
@@ -82,7 +82,7 @@ namespace System {
             System::String::Object* str = this->instance();
             System::Text::UnicodeEncoding::Object* encoding = System::Text::Encoding::get_Unicode();
             uint32_t size = encoding->GetByteCount(str);
-            auto arr = reinterpret_cast<System::Byte_array *>(system_array_new(System::Byte_array_TypeInfo(), size+2));
+            auto arr = System::Byte_array::newArray(size+2);
             encoding->GetBytes(str, 0, str->fields.m_stringLength, arr, 0);
             arr->m_Items[size] = 0;
             arr->m_Items[size+1] = 0;

--- a/src/mod/externals/il2cpp-api.h
+++ b/src/mod/externals/il2cpp-api.h
@@ -34,13 +34,27 @@ struct _ILExternal {
     }
 };
 
-template <typename T>
+template <typename T, long ArrayTypeInfo = 0>
 struct ILStruct : _ILExternal  {
 public:
     struct Fields { };
 
     struct Object : T {
         T::Fields fields;
+    };
+
+    struct ArrayClass : Il2CppClass {
+        inline void initIfNeeded() {
+            if ((_2.bitflags2 >> 1 & 1) && (_2.cctor_finished == 0)) {
+                il2cpp_runtime_class_init((Il2CppClass*)this);
+            }
+        }
+
+        T::Array* newArray(long length) {
+            auto array = reinterpret_cast<T::Array*>(system_array_new((Il2CppClass*)this, length));
+            system_array_init(array, nullptr);
+            return array;
+        }
     };
 
     struct Array {
@@ -94,6 +108,17 @@ public:
             return iterator(&this->m_Items[this->max_length]);
         }
     };
+
+    static Array* newArray(long length) {
+        auto klass = getArrayClass();
+        klass->initIfNeeded();
+        return klass->newArray(length);
+    }
+
+    static ArrayClass* getArrayClass() {
+        static_assert(ArrayTypeInfo != 0, "ArrayTypeInfo address not set");
+        return *reinterpret_cast<T::ArrayClass**>(exl::util::modules::GetTargetOffset(ArrayTypeInfo));
+    }
 };
 
 template <typename T, long TypeInfo = 0, long ArrayTypeInfo = 0>
@@ -246,23 +271,33 @@ public:
     }
 };
 
-#define PRIMITIVE_ARRAY(name)                               \
-struct name##_array {                                       \
-    Il2CppObject obj;                                       \
-    Il2CppArrayBounds* bounds;                              \
-    uint64_t max_length;                                    \
-    name m_Items[65535];                                    \
-    inline void copyInto(name* dst) {                       \
-        for (uint64_t i = 0; i < max_length; i++) {         \
-            dst[i] = m_Items[i];                            \
-        }                                                   \
-    }                                                       \
-    inline void fillWith(name value) {                      \
-        for (uint64_t i = 0; i < max_length; i++) {         \
-            m_Items[i] = value;                             \
-        }                                                   \
-    }                                                       \
+#define PRIMITIVE_ARRAY(name, typeInfo)                                                             \
+struct name##_array {                                                                               \
+    Il2CppObject obj;                                                                               \
+    Il2CppArrayBounds* bounds;                                                                      \
+    uint64_t max_length;                                                                            \
+    name m_Items[65535];                                                                            \
+    inline void copyInto(name* dst) {                                                               \
+        for (uint64_t i = 0; i < max_length; i++) {                                                 \
+            dst[i] = m_Items[i];                                                                    \
+        }                                                                                           \
+    }                                                                                               \
+    inline void fillWith(name value) {                                                              \
+        for (uint64_t i = 0; i < max_length; i++) {                                                 \
+            m_Items[i] = value;                                                                     \
+        }                                                                                           \
+    }                                                                                               \
+    inline static Il2CppClass* getClass() {                                                         \
+        return *reinterpret_cast<Il2CppClass**>(exl::util::modules::GetTargetOffset(typeInfo));     \
+    }                                                                                               \
+    inline static name##_array* newArray(long length) {                                             \
+        auto array = reinterpret_cast<name##_array*>(system_array_new(getClass(), length));         \
+        system_array_init(array, nullptr);                                                          \
+        return array;                                                                               \
+    }                                                                                               \
 };
+
+
 
 template <typename... Args>
 struct ILMethod {

--- a/src/mod/features/encounter_slots.cpp
+++ b/src/mod/features/encounter_slots.cpp
@@ -680,7 +680,7 @@ HOOK_DEFINE_REPLACE(FieldEncountCheckEncounterSlots) {
         }
 
         Dpr::Field::EncountResult::Object *encounterHolder = Dpr::Field::EncountResult::newInstance();
-        auto slots = (MonsLv::Array*)system_array_new(MonsLv::Array_TypeInfo(), 12); // local_100 = 0x0
+        auto slots = MonsLv::newArray(12); // local_100 = 0x0
         bool isSafariFlag = false;
 
         // Handle Roaming and water encounters
@@ -750,7 +750,7 @@ HOOK_DEFINE_REPLACE(GetSafariScopeMonsterEncounterSlots) {
     static int32_t Callback(int32_t zoneId) {
         system_load_typeinfo(0x48c3);
 
-        auto slots = (MonsLv::Array*)system_array_new(MonsLv::Array_TypeInfo(), 12);
+        auto slots = MonsLv::newArray(12);
         XLSXContent::FieldEncountTable::Sheettable::Object *fieldEnc = GameManager::GetFieldEncountData(zoneId);
 
         if (slots->max_length > 0)
@@ -806,7 +806,7 @@ HOOK_DEFINE_REPLACE(SetFishingEncountEncounterSlots) {
         }
 
         Dpr::Field::EncountResult::Object *encounterHolder = Dpr::Field::EncountResult::newInstance();
-        auto slots = (MonsLv::Array*)system_array_new(MonsLv::Array_TypeInfo(), 5);
+        auto slots = MonsLv::newArray(5);
 
         // Set slots
         SetBaseFishingSlots(&encounterHolder, slots, inRodType);
@@ -871,7 +871,7 @@ HOOK_DEFINE_REPLACE(SetSweetEncountEncounterSlots) {
         Dpr::Field::FieldEncount::SetSpaStruct((Pml::PokePara::PokemonParam::Object *)firstPokemon, fieldEnc, &spaStruct);
 
         Dpr::Field::EncountResult::Object *encounterHolder = Dpr::Field::EncountResult::newInstance();
-        auto slots = (MonsLv::Array*)system_array_new(MonsLv::Array_TypeInfo(), 12); // local_100 = 0x0
+        auto slots = MonsLv::newArray(12); // local_100 = 0x0
         bool isSafariFlag = false;
 
         // Handle Roaming and water encounters

--- a/src/mod/features/field_handlers.cpp
+++ b/src/mod/features/field_handlers.cpp
@@ -159,10 +159,9 @@ HOOK_DEFINE_REPLACE(Section_FieldEffect_End_Execute) {
 
 HOOK_DEFINE_INLINE(Field_system_array_new) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto typeInfo = (Il2CppClass*)ctx->X[0];
         uint64_t size = ctx->X[1];
 
-        auto array = (Handler::Field::GET_FUNC_TABLE_ELEM::Array*)system_array_new(typeInfo, size + getExtraFieldEffectHandlers()->count);
+        auto array = Handler::Field::GET_FUNC_TABLE_ELEM::newArray(size + getExtraFieldEffectHandlers()->count);
         getExtraFieldEffectHandlers()->currentIndex = size;
 
         // DO NOT REMOVE ANY OF THESE! Disable the field effects in exl_field_handlers_main() below instead!

--- a/src/mod/features/key_items/incense_burner.cpp
+++ b/src/mod/features/key_items/incense_burner.cpp
@@ -122,7 +122,7 @@ void UseIncenseBurner(int32_t itemId, bool fromBag, Dpr::UI::UIBag::__c__Display
         };
         
         // There's probably a way to generalize converting a vector to our IL Arrays and then add the method to il2cpp-api.h, but I'm not smart enough to figure it out
-        System::Int32_array* contextMenuIDArray = (System::Int32_array*)system_array_new(System::Int32_array_TypeInfo(), contextMenuIDVector.size());
+        auto contextMenuIDArray = System::Int32_array::newArray(contextMenuIDVector.size());
         std::memcpy(contextMenuIDArray->m_Items, &contextMenuIDVector[0], sizeof(int32_t) * contextMenuIDVector.size());
         
         uiBag->OpenContextMenu(contextMenuIDArray, onSelected, pivot, pos, nullptr, false, false);

--- a/src/mod/features/move_handlers.cpp
+++ b/src/mod/features/move_handlers.cpp
@@ -50,10 +50,9 @@ void SetMoveFunctionTable(Handler::Waza::GET_FUNC_TABLE_ELEM::Array* getFuncTabl
 
 HOOK_DEFINE_INLINE(Handler_Waza_newGetFunc) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto typeInfo = (Il2CppClass*)ctx->X[0];
         uint64_t size = ctx->X[1];
 
-        auto array = (Handler::Waza::GET_FUNC_TABLE_ELEM::Array*)system_array_new(typeInfo, size + getExtraMoveHandlers()->count);
+        auto array = Handler::Waza::GET_FUNC_TABLE_ELEM::newArray(size + getExtraMoveHandlers()->count);
         getExtraMoveHandlers()->currentIndex = size;
 
         // DO NOT REMOVE ANY OF THESE! Disable the moves in exl_move_handlers_main() below instead!

--- a/src/mod/features/move_handlers/flame_burst.cpp
+++ b/src/mod/features/move_handlers/flame_burst.cpp
@@ -23,7 +23,7 @@ void HandlerFlameBurstDamageprocEndHitReal(EventFactor::EventHandlerArgs::Object
         auto target = (EventVar::Label)(i + (uint16_t)EventVar::Label::POKEID_TARGET1);
         uint8_t targetPokeID = Common::GetEventVar(args, target);
 
-        auto opponents = (System::Byte_array*)system_array_new(System::Byte_array_TypeInfo(), 5);
+        auto opponents = System::Byte_array::newArray(5);
         uint8_t opponentCount = GetAllOtherOutPokeID(args, targetPokeID, opponents);
         for (int32_t j=0; j<opponentCount; j++)
         {

--- a/src/mod/features/pickup.cpp
+++ b/src/mod/features/pickup.cpp
@@ -30,14 +30,14 @@ HOOK_DEFINE_REPLACE(GetPickupItem) {
         }
 
         int32_t ratioTotal = 0;
-        for (int32_t i=0; i<pickupTable->max_length; i++)
+        for (uint64_t i=0; i<pickupTable->max_length; i++)
         {
             ratioTotal += pickupTable->m_Items[i]->fields.Ratios->m_Items[tableIndex];
         }
 
         int32_t randomRoll = UnityEngine::Random::Range(1, ratioTotal+1);
         int32_t ratio = 0;
-        for (int32_t i=0; i<pickupTable->max_length; i++)
+        for (uint64_t i=0; i<pickupTable->max_length; i++)
         {
             ratio += pickupTable->m_Items[i]->fields.Ratios->m_Items[tableIndex];
             if (randomRoll <= ratio)

--- a/src/mod/features/side_handlers.cpp
+++ b/src/mod/features/side_handlers.cpp
@@ -52,10 +52,9 @@ void SetSideEffectFunctionTable(Handler::Side::GET_FUNC_TABLE_ELEM::Array* getFu
 
 HOOK_DEFINE_INLINE(Side_system_array_new) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto typeInfo = (Il2CppClass*)ctx->X[0];
         uint64_t size = ctx->X[1];
 
-        auto array = (Handler::Side::GET_FUNC_TABLE_ELEM::Array*)system_array_new(typeInfo, size + getExtraSideEffectHandlers()->count);
+        auto array = Handler::Side::GET_FUNC_TABLE_ELEM::newArray(size + getExtraSideEffectHandlers()->count);
         getExtraSideEffectHandlers()->currentIndex = size;
 
         // DO NOT REMOVE ANY OF THESE! Disable the side effects in exl_side_handlers_main() below instead!

--- a/src/mod/save/data/berry/berry.cpp
+++ b/src/mod/save/data/berry/berry.cpp
@@ -39,10 +39,8 @@ void loadBerries(bool isBackup)
 
 void linkBerries(PlayerWork::Object* playerWork)
 {
-    auto kinomiGrowCls = DPData::KinomiGrow_array_TypeInfo();
-
     // Create new array
-    auto newBerries = (DPData::KinomiGrow::Array*) system_array_new(kinomiGrowCls, BerryCount);
+    auto newBerries = DPData::KinomiGrow::newArray(BerryCount);
 
     // Fill the new array with the custom save data
     memcpy(newBerries->m_Items, getCustomSaveData()->berries.items, sizeof(getCustomSaveData()->berries.items));

--- a/src/mod/save/data/box/box.cpp
+++ b/src/mod/save/data/box/box.cpp
@@ -1,7 +1,6 @@
 #include "helpers/fsHelper.h"
 #include "save/save.h"
 
-
 static Dpr::Box::SaveBoxTrayData::Array* cache_boxTray;
 static Dpr::Box::SaveBoxData::_STR17::Array* cache_trayNames;
 static System::Byte_array* cache_wallPapers;
@@ -44,14 +43,10 @@ void loadBoxes(bool isBackup)
 
 void linkBoxes(PlayerWork::Object* playerWork)
 {
-    auto str17Cls = Dpr::Box::SaveBoxData::_STR17_array_TypeInfo();
-    auto saveBoxTrayCls = Dpr::Box::SaveBoxTrayData_array_TypeInfo();
-    auto byteCls = System::Byte_array_TypeInfo();
-
     // Create new array
-    auto newBoxNames = (Dpr::Box::SaveBoxData::_STR17::Array*) system_array_new(str17Cls, BoxCount);
-    auto wallPapers = (System::Byte_array*) system_array_new(byteCls, BoxCount);
-    auto newBoxData = (Dpr::Box::SaveBoxTrayData::Array*) system_array_new(saveBoxTrayCls, BoxCount);
+    auto newBoxNames = Dpr::Box::SaveBoxData::_STR17::newArray(BoxCount);
+    auto wallPapers = System::Byte_array::newArray(BoxCount);
+    auto newBoxData = Dpr::Box::SaveBoxTrayData::newArray(BoxCount);
 
     // Fill the new array with the custom save data
     for (uint64_t i=0; i<BoxCount; i++) {
@@ -71,7 +66,6 @@ void linkBoxes(PlayerWork::Object* playerWork)
     savedata.boxData.fields.trayName = newBoxNames;
     savedata.boxData.fields.wallPaper = wallPapers;
     savedata.boxTray = newBoxData;
-
 }
 
 void unlinkBoxes(PlayerWork::Object* playerWork)

--- a/src/mod/save/data/box/box.h
+++ b/src/mod/save/data/box/box.h
@@ -60,8 +60,7 @@ struct BoxSaveData {
     long FromBytes(char* buffer, long buffer_size, long index) {
         if (buffer_size >= GetByteCount() + index)
         {
-            auto newBoxNames = (Dpr::Box::SaveBoxData::_STR17::Array*)system_array_new(
-                    Dpr::Box::SaveBoxData::_STR17_array_TypeInfo(), size);
+            auto newBoxNames = Dpr::Box::SaveBoxData::_STR17::newArray(size);
 
             for (uint64_t i=0; i<size; i++)
             {
@@ -75,19 +74,15 @@ struct BoxSaveData {
             memcpy(&wallpapers, (void*)(buffer+index), sizeof(System::Byte)*size);
             index += sizeof(System::Byte)*size;
 
-            auto newBoxData = (Dpr::Box::SaveBoxTrayData::Array*)system_array_new(
-                    Dpr::Box::SaveBoxTrayData_array_TypeInfo(), size);
+            auto newBoxData = Dpr::Box::SaveBoxTrayData::newArray(size);
             for (uint64_t i=0; i<newBoxData->max_length; i++)
             {
-                auto newPokeParams = (Pml::PokePara::SerializedPokemonFull::Array*)system_array_new(
-                        Pml::PokePara::SerializedPokemonFull_array_TypeInfo(), 30);
+                auto newPokeParams = Pml::PokePara::SerializedPokemonFull::newArray(30);
                 newBoxData->m_Items[i].fields.pokemonParam = newPokeParams;
                 for (uint64_t j=0; j<newPokeParams->max_length; j++)
                 {
                     void* pokeData = (void*)(buffer+index);
-                    auto pokeByteArray = (System::Byte_array*)system_array_new(
-                            System::Byte_array_TypeInfo(),
-                            Pml::PokePara::SerializedPokemonFull::GetByteCount());
+                    auto pokeByteArray = System::Byte_array::newArray(Pml::PokePara::SerializedPokemonFull::GetByteCount());
                     memcpy(pokeByteArray->m_Items, pokeData, Pml::PokePara::SerializedPokemonFull::GetByteCount());
                     newPokeParams->m_Items[j].fields.buffer = pokeByteArray;
                     newPokeParams->m_Items[j].CreateWorkIfNeed();

--- a/src/mod/save/data/dex/dex.cpp
+++ b/src/mod/save/data/dex/dex.cpp
@@ -49,15 +49,13 @@ void loadZukan(bool isBackup)
 
 void linkZukan(PlayerWork::Object* playerWork)
 {
-    auto boolCls = System::Boolean_array_TypeInfo();
-
     // Create new arrays
-    auto newStatus = (DPData::GET_STATUS_array*)system_array_new(DPData::GET_STATUS_array_TypeInfo(), DexSize);
-    auto newMaleColorFlag = (System::Boolean_array*)system_array_new(boolCls, DexSize);
-    auto newFemaleColorFlag = (System::Boolean_array*)system_array_new(boolCls, DexSize);
-    auto newMaleFlag = (System::Boolean_array*)system_array_new(boolCls, DexSize);
-    auto newFemaleFlag = (System::Boolean_array*)system_array_new(boolCls, DexSize);
-    auto newLanguageFlags = (System::Int32_array*)system_array_new(System::Int32_array_TypeInfo(), DexSize);
+    auto newStatus = DPData::GET_STATUS_array::newArray(DexSize);
+    auto newMaleColorFlag = System::Boolean_array::newArray(DexSize);
+    auto newFemaleColorFlag = System::Boolean_array::newArray(DexSize);
+    auto newMaleFlag = System::Boolean_array::newArray(DexSize);
+    auto newFemaleFlag = System::Boolean_array::newArray(DexSize);
+    auto newLanguageFlags = System::Int32_array::newArray(DexSize);
 
     // Fill the new arrays with the custom save data
     for (uint64_t i=0; i<DexSize; i++)

--- a/src/mod/save/data/flag/flag.cpp
+++ b/src/mod/save/data/flag/flag.cpp
@@ -39,10 +39,8 @@ void loadFlags(bool isBackup)
 
 void linkFlags(PlayerWork::Object* playerWork)
 {
-    auto boolCls = System::Boolean_array_TypeInfo();
-
     // Create new array
-    auto newFlags = (System::Boolean_array*) system_array_new(boolCls, FlagCount);
+    auto newFlags = System::Boolean_array::newArray(FlagCount);
 
     // Fill the new array with the custom save data
     memcpy(newFlags->m_Items, getCustomSaveData()->flags.items, sizeof(getCustomSaveData()->flags.items));

--- a/src/mod/save/data/item/item.cpp
+++ b/src/mod/save/data/item/item.cpp
@@ -39,10 +39,8 @@ void loadItems(bool isBackup)
 
 void linkItems(PlayerWork::Object* playerWork)
 {
-    auto saveItemCls = Dpr::Item::SaveItem_array_TypeInfo();
-
     // Create new array
-    auto newItems = (Dpr::Item::SaveItem::Array*) system_array_new(saveItemCls, SaveItemCount);
+    auto newItems = Dpr::Item::SaveItem::newArray(SaveItemCount);
 
     // Fill the new array with the custom save data
     memcpy(newItems->m_Items, getCustomSaveData()->items.items, sizeof(getCustomSaveData()->items.items));

--- a/src/mod/save/data/string/string.h
+++ b/src/mod/save/data/string/string.h
@@ -30,7 +30,7 @@ struct StringSaveData {
     long FromBytes(char* buffer, long buffer_size, long index) {
         if (buffer_size >= GetByteCount() + index)
         {
-            auto newStrings = (Dpr::Box::SaveBoxData::_STR17::Array*)system_array_new(Dpr::Box::SaveBoxData::_STR17_array_TypeInfo(), size);
+            auto newStrings = Dpr::Box::SaveBoxData::_STR17::newArray(size);
             for (uint64_t i=0; i<newStrings->max_length; i++)
             {
                 void* strData = (void*)(buffer+index);

--- a/src/mod/save/data/sysflag/sysflag.cpp
+++ b/src/mod/save/data/sysflag/sysflag.cpp
@@ -39,10 +39,8 @@ void loadSysFlags(bool isBackup)
 
 void linkSysFlags(PlayerWork::Object* playerWork)
 {
-    auto boolCls = System::Boolean_array_TypeInfo();
-
     // Create new array
-    auto newSysFlags = (System::Boolean_array*) system_array_new(boolCls, SysFlagCount);
+    auto newSysFlags = System::Boolean_array::newArray(SysFlagCount);
 
     // Fill the new array with the custom save data
     memcpy(newSysFlags->m_Items, getCustomSaveData()->sysflags.items, sizeof(getCustomSaveData()->sysflags.items));

--- a/src/mod/save/data/trainer/trainer.cpp
+++ b/src/mod/save/data/trainer/trainer.cpp
@@ -39,10 +39,8 @@ void loadTrainers(bool isBackup)
 
 void linkTrainers(PlayerWork::Object* playerWork)
 {
-    auto trainerCls = DPData::TR_BATTLE_DATA_array_TypeInfo();
-
     // Create new array
-    auto newTrainers = (DPData::TR_BATTLE_DATA::Array*) system_array_new(trainerCls, TrainerCount);
+    auto newTrainers = DPData::TR_BATTLE_DATA::newArray(TrainerCount);
 
     // Fill the new array with the custom save data
     memcpy(newTrainers->m_Items, getCustomSaveData()->trainers.items, sizeof(getCustomSaveData()->trainers.items));

--- a/src/mod/save/data/work/work.cpp
+++ b/src/mod/save/data/work/work.cpp
@@ -39,10 +39,8 @@ void loadWorks(bool isBackup)
 
 void linkWorks(PlayerWork::Object* playerWork)
 {
-    auto int32Cls = System::Int32_array_TypeInfo();
-
     // Create new array
-    auto newWorks = (System::Int32_array*) system_array_new(int32Cls, WorkCount);
+    auto newWorks = System::Int32_array::newArray(WorkCount);
 
     // Fill the new array with the custom save data
     memcpy(newWorks->m_Items, getCustomSaveData()->works.items, sizeof(getCustomSaveData()->works.items));

--- a/src/mod/save/migration/vanilla_1.cpp
+++ b/src/mod/save/migration/vanilla_1.cpp
@@ -27,9 +27,6 @@ void migrateFromVanilla(PlayerWork::Object* playerWork) {
         save->dex.elements[i].female_flag = zukan.female_flag->m_Items[i];
     }
 
-    auto spfCls = Pml::PokePara::SerializedPokemonFull_array_TypeInfo();
-
-
     savedata.boxData.fields.trayName->copyInto(save->boxes.boxNames);
     savedata.boxData.fields.wallPaper->copyInto(save->boxes.wallpapers);
     savedata.boxTray->copyInto(save->boxes.pokemonParams);
@@ -45,7 +42,7 @@ void migrateFromVanilla(PlayerWork::Object* playerWork) {
     // Initializes boxes 41-80, 1-40 are copied directly from Vanilla.
     for (uint64_t i=VANILLA_BOXSIZE; i < BoxCount; i++) {
         save->boxes.wallpapers[i] = save->boxes.wallpapers[i-VANILLA_BOXSIZE+INIT_WALLPAPER_OFFSET]; // Follows exact pattern of Vanilla 1-40
-        auto serializedPokemon = (Pml::PokePara::SerializedPokemonFull::Array*) system_array_new(spfCls, 30);
+        auto serializedPokemon = Pml::PokePara::SerializedPokemonFull::newArray(30);
         save->boxes.pokemonParams[i].fields.pokemonParam = serializedPokemon;
         for (uint64_t j=0; j < serializedPokemon->max_length; j++) {
             serializedPokemon->m_Items[j].CreateWorkIfNeed();

--- a/src/mod/ui/tools/poffin_tool.h
+++ b/src/mod/ui/tools/poffin_tool.h
@@ -67,7 +67,7 @@ namespace ui {
                         DPData::PoffinSaveData::Object poffinSaveData = PlayerWork::get_poffinSaveData();
                         DPData::PoffinData::Object newPoffin = {};
 
-                        auto flavors = (System::Byte_array*) system_array_new(System::Byte_array_TypeInfo(), 5);
+                        auto flavors = System::Byte_array::newArray(5);
                         flavors->m_Items[0] = (uint8_t)spicyValue->value;
                         flavors->m_Items[1] = (uint8_t)dryValue->value;
                         flavors->m_Items[2] = (uint8_t)sweetValue->value;


### PR DESCRIPTION
Overhauls arrays to make them easier to work with.

- Adds a TypeInfo argument to the PRIMITIVE_ARRAY macro.
  - This allows the inclusion of a getClass() method and a newArray() method to avoid having to deal with using system_array_new.
- Adds an ArrayTypeInfo argument to the ILStruct template.
  - This allows the inclusion of a getArrayClass() method and a newArray() method to avoid having to deal with using system_array_new.
- Replaces all instances of system_array_new in code outside of il2cpp-api.h with the newArray() method.