### PR TITLE
Feature: JSON-ify Feature Selection

### DIFF
--- a/include/nn/fs/fs_mount.hpp
+++ b/include/nn/fs/fs_mount.hpp
@@ -10,6 +10,9 @@ namespace nn::fs {
     */
     Result MountSdCardForDebug(char const* mount);
 
-    void QueryMountRomCacheSize(uint64_t* out);
-    void MountRom(char const* mount, void* cache, uint64_t cache_size);
+    Result QueryMountRomCacheSize(size_t* out);
+
+    Result MountRom(char const* mount, void* cache, size_t cache_size);
+
+    void Unmount(char const* mount);
 };

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -3,6 +3,10 @@
 
 #include "features/activated_features.h"
 #include "features/features.h"
+#include "romdata/romdata.h"
+#include "helpers/fsHelper.h"
+#include "nn/fs/fs_mount.hpp"
+#include "nn/err.h"
 
 void CallFeatureHooks()
 {
@@ -99,6 +103,37 @@ void CallFeatureHooks()
     exl_battle_features_main();
 }
 
+void MountRomAndReadJSON() {
+    size_t cacheSize = 0;
+    Result result = nn::fs::QueryMountRomCacheSize(&cacheSize);
+    if (R_FAILED(result) || cacheSize == 0) {
+        Logger::log("Failed to query ROM cache size or size is zero.\n");
+        return;
+    }
+
+    void* pFileSystemCacheBuffer = nn_malloc(cacheSize);
+    if (pFileSystemCacheBuffer == nullptr) {
+        Logger::log("Failed to allocate memory for the file system cache buffer.\n");
+        return;
+    }
+
+    const char* mountName = "rom";
+    result = nn::fs::MountRom(mountName, pFileSystemCacheBuffer, cacheSize);
+    if (R_FAILED(result)) {
+        Logger::log("Failed to mount ROM.\n");
+        nn_free(pFileSystemCacheBuffer);  // Free the buffer if the mount fails
+        return;
+    }
+
+    nn::string filePath("rom:/Data/ExtraData/Features/features.json");
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded()) {
+        LoadFeaturesFromJSON(j);
+    }
+    nn::fs::Unmount(mountName);
+    nn_free(pFileSystemCacheBuffer); // Free buffer after use
+}
+
 void exl_features_main() {
     // First disables all features
     DisableFeatures();
@@ -109,75 +144,7 @@ void exl_features_main() {
     DisableSmallPatchFeatures();
     DisableBattleFeatures();
 
-    // Select which new features are activated
-    SetActivatedFeature(array_index(FEATURES, "Ability Changes"));
-    SetActivatedFeature(array_index(FEATURES, "Alt Starters"));
-    SetActivatedFeature(array_index(FEATURES, "Area/Zone Codes"));
-    SetActivatedFeature(array_index(FEATURES, "Badge Check"));
-    SetActivatedFeature(array_index(FEATURES, "New Poké Balls"));
-    SetActivatedFeature(array_index(FEATURES, "Battle Escape Flag"));
-    SetActivatedFeature(array_index(FEATURES, "Battle Camera Fix"));
-    SetActivatedFeature(array_index(FEATURES, "Color Variations"));
-    SetActivatedFeature(array_index(FEATURES, "Commands"));
-    SetActivatedFeature(array_index(FEATURES, "Encounter Slots"));
-    SetActivatedFeature(array_index(FEATURES, "EV/IV in Summary"));
-    SetActivatedFeature(array_index(FEATURES, "Evolution Methods"));
-    SetActivatedFeature(array_index(FEATURES, "Extended TM Learnsets"));
-    SetActivatedFeature(array_index(FEATURES, "Form Change Held Items"));
-    SetActivatedFeature(array_index(FEATURES, "Gender Neutral Boutique"));
-    SetActivatedFeature(array_index(FEATURES, "Hidden Power UI"));
-    SetActivatedFeature(array_index(FEATURES, "Language Select"));
-    SetActivatedFeature(array_index(FEATURES, "Level Cap"));
-    SetActivatedFeature(array_index(FEATURES, "NPC Collision Audio"));
-    SetActivatedFeature(array_index(FEATURES, "Uniform UI"));
-    SetActivatedFeature(array_index(FEATURES, "Party Context Menu"));
-    SetActivatedFeature(array_index(FEATURES, "Pickup Changes"));
-    SetActivatedFeature(array_index(FEATURES, "Poké Radar Fixes"));
-    SetActivatedFeature(array_index(FEATURES, "Trainer Double Battle"));
-    SetActivatedFeature(array_index(FEATURES, "Two-Button Pokétch"));
-    SetActivatedFeature(array_index(FEATURES, "Relearn TMs"));
-    SetActivatedFeature(array_index(FEATURES, "New Settings"));
-    SetActivatedFeature(array_index(FEATURES, "Shiny Rates"));
-    SetActivatedFeature(array_index(FEATURES, "Static Held Items"));
-    SetActivatedFeature(array_index(FEATURES, "Swarm Forms"));
-    SetActivatedFeature(array_index(FEATURES, "Turn Counter"));
-    SetActivatedFeature(array_index(FEATURES, "Underground Forms"));
-    SetActivatedFeature(array_index(FEATURES, "Validity Checks"));
-    SetActivatedFeature(array_index(FEATURES, "Visible Shiny Eggs"));
-    SetActivatedFeature(array_index(FEATURES, "Wild Forms"));
-    SetActivatedFeature(array_index(FEATURES, "Wild Held Item Rates"));
-    SetActivatedFeature(array_index(FEATURES, "Contest NPC Forms"));
-    SetActivatedFeature(array_index(FEATURES, "Re:Lumi Pokédex UI"));
-    SetActivatedFeature(array_index(FEATURES, "Local Trades Extension"));
-
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Battle Bundles in UI"));
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Boutique Models"));
-    //SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "IL2CPP Logging"));
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "PokemonInfo Logging"));
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Unity Logging"));
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Feature Logging"));
-    SetActivatedDebugFeature(array_index(DEBUG_FEATURES, "Pickup 100%"));
-
-    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Ability Patch"));
-    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies"));
-    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite TMs"));
-    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Leek"));
-    SetActivatedItemFeature(array_index(ITEM_FEATURES, "Infinite Repel"));
-
-    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Clothing Trunk"));
-    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Incense Burner"));
-    SetActivatedKeyItemFeature(array_index(KEY_ITEM_FEATURES, "Infinite Repel"));
-
-    SetActivatedSaveFeature(array_index(SAVE_FEATURES, "Box Expansion"));
-    SetActivatedSaveFeature(array_index(SAVE_FEATURES, "Dex Expansion"));
-
-    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Affection Toggle"));
-    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Global Exp. Share Toggle"));
-    SetActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Catch Rate Fix"));
-
-    SetActivatedBattleFeature(array_index(BATTLE_FEATURES, "Move Handlers"));
-    SetActivatedBattleFeature(array_index(BATTLE_FEATURES, "Field Handlers"));
-    SetActivatedBattleFeature(array_index(BATTLE_FEATURES, "Side Handlers"));
+    MountRomAndReadJSON();
 
     // Install all activated hooks
     CallFeatureHooks();

