### PR TITLE
Restore Field Waza Functionality

### DIFF
--- a/src/mod/features/pla_context_menu.cpp
+++ b/src/mod/features/pla_context_menu.cpp
@@ -197,6 +197,9 @@ HOOK_DEFINE_INLINE(ContextMenuAction) {
             default:
                 break;
         }
+
+        //Allow Field Waza to perform its original checks
+        ctx->W[9] = contextMenuId - 35; // sub w9, w9, #0x23
     }
 };
 


### PR DESCRIPTION
**Bug Fix: Field Waza Functionality 🔨**
-
- Closes #105 
- Restores the instruction that was overwritten by the inline hook at 0x019fbf7c (`sub w9, w9, #0x23`)