### PR TITLE
Port - Local Trades Extension

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -42,6 +42,7 @@ static constexpr const char* FEATURES[] = {
     "Visible Shiny Eggs",
     "Contest NPC Forms",
     "Re:Lumi Pokédex UI",
+    "Local Trades Extension",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/Dpr/Message/MessageManager.h
+++ b/src/mod/externals/Dpr/Message/MessageManager.h
@@ -18,7 +18,7 @@ namespace Dpr::Message {
             return SmartPoint::AssetAssistant::SingletonMonoBehaviour::get_Instance(SmartPoint::AssetAssistant::SingletonMonoBehaviour::Method$$MessageManager$$get_Instance);
         }
 
-        inline System::String::Object * GetSimpleMessage(System::String::Object *fileName,System::String::Object *label) {
+        inline System::String::Object* GetSimpleMessage(System::String::Object* fileName, System::String::Object* label) {
             return external<System::String::Object *>(0x0210d000, this, fileName, label);
         }
 
@@ -28,6 +28,10 @@ namespace Dpr::Message {
 
         inline int32_t get_UserLanguageID() {
             return external<int32_t>(0x0210a0a0, this);
+        }
+
+        inline System::String::Object* GetNameMessage(System::String::Object* fileName, System::String::Object* label) {
+            return external<System::String::Object*>(0x0210ce50, this, fileName, label);
         }
     };
 }

--- a/src/mod/externals/GameData/DataManager.h
+++ b/src/mod/externals/GameData/DataManager.h
@@ -4,9 +4,10 @@
 
 #include "externals/Pml/Sex.h"
 #include "externals/XLSXContent/CharacterDressData.h"
+#include "externals/XLSXContent/LocalKoukanData.h"
+#include "externals/XLSXContent/MonohiroiTable.h"
 #include "externals/XLSXContent/PokemonInfo.h"
 #include "externals/XLSXContent/ShopTable.h"
-#include "externals/XLSXContent/MonohiroiTable.h"
 
 namespace GameData {
     struct DataManager : ILClass<DataManager, 0x04c59d70> {
@@ -34,7 +35,7 @@ namespace GameData {
             void* AdventureNoteDataDict; //System::Collections::Generic::Dictionary$$int$$List_AdventureNoteData_SheetData::Object*
             void* TowerBattlePoint;
             void* TagPlaceData;
-            void* LocalKoukanData;
+            XLSXContent::LocalKoukanData::Object* LocalKoukanData;
             void* ContestCommonData;
             void* TvDataTable;
             void* TvSchedule;

--- a/src/mod/externals/LocalKoukan.h
+++ b/src/mod/externals/LocalKoukan.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Message/MessageEnumData.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/XLSXContent/LocalKoukanData.h"
+
+struct LocalKoukan : ILClass<LocalKoukan> {
+    struct Operation : ILClass<Operation, 0x04c643b0> {
+        struct Fields {
+            bool IsTemotiMode;
+            int32_t TrayNo;
+            int32_t Pos;
+            Pml::PokePara::PokemonParam::Object* from;
+            Pml::PokePara::PokemonParam::Object* other;
+        };
+
+        inline void ctor() {
+            external<void>(0x01af3940, this);
+        }
+    };
+
+    struct Fields {};
+
+    inline static XLSXContent::LocalKoukanData::Sheetdata::Object* GetTargetData(int32_t npcindex, Dpr::Message::MessageEnumData::MsgLangId lang) {
+        return external<XLSXContent::LocalKoukanData::Sheetdata::Object*>(0x01af32a0, npcindex, lang);
+    }
+};

--- a/src/mod/externals/PlayerWork.h
+++ b/src/mod/externals/PlayerWork.h
@@ -39,6 +39,7 @@
 #include "externals/Dpr/Box/SaveBoxTrayData.h"
 #include "externals/Dpr/Item/ItemInfo.h"
 #include "externals/Dpr/Item/SaveItem.h"
+#include "externals/Dpr/Message/MessageEnumData.h"
 #include "externals/MT_DATA.h"
 #include "externals/PLAYREPORT_DATA.h"
 #include "externals/Pml/PokePara/SavePokeParty.h"
@@ -298,5 +299,9 @@ struct PlayerWork : ILClass<PlayerWork, 0x04c59b58> {
 
     static inline Dpr::Box::SaveBoxData::Object* GetBoxData() {
         return external<Dpr::Box::SaveBoxData::Object*>(0x02cf0180);
+    }
+
+    static inline Dpr::Message::MessageEnumData::MsgLangId get_msgLangID() {
+        return external<Dpr::Message::MessageEnumData::MsgLangId>(0x02ce2c20);
     }
 };

--- a/src/mod/externals/Pml/PokePara/Condition.h
+++ b/src/mod/externals/Pml/PokePara/Condition.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Pml::PokePara {
+    enum class Condition : int32_t {
+        STYLE = 0,
+        BEAUTIFUL = 1,
+        CUTE = 2,
+        CLEVER = 3,
+        STRONG = 4,
+        FUR = 5,
+    };
+}

--- a/src/mod/externals/Pml/PokePara/CoreParam.h
+++ b/src/mod/externals/Pml/PokePara/CoreParam.h
@@ -3,7 +3,10 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/Pml/PokePara/Accessor.h"
+#include "externals/Pml/PokePara/Condition.h"
 #include "externals/Pml/PokePara/EggCheckType.h"
+#include "externals/Pml/PokePara/OwnerInfo.h"
+#include "externals/Pml/PokePara/PowerID.h"
 #include "externals/Pml/WazaNo.h"
 
 namespace Pml::PokePara {
@@ -180,6 +183,34 @@ namespace Pml::PokePara {
 
         inline uint8_t GetRareType() {
             return external<uint8_t>(0x0204a5a0, this);
+        }
+
+        inline void ChangeEffortPower(Pml::PokePara::PowerID powerId, uint32_t value) {
+            external<void>(0x02044da0, this, powerId, value);
+        }
+
+        inline void SetParentName(System::String::Object* name) {
+            external<void>(0x0204ac00, this, name);
+        }
+
+        inline void SetLangId(uint32_t langId) {
+            external<void>(0x02049650, this, langId);
+        }
+
+        inline void SetCondition(Pml::PokePara::Condition cond, uint8_t value) {
+            external<void>(0x0204b040, this, cond, value);
+        }
+
+        inline bool UpdateOwnerInfo(Pml::PokePara::OwnerInfo::Object* ownerInfo) {
+            return external<bool>(0x02048c90, this, ownerInfo);
+        }
+
+        inline bool StartFastMode() {
+            return external<bool>(0x0204c910, this);
+        }
+
+        inline bool EndFastMode(bool validFlag) {
+            return external<bool>(0x0204c960, this, validFlag);
         }
     };
 }

--- a/src/mod/externals/Pml/PokePara/OwnerInfo.h
+++ b/src/mod/externals/Pml/PokePara/OwnerInfo.h
@@ -2,15 +2,20 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/DPData/MYSTATUS.h"
 #include "externals/System/String.h"
 
 namespace Pml::PokePara {
-    struct OwnerInfo : ILClass<OwnerInfo> {
+    struct OwnerInfo : ILClass<OwnerInfo, 0x04c5fbe8> {
         struct Fields {
             uint32_t trainerId;
             uint8_t sex;
             uint8_t langID;
             System::String::Object* name;
         };
+
+        inline void ctor(DPData::MYSTATUS::Object* ownerStatus) {
+            external<void>(0x02054ea0, this, ownerStatus);
+        }
     };
 }

--- a/src/mod/externals/XLSXContent/LocalKoukanData.h
+++ b/src/mod/externals/XLSXContent/LocalKoukanData.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Pml/WazaNo.h"
+#include "externals/UnityEngine/ScriptableObject.h"
+
+namespace XLSXContent {
+    struct LocalKoukanData : ILClass<LocalKoukanData, 0x04c63f80> {
+        struct Sheetdata : ILClass<Sheetdata> {
+            struct Fields {
+                int32_t target;
+                System::String::Object* name_label;
+                int32_t trainerid;
+                int32_t monsno;
+                System::String::Object* nickname_label;
+                int32_t level;
+                int32_t seikaku;
+                int32_t tokusei;
+                uint16_t itemno;
+                int32_t rand;
+                uint8_t sex;
+                int32_t language;
+                Pml_WazaNo_array* waza;
+            };
+        };
+
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            XLSXContent::LocalKoukanData::Sheetdata::Array* data;
+        };
+
+        inline XLSXContent::LocalKoukanData::Sheetdata::Object* get_Item(int32_t index) {
+            return external<XLSXContent::LocalKoukanData::Sheetdata::Object*>(0x017d5670, this, index);
+        }
+    };
+}

--- a/src/mod/externals/poketool/poke_memo/DataType.h
+++ b/src/mod/externals/poketool/poke_memo/DataType.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace poketool::poke_memo {
+    enum DataType : int32_t {
+        DATA_TYPE_EGG_TAKEN = 0,
+        DATA_TYPE_FIRST_CONTACT = 1,
+    };
+}

--- a/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
+++ b/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
@@ -4,6 +4,7 @@
 
 #include "externals/DPData/MYSTATUS.h"
 #include "externals/Pml/PokePara/CoreParam.h"
+#include "externals/poketool/poke_memo/DataType.h"
 
 namespace poketool::poke_memo {
     struct poketool_poke_memo : ILClass<poketool_poke_memo> {
@@ -13,6 +14,22 @@ namespace poketool::poke_memo {
 
         static inline void SetFromCapture(Pml::PokePara::CoreParam::Object* pParam, DPData::MYSTATUS::Object* pMystatus, uint32_t placeNo) {
             external<void>(0x02bacb10, pParam, pMystatus, placeNo);
+        }
+
+        static inline void ClearPlaceTime(Pml::PokePara::CoreParam::Object* pParam, poketool::poke_memo::DataType type) {
+            external<void>(0x02bacca0, pParam, type);
+        }
+
+        static inline void SetPlaceTime(Pml::PokePara::CoreParam::Object* pParam, uint32_t placeNo, poketool::poke_memo::DataType dataType) {
+            external<void>(0x02baccc0, pParam, placeNo, dataType);
+        }
+
+        static inline void SetGetLevel(Pml::PokePara::CoreParam::Object* pParam) {
+            external<void>(0x02bace70, pParam);
+        }
+
+        static inline void SetVersion(Pml::PokePara::CoreParam::Object* pParam) {
+            external<void>(0x02baceb0, pParam);
         }
     };
 }

--- a/src/mod/externals/poketool/pokeplace/PlaceNo.h
+++ b/src/mod/externals/poketool/pokeplace/PlaceNo.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace poketool::pokeplace {
+    enum PlaceNo : int32_t {
+        START_NORMAL = 0,
+        START_SPECIAL = 30001,
+        START_OUTER = 40001,
+        START_PERSON = 60001,
+        END = 65535,
+        PERSON_SODATEYA = 60010,
+        SPECIAL_INNER_TRADE = 30001,
+        SPECIAL_OUTER_TRADE = 30002,
+    };
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -86,6 +86,9 @@ void exl_language_select_main();
 // Adds the Level Cap functionality.
 void exl_level_cap_main();
 
+// Uniformizes local trades across languages and allows extending the table in RomFS.
+void exl_local_trades_main();
+
 // Adds audio feedback when "bonking" into NPCs.
 void exl_npc_collision_audio_main();
 

--- a/src/mod/features/local_trades_extension.cpp
+++ b/src/mod/features/local_trades_extension.cpp
@@ -1,0 +1,150 @@
+#include "exlaunch.hpp"
+
+#include "data/balls.h"
+#include "data/utils.h"
+
+#include "externals/Dpr/Message/MessageEnumData.h"
+#include "externals/Dpr/Message/MessageManager.h"
+#include "externals/GameData/DataManager.h"
+#include "externals/LocalKoukan.h"
+#include "externals/PlayerWork.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/Pml/PokePara/PowerID.h"
+#include "externals/poketool/poke_memo/poketool_poke_memo.h"
+#include "externals/poketool/pokeplace/PlaceNo.h"
+#include "externals/XLSXContent/LocalKoukanData.h"
+#include "romdata/romdata.h"
+
+Dpr::Message::MessageEnumData::MsgLangId GetUniformLanguage(Dpr::Message::MessageEnumData::MsgLangId langId)
+{
+    auto playerLangId = PlayerWork::get_msgLangID();
+
+    if ((int32_t)langId == 0) // No language, so set to same language as player.
+        return playerLangId;
+    else if (langId != playerLangId) // Foreign trade, so set to the trade's language.
+        return langId;
+    else if (langId != Dpr::Message::MessageEnumData::MsgLangId::USA) // Foreign trade that matches player, so set to English.
+        return Dpr::Message::MessageEnumData::MsgLangId::USA;
+    else // Foreign trade that matches player and is English, so set to Japanese.
+        return Dpr::Message::MessageEnumData::MsgLangId::JPN;
+}
+
+Pml::PokePara::PokemonParam::Object* CreateTradePokeParam(int32_t npcindex, Dpr::Message::MessageEnumData::MsgLangId lang)
+{
+    auto data = LocalKoukan::GetTargetData(npcindex, lang);
+    auto extraData = GetExtraLocalTradeData(npcindex);
+
+    system_load_typeinfo(0x5e90);
+
+    auto spec = Pml::PokePara::InitialSpec::newInstance();
+
+    int32_t formNo =      (data->fields.monsno & 0xFFFF0000) >> 16;  // Bits 16-31
+    int32_t monsNo =       data->fields.monsno & 0x0000FFFF;         // Bits 0-15
+
+    spec->fields.monsno = monsNo;
+    spec->fields.formno = formNo;
+    spec->fields.level = (uint16_t)data->fields.level;
+    spec->fields.rareRnd = extraData.forceShiny ? 0x2FFFFFFFF : 0x3FFFFFFFF;
+    spec->fields.id = (uint64_t)data->fields.trainerid;
+    spec->fields.sex = (uint16_t)data->fields.sex;
+    spec->fields.seikaku = (uint16_t)data->fields.seikaku;
+    spec->fields.tokuseiIndex = (uint8_t)data->fields.tokusei;
+    spec->fields.personalRnd = (uint64_t)data->fields.rand;
+    spec->fields.randomSeed = (uint64_t)data->fields.rand;
+    spec->fields.isRandomSeedEnable = true;
+
+    if (!extraData.ivs.empty())
+    {
+        for (uint64_t i=0; i<spec->fields.talentPower->max_length; i++)
+            spec->fields.talentPower->m_Items[i] = extraData.ivs[i];
+    }
+
+    auto pokeParam = Pml::PokePara::PokemonParam::newInstance(spec);
+    auto coreParam = (Pml::PokePara::CoreParam::Object*)pokeParam;
+
+    auto messageManager = Dpr::Message::MessageManager::instance();
+
+    coreParam->SetNickName(messageManager->GetNameMessage(System::String::Create("dp_scenario3"), data->fields.nickname_label));
+    coreParam->SetParentName(messageManager->GetNameMessage(System::String::Create("dp_scenario3"), data->fields.name_label));
+    coreParam->SetItem(data->fields.itemno);
+    coreParam->SetLangId((uint32_t)GetUniformLanguage((Dpr::Message::MessageEnumData::MsgLangId)data->fields.language));
+    coreParam->SetGetBall(extraData.ballId == array_index(BALLS, "--BALL ZERO--") ? array_index(BALLS, "Poké Ball") : extraData.ballId);
+    coreParam->UpdateOwnerInfo(Pml::PokePara::OwnerInfo::newInstance(PlayerWork::get_playerStatus()));
+
+    if (!extraData.evs.empty())
+    {
+        for (int32_t i=0; i<6; i++)
+            coreParam->ChangeEffortPower((Pml::PokePara::PowerID)i, extraData.evs[i]);
+    }
+
+    if (!extraData.contestStats.empty())
+    {
+        for (int32_t i=0; i<5; i++)
+            coreParam->SetCondition((Pml::PokePara::Condition)i, extraData.evs[i]);
+
+        if (extraData.contestStats.size() >= 6)
+            coreParam->SetCondition(Pml::PokePara::Condition::FUR, extraData.evs[5]);
+    }
+
+    for (int32_t i=0; i<data->fields.waza->max_length && i<4; i++)
+        coreParam->SetWaza(i, data->fields.waza->m_Items[i]);
+
+    poketool::poke_memo::poketool_poke_memo::ClearPlaceTime(coreParam, poketool::poke_memo::DATA_TYPE_EGG_TAKEN);
+    poketool::poke_memo::poketool_poke_memo::SetPlaceTime(coreParam, poketool::pokeplace::PlaceNo::SPECIAL_INNER_TRADE, poketool::poke_memo::DATA_TYPE_FIRST_CONTACT);
+    poketool::poke_memo::poketool_poke_memo::SetGetLevel(coreParam);
+    poketool::poke_memo::poketool_poke_memo::SetVersion(coreParam);
+
+    coreParam->EndFastMode(coreParam->StartFastMode());
+
+    return pokeParam;
+}
+
+HOOK_DEFINE_REPLACE(LocalKoukan_GetIndex) {
+    static int32_t Callback(int32_t npcindex, Dpr::Message::MessageEnumData::MsgLangId lang) {
+        return npcindex;
+    }
+};
+
+HOOK_DEFINE_REPLACE(LocalKoukan_GetTargetData) {
+    static XLSXContent::LocalKoukanData::Sheetdata::Object* Callback(int32_t npcindex, Dpr::Message::MessageEnumData::MsgLangId lang) {
+        system_load_typeinfo(0x5e91);
+        GameData::DataManager::getClass()->initIfNeeded();
+        auto result = GameData::DataManager::getClass()->static_fields->LocalKoukanData->get_Item(npcindex);
+        return result;
+    }
+};
+
+HOOK_DEFINE_REPLACE(LocalKoukan_CreateOperation) {
+    static LocalKoukan::Operation::Object* Callback(Pml::PokePara::PokemonParam::Object* myparam, int32_t npcindex,
+            Dpr::Message::MessageEnumData::MsgLangId lang, bool istemoti, int32_t trayno, int32_t pos) {
+        auto data = LocalKoukan::GetTargetData(npcindex, lang);
+
+        int32_t targetFormNo =      (data->fields.target & 0xFFFF0000) >> 16;  // Bits 16-31
+        int32_t targetMonsNo =       data->fields.target & 0x0000FFFF;         // Bits 0-15
+
+        // Not the trade target monsno
+        if (targetMonsNo != ((Pml::PokePara::CoreParam::Object*)myparam)->GetMonsNo())
+            return nullptr;
+
+        // Not the trade target formno (removed the check for now)
+        /*if (targetFormNo != ((Pml::PokePara::CoreParam::Object*)myparam)->GetFormNo())
+            return nullptr;*/
+
+        system_load_typeinfo(0x5e8f);
+
+        auto operation =  LocalKoukan::Operation::newInstance();
+        operation->fields.from = myparam;
+        operation->fields.other = CreateTradePokeParam(npcindex, lang);
+        operation->fields.IsTemotiMode = istemoti;
+        operation->fields.TrayNo = trayno;
+        operation->fields.Pos = pos;
+
+        return operation;
+    }
+};
+
+void exl_local_trades_main() {
+    LocalKoukan_GetIndex::InstallAtOffset(0x01af3390);
+    LocalKoukan_GetTargetData::InstallAtOffset(0x01af32a0);
+    LocalKoukan_CreateOperation::InstallAtOffset(0x01af3420);
+}

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -88,6 +88,8 @@ void CallFeatureHooks()
         exl_contest_npc_forms_main();
     if (IsActivatedFeature(array_index(FEATURES, "Re:Lumi Pokédex UI")))
         exl_relumi_dex_ui();
+    if (IsActivatedFeature(array_index(FEATURES, "Local Trades Extension")))
+        exl_local_trades_main();
 
     exl_debug_features_main();
     exl_items_changes_main();
@@ -146,6 +148,7 @@ void exl_features_main() {
     SetActivatedFeature(array_index(FEATURES, "Wild Held Item Rates"));
     SetActivatedFeature(array_index(FEATURES, "Contest NPC Forms"));
     SetActivatedFeature(array_index(FEATURES, "Re:Lumi Pokédex UI"));
+    SetActivatedFeature(array_index(FEATURES, "Local Trades Extension"));
 
     SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Battle Bundles in UI"));
     SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Boutique Models"));

--- a/src/mod/romdata/data/LocalTrade.h
+++ b/src/mod/romdata/data/LocalTrade.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+#include "memory/json.h"
+#include "memory/vector.h"
+
+namespace RomData
+{
+    struct LocalTrade
+    {
+        nn::vector<uint16_t> ivs;
+        nn::vector<uint32_t> evs;
+        nn::vector<uint8_t> contestStats;
+        uint32_t ballId;
+        bool forceShiny;
+    };
+
+    JSON_TEMPLATE
+    void to_json(GENERIC_JSON& j, const LocalTrade& t) {
+        j = nn::json {
+            {"ivs", t.ivs},
+            {"evs", t.evs},
+            {"contestStats", t.contestStats},
+            {"ballId", t.ballId},
+            {"forceShiny", t.forceShiny},
+        };
+    }
+
+    JSON_TEMPLATE
+    void from_json(const GENERIC_JSON& j, LocalTrade& t) {
+        j.at("ivs").get_to(t.ivs);
+        j.at("evs").get_to(t.evs);
+        j.at("contestStats").get_to(t.contestStats);
+        j.at("ballId").get_to(t.ballId);
+        j.at("forceShiny").get_to(t.forceShiny);
+    }
+}

--- a/src/mod/romdata/local_trades.cpp
+++ b/src/mod/romdata/local_trades.cpp
@@ -1,0 +1,62 @@
+#include "exlaunch.hpp"
+
+#include "helpers.h"
+#include "memory/json.h"
+#include "memory/string.h"
+
+#include "romdata/data/LocalTrade.h"
+
+#include "logger/logger.h"
+
+const char* localTradeFolderPath = "rom:/Data/ExtraData/LocalTrades/";
+
+void LogLocalTradeData(const RomData::LocalTrade& t)
+{
+    Logger::log("CURRENT LOCAL TRADE\n");
+
+    Logger::log("IVs: ");
+    for (int i=0; i<t.ivs.size(); i++)
+        Logger::log("%d ", t.ivs[i]);
+    Logger::log("\n");
+
+    Logger::log("EVs: ");
+    for (int i=0; i<t.evs.size(); i++)
+        Logger::log("%d ", t.evs[i]);
+    Logger::log("\n");
+
+    Logger::log("Contest Stats: ");
+    for (int i=0; i<t.contestStats.size(); i++)
+        Logger::log("%d ", t.contestStats[i]);
+    Logger::log("\n");
+
+    Logger::log("Ball ID: %d\nForced Shiny: %d\n", t.ballId, t.forceShiny);
+}
+
+RomData::LocalTrade GetExtraLocalTradeData(int32_t tradeId)
+{
+    nn::string filePath(localTradeFolderPath);
+    filePath.append("trade_" + nn::to_string(tradeId) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::LocalTrade tradeData = {};
+        tradeData = j.get<RomData::LocalTrade>();
+        LogLocalTradeData(tradeData);
+
+        return tradeData;
+    }
+    else
+    {
+        Logger::log("Error when parsing Local Trade data!\n");
+    }
+
+    // Default: Random IVs, 0 EVs, 0 Contest Stats, Poké Ball, Not Forced Shiny
+    return {
+        .ivs = {},
+        .evs = {},
+        .contestStats = {},
+        .ballId = 0,
+        .forceShiny = false,
+    };
+}

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -5,6 +5,7 @@
 #include "romdata/data/FormHeldItemMon.h"
 #include "romdata/data/HoneyTreeEncounters.h"
 #include "romdata/data/IntroData.h"
+#include "romdata/data/LocalTrade.h"
 #include "romdata/data/ShinyRates.h"
 #include "romdata/data/Starter.h"
 #include "romdata/data/TMLearnset.h"
@@ -57,3 +58,6 @@ nn::vector<int32_t> GetIntroColorVariationPresets();
 
 // Returns the extra arena data.
 RomData::Arena GetExtraArenaData(int32_t arena);
+
+// Returns the extra local trade data.
+RomData::LocalTrade GetExtraLocalTradeData(int32_t tradeId);


### PR DESCRIPTION
Closes #16.

- Ports the Local Trades Extension patch from Starlight.
- Moved the extra data that was packed in ability and nature fields to extra JSON data in ExtraData/LocalTrades/trade_x.json.