--- a/src/mod/main.cpp
+++ b/src/mod/main.cpp
@@ -75,6 +75,11 @@ HOOK_DEFINE_TRAMPOLINE(MainInitHook){
         nn::oe::GetDisplayVersion(&display_version);
         Logger::log("Detected version: %s\n", display_version.name);
 
+
+        // Load activated features
+        exl_save_main();
+        exl_features_main(); // Features JSON is read here
+
         if (IsActivatedDebugFeature(array_index(DEBUG_FEATURES, "Feature Logging")))
             logFeatures();
 
@@ -113,8 +118,6 @@ extern "C" void exl_main(void* x0, void* x1) {
     exl_imgui_main();
     exl_debug_menu_main();
 #endif
-    exl_save_main();
-    exl_features_main();
 }
 
 extern "C" NORETURN void exl_exception_entry() {

--- a/src/mod/romdata/feature_status.cpp
+++ b/src/mod/romdata/feature_status.cpp
@@ -1,0 +1,67 @@
+#include "exlaunch.hpp"
+
+#include "helpers.h"
+#include "memory/json.h"
+#include "memory/string.h"
+#include "data/features.h"
+#include "features/activated_features.h"
+
+#include "logger/logger.h"
+
+void LoadFeaturesFromJSON(nn::json j) {
+    for (int i = 0; i < FEATURE_COUNT; i++) {
+        if (j.at("MainFeatures").contains(FEATURES[i])) {
+            if (j.at("MainFeatures")[FEATURES[i]].get<bool>()) {
+                SetActivatedFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < DEBUG_FEATURE_COUNT; i++) {
+        if (j.at("DebugFeatures").contains(DEBUG_FEATURES[i])) {
+            if (j.at("DebugFeatures")[DEBUG_FEATURES[i]].get<bool>()) {
+                SetActivatedDebugFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < ITEM_FEATURE_COUNT; i++) {
+        if (j.at("ItemFeatures").contains(ITEM_FEATURES[i])) {
+            if (j.at("ItemFeatures")[ITEM_FEATURES[i]].get<bool>()) {
+                SetActivatedItemFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < KEY_ITEM_FEATURE_COUNT; i++) {
+        if (j.at("KeyItemFeatures").contains(KEY_ITEM_FEATURES[i])) {
+            if (j.at("KeyItemFeatures")[KEY_ITEM_FEATURES[i]].get<bool>()) {
+                SetActivatedKeyItemFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < SMALL_PATCH_FEATURE_COUNT; i++) {
+        if (j.at("SmallPatchFeatures").contains(SMALL_PATCH_FEATURES[i])) {
+            if (j.at("SmallPatchFeatures")[SMALL_PATCH_FEATURES[i]].get<bool>()) {
+                SetActivatedSmallPatchFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < SAVE_FEATURE_COUNT; i++) {
+        if (j.at("SaveDataFeatures").contains(SAVE_FEATURES[i])) {
+            if (j.at("SaveDataFeatures")[SAVE_FEATURES[i]].get<bool>()) {
+                SetActivatedSaveFeature(i);
+            }
+        }
+    }
+
+    for (int i = 0; i < BATTLE_FEATURE_COUNT; i++) {
+        if (j.at("BattleFeatures").contains(BATTLE_FEATURES[i])) {
+            if (j.at("BattleFeatures")[BATTLE_FEATURES[i]].get<bool>()) {
+                SetActivatedBattleFeature(i);
+            }
+        }
+    }
+}

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -61,3 +61,5 @@ RomData::Arena GetExtraArenaData(int32_t arena);
 
 // Returns the extra local trade data.
 RomData::LocalTrade GetExtraLocalTradeData(int32_t tradeId);
+
+void LoadFeaturesFromJSON(nn::json j);


### PR DESCRIPTION
Feature: JSON-ify Feature Selection ⚙️
-
- Converted all `SetActivatedFeature` logic to read from a JSON file allowing flexibility for the user.
- Additional features can be added by appending them to the end of the relevant feature category (the placement must be identical to its position in the relevant features array). All other previous setup work still needs to be performed including:
    - Appending it to the relevant features array in `data/features.h`
    - Adding logic for `IsActivatedFeature` that points to its exl function
    - Linking the exl function by placing it in `features/features.h`
