### PR TITLE
Pokémon Variants

### DIFF
--- a/src/common/memory/string.cpp
+++ b/src/common/memory/string.cpp
@@ -5,12 +5,16 @@ namespace nn {
     string to_string(int32_t value) {
         char buffer[100] = {};
         if (nn::util::SNPrintf(buffer, sizeof(buffer), "%d", value) >= 0)
-        {
             return string(buffer);
-        }
         else
-        {
             return string("");
-        }
+    }
+
+    string to_string(int32_t value, const char* format) {
+        char buffer[100] = {};
+        if (nn::util::SNPrintf(buffer, sizeof(buffer), format, value) >= 0)
+            return string(buffer);
+        else
+            return string("");
     }
 }

--- a/src/common/memory/string.h
+++ b/src/common/memory/string.h
@@ -7,4 +7,5 @@ namespace nn {
     using string = std::basic_string<char, std::char_traits<char>, nn_allocator<char>>;
 
     string to_string(int32_t value);
+    string to_string(int32_t value, const char* format);
 }

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -43,6 +43,7 @@ static constexpr const char* FEATURES[] = {
     "Contest NPC Forms",
     "Re:Lumi Pokédex UI",
     "Local Trades Extension",
+    "Spinda Hijacking",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -45,6 +45,7 @@ static constexpr const char* FEATURES[] = {
     "Local Trades Extension",
     "Spinda Hijacking",
     "Form Argument Pokémon Icons",
+    "Form Argument Generation",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -44,6 +44,7 @@ static constexpr const char* FEATURES[] = {
     "Re:Lumi Pokédex UI",
     "Local Trades Extension",
     "Spinda Hijacking",
+    "Form Argument Pokémon Icons",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/BattlePokemonEntity.h
+++ b/src/mod/externals/BattlePokemonEntity.h
@@ -2,16 +2,19 @@
 
 #include "externals/il2cpp-api.h"
 #include "externals/BattleObjectEntity.h"
-#include "externals/UnityEngine/Color.h"
-#include "externals/UnityEngine/Vector3.h"
 #include "externals/Dpr/Battle/View/SimpleParam.h"
+#include "externals/Dpr/PatcheelPattern.h"
+#include "externals/UnityEngine/Color.h"
+#include "externals/UnityEngine/Rendering/CompareFunction.h"
+#include "externals/UnityEngine/Rendering/StencilOp.h"
+#include "externals/UnityEngine/Vector3.h"
 
 struct BattlePokemonEntity : ILClass<BattlePokemonEntity> {
-    struct RenderingParam {
+    struct RenderingParam : ILStruct<RenderingParam> {
         struct Fields {
             int32_t stencilRef;
-            int32_t stencilComp;
-            int32_t stencilOp;
+            UnityEngine::Rendering::CompareFunction stencilComp;
+            UnityEngine::Rendering::StencilOp stencilOp;
         };
     };
 
@@ -21,7 +24,7 @@ struct BattlePokemonEntity : ILClass<BattlePokemonEntity> {
         float _scale;
         int32_t _landingType;
         int32_t _animationState;
-        BattlePokemonEntity::RenderingParam _renderingParam;
+        BattlePokemonEntity::RenderingParam::Object _renderingParam;
         void* _rendererClusters; //SmartPoint_Components_SkinnedMeshRendererCluster_array*
         void* _pokeAnimSound; //Dpr_PokeAnimSound_o*
         void* _propertyBlock; //UnityEngine_MaterialPropertyBlock_o*
@@ -39,11 +42,9 @@ struct BattlePokemonEntity : ILClass<BattlePokemonEntity> {
         void* _PokemonCustomNodeAnim_k__BackingField; //PokemonCustomNodeAnim_o*
         void* _PokemonAnime_k__BackingField; //PokemonAnime_o*
         void* _PokemonPrefabInfo_k__BackingField; //PokemonPrefabInfo_o*
-        void* _patcheelPattern_k__BackingField; //Dpr_PatcheelPattern_o*
+        Dpr::PatcheelPattern::Object* _patcheelPattern_k__BackingField;
         bool isZIBAKOIRU;
     };
 
-    inline void SetPatcheelPattern(uint32_t rand) {
-        external<void>(0x01d77990, this, rand);
-    }
+    static_assert(offsetof(Fields, isZIBAKOIRU) == 0x170);
 };

--- a/src/mod/externals/CustomNodeMaterial.h
+++ b/src/mod/externals/CustomNodeMaterial.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/CustomNodeProperty.h"
+#include "externals/MaterialParam.h"
+#include "externals/System/String.h"
+#include "externals/UnityEngine/Color.h"
+
+struct CustomNodeMaterial : ILClass<CustomNodeMaterial> {
+    struct Fields {
+        struct MaterialParam::Object* mp;
+        struct System::String::Object* shaderName;
+        struct CustomNodeProperty::Array* cnProperties;
+        struct UnityEngine::Color::Object fixMultiplyColor;
+    };
+};

--- a/src/mod/externals/CustomNodeProperty.h
+++ b/src/mod/externals/CustomNodeProperty.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/String.h"
+#include "externals/UnityEngine/GameObject.h"
+#include "externals/UnityEngine/Vector2.h"
+
+struct CustomNodeProperty : ILClass<CustomNodeProperty> {
+    struct Fields {
+        UnityEngine::GameObject::Object* bone;
+        UnityEngine::GameObject::Object* boneSub;
+        System::String::Object* propertyName;
+        int32_t pType;
+        UnityEngine::Vector2::Object baseUV;
+        UnityEngine::Vector2::Object baseScale;
+        System::String::Object* propertyName_U;
+        System::String::Object* propertyName_V;
+    };
+};

--- a/src/mod/externals/CustomNodeVisibility.h
+++ b/src/mod/externals/CustomNodeVisibility.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/GameObject.h"
+#include "externals/UnityEngine/Renderer.h"
+
+struct CustomNodeVisibility : ILClass<CustomNodeVisibility> {
+    struct Fields {
+        UnityEngine::GameObject::Object* bone;
+        UnityEngine::Renderer::Object* skin;
+    };
+};

--- a/src/mod/externals/DPData/Form_Enums.h
+++ b/src/mod/externals/DPData/Form_Enums.h
@@ -214,6 +214,13 @@ enum class SilvallyForm : int32_t {
     MAX
 };
 
+enum class ToxtricityForm : int32_t {
+    AMPED = 0,
+    LOW_KEY = 1,
+
+    MAX
+};
+
 enum class AlcremieCream : int32_t {
     VANILLA_CREAM = 0,
     RUBY_CREAM = 1,

--- a/src/mod/externals/Dpr/Contest/AContestPlayerData.h
+++ b/src/mod/externals/Dpr/Contest/AContestPlayerData.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Battle/View/BtlvBallInfo.h"
+#include "externals/Dpr/Contest/PokemonInfo.h"
+#include "externals/System/String.h"
+
+namespace Dpr::Contest {
+    struct AContestPlayerData : ILClass<AContestPlayerData> {
+        struct Fields {
+            int32_t playerType;
+            int32_t index;
+            void* playerInfo; // Dpr_Contest_PlayerInfo_o*
+            Dpr::Contest::PokemonInfo::Object* pokemonInfo;
+            Dpr::Battle::View::BtlvBallInfo::Object ballInfo;
+            void* visualDataModel; // Dpr_Contest_PlayerVisualDataModel_o*
+            void* danceDataModel; // Dpr_Contest_PlayerDanceDataModel_o*
+            int32_t modelColorID;
+            int32_t trainerType;
+            System::String::Object* trainerModelPath;
+            System::String::Object* pokemonModelPath;
+            System::String::Object* ballModelPath;
+        };
+
+        static_assert(offsetof(Fields, ballModelPath) == 0x58);
+    };
+}

--- a/src/mod/externals/Dpr/Contest/ContestPlayerEntity.h
+++ b/src/mod/externals/Dpr/Contest/ContestPlayerEntity.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Contest/AContestPlayerData.h"
+#include "externals/UnityEngine/Sprite.h"
+#include "externals/UnityEngine/Vector3.h"
+#include "externals/XLSXContent/PokemonInfo.h"
+
+namespace Dpr::Contest {
+    struct ContestPlayerEntity : ILClass<ContestPlayerEntity> {
+        struct Fields {
+            UnityEngine::Vector3::Object RESET_BALL_POS;
+            XLSXContent::PokemonInfo::SheetCatalog::Object* catalog;
+            UnityEngine::_Object::Object* assetPokeModel;
+            void* iPtrSealEffects; // System_Collections_Generic_List_BtlvEffectInstance__o*
+            void* iPtrLightEffect; // Dpr_Battle_View_Objects_BtlvEffectInstance_o*
+            void* wazaPoke; // Dpr_Battle_View_Objects_BOPokemon_o*
+            void* boTrainer; // Dpr_Battle_View_Objects_BOTrainer_o*
+            void* boPokemon; // Dpr_Battle_View_Objects_BOPokemon_o*
+            void* ballEntity; // Dpr_ObjectEntity_o*
+            Dpr::Contest::AContestPlayerData::Object* playerData;
+            UnityEngine::Sprite::Object* pmIconSpr;
+            UnityEngine::Sprite::Object* wazaTypeIconSpr;
+            UnityEngine::Vector3::Object defaultTrainerPos;
+            UnityEngine::Vector3::Object defaultPokemonPos;
+            int32_t trainerType;
+            int32_t colorID;
+            System::String::Object* characterModelPath;
+            System::String::Object* pokeModelPath;
+            System::String::Object* ballModelPath;
+            System::String::Object* pokeIconPath;
+        };
+
+        static_assert(offsetof(Fields, pokeIconPath) == 0xA0);
+
+        static inline StaticILMethod<0x04c7c628, UnityEngine::Sprite::Object*> Method$$AppendLoadPokemonIcon_b_99 {};
+    };
+}

--- a/src/mod/externals/Dpr/Contest/PokemonInfo.h
+++ b/src/mod/externals/Dpr/Contest/PokemonInfo.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/System/String.h"
+
+namespace Dpr::Contest {
+    struct PokemonInfo : ILClass<PokemonInfo> {
+        struct Fields {
+            System::String::Object* nickname;
+            bool isZIBAKOIRU;
+            Pml::PokePara::PokemonParam::Object* pokeParam;
+            int32_t size;
+            uint8_t wazaType;
+            int32_t wazaNo;
+            int32_t haveItemNo;
+            System::String::Object* wazaName;
+            float wazaSeqTime;
+            int32_t langID;
+            Dpr::Battle::Logic::BTL_POKEPARAM::Object* btlPokeParam;
+        };
+
+        static_assert(offsetof(Fields, btlPokeParam) == 0x38);
+    };
+}

--- a/src/mod/externals/Dpr/PatcheelPattern.h
+++ b/src/mod/externals/Dpr/PatcheelPattern.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/SkinnedMeshRenderer.h"
+#include "externals/UnityEngine/Vector2.h"
+
+namespace Dpr {
+    struct PatcheelPattern : ILClass<PatcheelPattern> {
+        struct UVData : ILClass<UVData> {
+            UnityEngine::SkinnedMeshRenderer::Object* renderer;
+            UnityEngine::Vector2::Array* UVs;
+            int32_t value;
+        };
+
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            UVData::Array* UVDatas;
+        };
+    };
+}

--- a/src/mod/externals/Dpr/PatcheelPattern.h
+++ b/src/mod/externals/Dpr/PatcheelPattern.h
@@ -9,9 +9,11 @@
 namespace Dpr {
     struct PatcheelPattern : ILClass<PatcheelPattern> {
         struct UVData : ILClass<UVData> {
-            UnityEngine::SkinnedMeshRenderer::Object* renderer;
-            UnityEngine::Vector2::Array* UVs;
-            int32_t value;
+            struct Fields {
+                UnityEngine::SkinnedMeshRenderer::Object* renderer;
+                UnityEngine::Vector2::Array* UVs;
+                int32_t value;
+            };
         };
 
         struct Fields : UnityEngine::MonoBehaviour::Fields {

--- a/src/mod/externals/Dpr/PatcheelPattern.h
+++ b/src/mod/externals/Dpr/PatcheelPattern.h
@@ -17,5 +17,10 @@ namespace Dpr {
         struct Fields : UnityEngine::MonoBehaviour::Fields {
             UVData::Array* UVDatas;
         };
+
+        // Third argument is normally a MethodInfo, we are sneaking in the PokemonParam in there :)
+        inline void SetPatcheelPattern(uint32_t personalRand, Pml::PokePara::PokemonParam::Object* param) {
+            external<void>(0x01bcb200, this, personalRand, param);
+        }
     };
 }

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -5,6 +5,7 @@
 #include "externals/Dpr/UI/UIModelViewController.h"
 #include "externals/Dpr/UI/UIWazaManage.h"
 #include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/SpriteAtlasID.h"
 #include "externals/System/Action.h"
 #include "externals/System/Func.h"
 #include "externals/UIWindowID.h"
@@ -82,12 +83,20 @@ namespace Dpr::UI {
             external<void>(0x017c3ef0, this, monsNo, formNo, sex, rareType, isEgg, onComplete);
         }
 
+        inline void LoadSpritePokemon(Pml::PokePara::PokemonParam::Object* pokemonParam, UnityEngine::Events::UnityAction::Object* onComplete) {
+            external<void>(0x017c3e40, this, pokemonParam, onComplete);
+        }
+
         inline UnityEngine::Sprite::Object* GetSpritePokemonTypeZukan(int32_t typeNo, int32_t langId) {
             return external<UnityEngine::Sprite::Object*>(0x017c2650, this, typeNo, langId);
         }
 
-        inline UnityEngine::Sprite::Object* GetAtlasSprite(int32_t spriteAtlasId, System::String::Object* name) {
+        inline UnityEngine::Sprite::Object* GetAtlasSprite(SpriteAtlasID spriteAtlasId, System::String::Object* name) {
             return external<UnityEngine::Sprite::Object*>(0x017a9080, this, spriteAtlasId, name);
+        }
+
+        inline XLSXContent::UIDatabase::SheetPokemonIcon::Object* GetPokemonIconData(int32_t monsNo, uint16_t formNo, Pml::Sex sex, Pml::PokePara::RareType rareType, bool isEgg) {
+            return external<XLSXContent::UIDatabase::SheetPokemonIcon::Object*>(0x017c1250, this, monsNo, formNo, sex, rareType, isEgg);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/ZukanCompareWeightController.h
+++ b/src/mod/externals/Dpr/UI/ZukanCompareWeightController.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/ZukanInfo.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/UI/Image.h"
+
+namespace Dpr::UI {
+    struct ZukanCompareWeightController : ILClass<ZukanCompareWeightController> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            void* animator; // UnityEngine_Animator_o*
+            UnityEngine::UI::Image::Array* playerImages;
+            UnityEngine::UI::Image::Object* pokemonIconImage;
+            uint16_t playerWeight;
+            Dpr::UI::ZukanInfo::Object* currentZukanInfo;
+            bool isSetupEnd;
+            bool _IsLoadEnd_k__BackingField;
+        };
+
+        static_assert(offsetof(Fields, _IsLoadEnd_k__BackingField) == 0x31);
+    };
+}

--- a/src/mod/externals/Dpr/UI/ZukanInfo.h
+++ b/src/mod/externals/Dpr/UI/ZukanInfo.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/Dpr/UI/IndexSelector.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
 #include "externals/System/String.h"
 
 namespace Dpr::UI {
@@ -31,5 +32,9 @@ namespace Dpr::UI {
             int32_t formIndex;
             Dpr::UI::IndexSelector::Object *modelIndexSelector;
         };
+
+        inline Pml::PokePara::PokemonParam::Object* GetCurrentPokemonParam() {
+            return external<Pml::PokePara::PokemonParam::Object*>(0x01bb04e0, this);
+        }
     };
 }

--- a/src/mod/externals/GFL.h
+++ b/src/mod/externals/GFL.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+struct GFL : ILClass<GFL> {
+    struct Fields {};
+
+    static inline void ASSERT(bool condition) {
+        external<void>(0x02ccb2e0, condition);
+    }
+};

--- a/src/mod/externals/MaterialParam.h
+++ b/src/mod/externals/MaterialParam.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/MaterialUsing.h"
+#include "externals/UnityEngine/Material.h"
+
+struct MaterialParam : ILClass<MaterialParam> {
+    struct Fields {
+        UnityEngine::Material::Object* mat;
+        MaterialUsing::Array* usings;
+    };
+};

--- a/src/mod/externals/MaterialUsing.h
+++ b/src/mod/externals/MaterialUsing.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Renderer.h"
+
+struct MaterialUsing : ILClass<MaterialUsing> {
+    struct Fields {
+        UnityEngine::Renderer::Object* renderer;
+        int32_t index;
+    };
+};

--- a/src/mod/externals/Pml/Personal/EvolveCond.h
+++ b/src/mod/externals/Pml/Personal/EvolveCond.h
@@ -65,5 +65,6 @@ namespace Pml::Personal {
         RND_99_OF_100_MOVE = 56,
         TOTAL_DAMAGE_RECIEVED_MALE = 57,
         TOTAL_DAMAGE_RECIEVED_FEMALE = 58,
+        VARIANT_TO_FORM = 59,
     };
 }

--- a/src/mod/externals/Pml/Personal/GrowTableExtensions.h
+++ b/src/mod/externals/Pml/Personal/GrowTableExtensions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/XLSXContent/GrowTable.h"
+
+namespace Pml::Personal {
+    struct GrowTableExtensions : ILClass<GrowTableExtensions, 0x04c64410> {
+        struct Fields {};
+
+        static inline uint32_t GetMinExp(XLSXContent::GrowTable::SheetData::Object* data, uint8_t level) {
+            return external<uint32_t>(0x024a0880, data, level);
+        }
+    };
+}

--- a/src/mod/externals/Pml/Personal/PersonalSystem.h
+++ b/src/mod/externals/Pml/Personal/PersonalSystem.h
@@ -3,15 +3,14 @@
 #include "externals/Pml/Personal/EvolveCond.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
 #include "externals/Pml/WazaNo.h"
+#include "externals/XLSXContent/GrowTable.h"
 #include "externals/XLSXContent/EvolveTable.h"
 #include "externals/XLSXContent/PersonalTable.h"
 #include "externals/il2cpp-api.h"
 
 namespace Pml::Personal {
-    struct PersonalSystem : ILClass<PersonalSystem,0x04c5ad18> {
-        struct Fields {
-
-        };
+    struct PersonalSystem : ILClass<PersonalSystem, 0x04c5ad18> {
+        struct Fields {};
 
         struct StaticFields {
             XLSXContent::PersonalTable::Object* m_alldata;
@@ -59,6 +58,10 @@ namespace Pml::Personal {
 
         static inline uint16_t GetEvolutionParam(uint8_t route_index) {
             return external<uint16_t>(0x024a2620, route_index);
+        }
+
+        static inline XLSXContent::GrowTable::SheetData::Object* GetGrowTable(int32_t monsno, uint16_t formno) {
+            return external<XLSXContent::GrowTable::SheetData::Object*>(0x024a1790, monsno, formno);
         }
     };
 }

--- a/src/mod/externals/Pml/Personal/PersonalSystem.h
+++ b/src/mod/externals/Pml/Personal/PersonalSystem.h
@@ -21,7 +21,7 @@ namespace Pml::Personal {
             void* s_GrowTable; // XLSXContent::GrowTable::SheetData::Object*
             XLSXContent::EvolveTable::SheetEvolve::Object* s_EvolutionTable;
             void* s_WazaOboeData; // XLSXContent::WazaOboeTable::SheetWazaOboe::Object*
-            Pml_WazaNo_array* OSHIE_WAZA;
+            Pml::WazaNo_array* OSHIE_WAZA;
         };
 
         static inline XLSXContent::PersonalTable::SheetPersonal::Object* GetPersonalData(int32_t monsno, uint16_t formno) {
@@ -62,6 +62,10 @@ namespace Pml::Personal {
 
         static inline XLSXContent::GrowTable::SheetData::Object* GetGrowTable(int32_t monsno, uint16_t formno) {
             return external<XLSXContent::GrowTable::SheetData::Object*>(0x024a1790, monsno, formno);
+        }
+
+        static inline System::String::Object* GetMonsName(int32_t monsNo, int32_t langId) {
+            return external<System::String::Object*>(0x024a0a90, monsNo, langId);
         }
     };
 }

--- a/src/mod/externals/Pml/PokePara/Accessor.h
+++ b/src/mod/externals/Pml/PokePara/Accessor.h
@@ -226,5 +226,29 @@ namespace Pml::PokePara {
         inline void SetTalentWeight(uint8_t value) {
             external<void>(0x024ac170, this, value);
         }
+
+        inline bool IsFastMode() {
+            return external<bool>(0x024a4250, this);
+        }
+
+        inline void StartFastMode() {
+            external<void>(0x024a4260, this);
+        }
+
+        inline void SetOyaName(System::String::Object* oyaName) {
+            external<void>(0x024aa550, this, oyaName);
+        }
+
+        inline void SetTamagoWazaNo(uint8_t index, uint32_t wazano) {
+            external<void>(0x024a9660, this, index, wazano);
+        }
+
+        inline void SetTamagoFlag(bool flag) {
+            external<void>(0x024a9d80, this, flag);
+        }
+
+        inline void EndFastMode() {
+            external<void>(0x024a42a0, this);
+        }
     };
 }

--- a/src/mod/externals/Pml/PokePara/Accessor.h
+++ b/src/mod/externals/Pml/PokePara/Accessor.h
@@ -2,11 +2,12 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Pml/Sex.h"
 #include "externals/System/Primitives.h"
 #include "externals/System/String.h"
 
 namespace Pml::PokePara {
-    struct Accessor : ILClass<Accessor> {
+    struct Accessor : ILClass<Accessor, 0x04c64ec8> {
         struct AccessState : ILStruct<AccessState> {
             bool isEncoded;
             bool isFastMode;
@@ -17,6 +18,10 @@ namespace Pml::PokePara {
             System::Byte_array* m_pCoreData;
             Pml::PokePara::Accessor::AccessState::Object m_accessState;
         };
+
+        inline void ctor() {
+            external<void>(0x024a3ed0, this);
+        }
 
         inline void SetLangID(uint8_t langId) {
             external<void>(0x024a8bb0, this, langId);
@@ -112,6 +117,114 @@ namespace Pml::PokePara {
 
         inline void SetMultiPurposeWork(uint32_t value) {
             external<void>(0x024abac0, this, value);
+        }
+
+        inline void AttachDecodedData(System::Byte_array* coreData, System::Byte_array* calcData) {
+            external<void>(0x024a3ee0, this, coreData, calcData);
+        }
+
+        inline void SetPersonalRnd(uint32_t rnd) {
+            external<void>(0x024a85a0, this, rnd);
+        }
+
+        inline void SetID(uint32_t id) {
+            external<void>(0x024a8950, this, id);
+        }
+
+        inline void SetColorRnd(uint32_t rnd) {
+            external<void>(0x024a8640, this, rnd);
+        }
+
+        inline void SetMonsNo(uint32_t monsno) {
+            external<void>(0x024a8870, this, monsno);
+        }
+
+        inline void SetLevel(uint8_t level) {
+            external<void>(0x024aad10, this, level);
+        }
+
+        inline void SetSeikaku(uint32_t seikaku) {
+            external<void>(0x024a9ca0, this, seikaku);
+        }
+
+        inline void SetSeikakuHosei(uint32_t seikaku) {
+            external<void>(0x024a9d10, this, seikaku);
+        }
+
+        inline void SetSex(Pml::Sex sex) {
+            external<void>(0x024a9b90, this, sex);
+        }
+
+        inline void SetGetLevel(uint8_t level) {
+            external<void>(0x024aac10, this, level);
+        }
+
+        inline void SetCassetteVersion(uint32_t version) {
+            external<void>(0x024aa4e0, this, version);
+        }
+
+        inline void SetFriendship(uint8_t friendship) {
+            external<void>(0x024a8a30, this, friendship);
+        }
+
+        inline void SetEquipRibbonNo(uint8_t ribbonNo) {
+            external<void>(0x024a9410, this, ribbonNo);
+        }
+
+        inline void SetTalentHp(uint8_t value) {
+            external<void>(0x024a9700, this, value);
+        }
+
+        inline void SetTalentAtk(uint8_t value) {
+            external<void>(0x024a9780, this, value);
+        }
+
+        inline void SetTalentDef(uint8_t value) {
+            external<void>(0x024a9800, this, value);
+        }
+
+        inline void SetTalentSpAtk(uint8_t value) {
+            external<void>(0x024a9880, this, value);
+        }
+
+        inline void SetTalentSpDef(uint8_t value) {
+            external<void>(0x024a9900, this, value);
+        }
+
+        inline void SetTalentAgi(uint8_t value) {
+            external<void>(0x024a9980, this, value);
+        }
+
+        inline void SetTokuseiNo(uint32_t tokusei) {
+            external<void>(0x024a8ad0, this, tokusei);
+        }
+
+        inline void SetTokusei1Flag(bool flag) {
+            external<void>(0x024a9e20, this, flag);
+        }
+
+        inline void SetTokusei2Flag(bool flag) {
+            external<void>(0x024a9ea0, this, flag);
+        }
+
+        inline void SetTokusei3Flag(bool flag) {
+            external<void>(0x024a9f40, this, flag);
+        }
+
+        inline void SetFavoriteFlag(bool flag) {
+            external<void>(0x024a9fe0, this, flag);
+        }
+
+        inline void SetExp(uint32_t exp) {
+            external<void>(0x024a89c0, this, exp);
+        }
+
+        inline void SetTalentHeight(uint8_t value) {
+            external<void>(0x024ac100, this, value);
+        }
+
+        inline void SetTalentWeight(uint8_t value) {
+            external<void>(0x024ac170, this, value);
         }
     };
 }

--- a/src/mod/externals/Pml/PokePara/Accessor.h
+++ b/src/mod/externals/Pml/PokePara/Accessor.h
@@ -105,5 +105,13 @@ namespace Pml::PokePara {
         inline uint16_t GetFormNo() {
             return external<uint16_t>(0x024a64e0, this);
         }
+
+        inline uint32_t GetMultiPurposeWork() {
+            return external<uint32_t>(0x024a7f40, this);
+        }
+
+        inline void SetMultiPurposeWork(uint32_t value) {
+            external<void>(0x024abac0, this, value);
+        }
     };
 }

--- a/src/mod/externals/Pml/PokePara/CalcTool.h
+++ b/src/mod/externals/Pml/PokePara/CalcTool.h
@@ -23,5 +23,9 @@ namespace Pml::PokePara {
         static inline bool IsSeikakuLow(int32_t seikaku) {
             return external<bool>(0x024ae000, seikaku);
         }
+
+        static inline uint16_t GetTokuseiNo(int32_t monsno, uint16_t formno, uint8_t tokuseiIndex) {
+            return external<uint16_t>(0x024ae1f0, monsno, formno, tokuseiIndex);
+        }
     };
 }

--- a/src/mod/externals/Pml/PokePara/CoreParam.h
+++ b/src/mod/externals/Pml/PokePara/CoreParam.h
@@ -15,9 +15,9 @@ namespace Pml::PokePara {
     struct CoreParam : ILClass<CoreParam> {
         struct FormChangeResult : ILClass<FormChangeResult> {
             struct Fields {
-                Pml_WazaNo_array* m_addedWaza;
-                Pml_WazaNo_array* m_removedWaza;
-                Pml_WazaNo_array* m_addFailedWaza;
+                Pml::WazaNo_array* m_addedWaza;
+                Pml::WazaNo_array* m_removedWaza;
+                Pml::WazaNo_array* m_addFailedWaza;
             };
         };
 
@@ -99,8 +99,8 @@ namespace Pml::PokePara {
             external<void>(0x02048e90, this, nickName);
         }
 
-        inline System::Collections::Generic::HashSet$$Pml_WazaNo::Object* CollectRemindableWaza() {
-            return external<System::Collections::Generic::HashSet$$Pml_WazaNo::Object*>(0x02047aa0, this);
+        inline System::Collections::Generic::HashSet$$WazaNo::Object* CollectRemindableWaza() {
+            return external<System::Collections::Generic::HashSet$$WazaNo::Object*>(0x02047aa0, this);
         }
 
         inline int32_t AddWazaIfEmptyExist(int32_t wazano) {

--- a/src/mod/externals/Pml/PokePara/CoreParam.h
+++ b/src/mod/externals/Pml/PokePara/CoreParam.h
@@ -7,6 +7,8 @@
 #include "externals/Pml/PokePara/EggCheckType.h"
 #include "externals/Pml/PokePara/OwnerInfo.h"
 #include "externals/Pml/PokePara/PowerID.h"
+#include "externals/Pml/PokePara/RareType.h"
+#include "externals/Pml/Sex.h"
 #include "externals/Pml/WazaNo.h"
 
 namespace Pml::PokePara {
@@ -89,8 +91,8 @@ namespace Pml::PokePara {
             return external<uint8_t>(0x0204b950, this);
         }
 
-        inline uint8_t GetSex() {
-            return external<uint8_t>(0x02048540, this);
+        inline Sex GetSex() {
+            return external<Sex>(0x02048540, this);
         }
 
         inline void SetNickName(System::String::Object* nickName) {
@@ -137,7 +139,7 @@ namespace Pml::PokePara {
             external<void>(0x0204b840, this, value);
         }
 
-        inline void SetRareType(uint8_t type) {
+        inline void SetRareType(RareType type) {
             external<void>(0x0204a920, this, type);
         }
 
@@ -181,8 +183,8 @@ namespace Pml::PokePara {
             external<void>(0x02049690, this);
         }
 
-        inline uint8_t GetRareType() {
-            return external<uint8_t>(0x0204a5a0, this);
+        inline RareType GetRareType() {
+            return external<RareType>(0x0204a5a0, this);
         }
 
         inline void ChangeEffortPower(Pml::PokePara::PowerID powerId, uint32_t value) {
@@ -211,6 +213,14 @@ namespace Pml::PokePara {
 
         inline bool EndFastMode(bool validFlag) {
             return external<bool>(0x0204c960, this, validFlag);
+        }
+
+        inline uint32_t GetMultiPurposeWork() {
+            return this->instance()->fields.m_accessor->GetMultiPurposeWork();
+        }
+
+        inline void SetMultiPurposeWork(uint32_t value) {
+            this->instance()->fields.m_accessor->SetMultiPurposeWork(value);
         }
     };
 }

--- a/src/mod/externals/Pml/PokePara/EggGenerator.h
+++ b/src/mod/externals/Pml/PokePara/EggGenerator.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Pml/PokePara/CoreParam.h"
+#include "externals/Pml/PokePara/EggParam.h"
+#include "externals/Pml/PokePara/Parents.h"
+#include "externals/System/MulticastDelegate.h"
+
+namespace Pml::PokePara {
+    struct EggGenerator : ILClass<EggGenerator> {
+        struct SavedRandomFunc : ILClass<SavedRandomFunc> {
+            struct Fields : System::MulticastDelegate::Fields {};
+        };
+
+        struct Setting : ILClass<Setting> {
+            struct Fields {
+                uint32_t IDNo;
+                System::String::Object* parentName;
+                bool haveItem_HIKARUOMAMORI;
+                SavedRandomFunc::Object* randFunc;
+                uint8_t realRegionFormNo;
+            };
+
+            static_assert(offsetof(Fields, realRegionFormNo) == 0x20);
+        };
+
+        struct Fields {};
+
+        static inline void SetupEggParam(CoreParam::Object* egg, EggParam::Object* egg_param, Parents::Object* parents, Setting::Object* setting) {
+            external<void>(0x0204e970, egg, egg_param, parents, setting);
+        }
+    };
+}

--- a/src/mod/externals/Pml/PokePara/EggParam.h
+++ b/src/mod/externals/Pml/PokePara/EggParam.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Pml/PokePara/InitialSpec.h"
+#include "externals/Pml/WazaNo.h"
+
+namespace Pml::PokePara {
+    struct EggParam : ILClass<EggParam> {
+        struct Fields {
+            Pml::PokePara::InitialSpec::Object* spec;
+            uint32_t wazaCount;
+            Pml::WazaNo_array* wazano;
+            uint32_t ballID;
+            System::Boolean_array* isTalentDerivedFromFather;
+            System::Boolean_array* isTalentDerivedFromMother;
+            uint32_t derivedTalentCount;
+            uint32_t totalDeriveTalentCount;
+        };
+
+        static_assert(offsetof(Fields, totalDeriveTalentCount) == 0x34);
+    };
+}

--- a/src/mod/externals/Pml/PokePara/Parents.h
+++ b/src/mod/externals/Pml/PokePara/Parents.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Pml/PokePara/CoreParam.h"
+
+namespace Pml::PokePara {
+    struct Parents : ILClass<Parents> {
+        struct Fields {
+            Pml::PokePara::CoreParam::Object* father;
+            Pml::PokePara::CoreParam::Object* mother;
+        };
+
+        static_assert(offsetof(Fields, mother) == 0x8);
+    };
+}

--- a/src/mod/externals/Pml/PokePara/PokemonParam.h
+++ b/src/mod/externals/Pml/PokePara/PokemonParam.h
@@ -7,9 +7,7 @@
 
 namespace Pml::PokePara {
     struct PokemonParam : ILClass<PokemonParam, 0x04c59c10> {
-        struct Fields : public CoreParam::Fields {
-            //TODO
-        };
+        struct Fields : public CoreParam::Fields {};
 
         inline void ctor(int32_t monsno, uint16_t level, uint64_t id) {
             external<void>(0x02054fe0, this, monsno, level, id);

--- a/src/mod/externals/Pml/PokePara/RareType.h
+++ b/src/mod/externals/Pml/PokePara/RareType.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Pml::PokePara {
+    enum class RareType : uint8_t {
+        NOT_RARE = 0,
+        CAPTURED = 1,
+        DISTRIBUTED = 2,
+        NUM = 3,
+    };
+}

--- a/src/mod/externals/Pml/WazaNo.h
+++ b/src/mod/externals/Pml/WazaNo.h
@@ -4,12 +4,13 @@
 #include "externals/il2cpp-api.h"
 #include "externals/System/Collections/Generic/HashSet.h"
 
-typedef int32_t Pml_WazaNo;
-
-PRIMITIVE_ARRAY(Pml_WazaNo, 0x04c5c7e8)
+namespace Pml {
+    typedef int32_t WazaNo;
+    PRIMITIVE_ARRAY(WazaNo, 0x04c5c7e8)
+}
 
 namespace System::Collections::Generic {
-    struct HashSet$$Pml_WazaNo : HashSet<HashSet$$Pml_WazaNo, Pml_WazaNo> {
-        static inline StaticILMethod<0x04c6f310, Pml_WazaNo> Method$$Add {};
+    struct HashSet$$WazaNo : HashSet<HashSet$$WazaNo, Pml::WazaNo> {
+        static inline StaticILMethod<0x04c6f310, Pml::WazaNo> Method$$Add {};
     };
 }

--- a/src/mod/externals/PokemonCustomNodeAnim.h
+++ b/src/mod/externals/PokemonCustomNodeAnim.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/CustomNodeMaterial.h"
+#include "externals/CustomNodeVisibility.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+
+struct PokemonCustomNodeAnim : ILClass<PokemonCustomNodeAnim> {
+    struct Fields : UnityEngine::MonoBehaviour::Fields {
+        bool debugKey;
+        CustomNodeMaterial::Array* mCustomNodeMaterials;
+        CustomNodeVisibility::Array* mCNViss;
+        bool isAutoUpdate;
+        bool _isSetup;
+    };
+};

--- a/src/mod/externals/SpriteAtlasID.h
+++ b/src/mod/externals/SpriteAtlasID.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+enum class SpriteAtlasID : int32_t {
+    SHAREDUI = 0,
+    COMMON = 1,
+    COMMON_LANG = 2,
+    TEXTUREMASS = 3,
+    SHAREDUI_LANG = 4,
+    BATTLE_LANG = 5,
+    ZUKAN = 6,
+};

--- a/src/mod/externals/UnityEngine/Component.h
+++ b/src/mod/externals/UnityEngine/Component.h
@@ -10,6 +10,7 @@
 // These are all to avoid cyclical definitions
 struct BattleCharacterEntity;
 struct FieldCharacterEntity;
+struct PokemonCustomNodeAnim;
 
 namespace System::Collections::Generic {
     struct List$$Component;
@@ -45,6 +46,7 @@ namespace UnityEngine {
         static inline StaticILMethod<0x04c67050, UnityEngine::BoxCollider> Method$$BoxCollider$$GetComponent {};
         static inline StaticILMethod<0x04c66d60, BattleCharacterEntity> Method$$BattleCharacterEntity$$GetComponent {};
         static inline StaticILMethod<0x04c66fc0, FieldCharacterEntity> Method$$FieldCharacterEntity$$GetComponent {};
+        static inline StaticILMethod<0x04c66840, PokemonCustomNodeAnim> Method$$PokemonCustomNodeAnim$$GetComponent {};
         static inline StaticILMethod<0x04c669c0, XMenuTopItem> Method$$XMenuTopItem$$GetComponent {};
 
         static inline StaticILMethod<0x04c66a18, Dpr::UI::UIText> Method$$UIText$$GetComponentInChildren {};

--- a/src/mod/externals/UnityEngine/Events/UnityAction.h
+++ b/src/mod/externals/UnityEngine/Events/UnityAction.h
@@ -12,7 +12,7 @@ namespace UnityEngine::Events {
 
         static const inline long bool_String_TypeInfo = 0x04c5ee10;
         static const inline long void_TypeInfo = 0x04c57230;
-
+        static const inline long Sprite_TypeInfo = 0x04c5e1a0;
 
         template <typename T, typename... Args>
         inline void ctor(T* owner, ILMethod<T, Args...>& mi) {
@@ -26,6 +26,10 @@ namespace UnityEngine::Events {
 
         inline void Invoke() {
             external<void>(0x026a3140, this);
+        }
+
+        inline void Invoke(Il2CppObject* arg0) {
+            external<void>(0x0253ded0, this, arg0);
         }
 
         inline void ctor() {

--- a/src/mod/externals/UnityEngine/Renderer.h
+++ b/src/mod/externals/UnityEngine/Renderer.h
@@ -18,5 +18,9 @@ namespace UnityEngine {
         inline UnityEngine::Material::Array* get_materials() {
             return external<UnityEngine::Material::Array*>(0x0269a3b0, this);
         }
+
+        inline void set_material(UnityEngine::Material::Object* value) {
+            external<void>(0x0269a4a0, this, value);
+        }
     };
 }

--- a/src/mod/externals/UnityEngine/Renderer.h
+++ b/src/mod/externals/UnityEngine/Renderer.h
@@ -19,8 +19,24 @@ namespace UnityEngine {
             return external<UnityEngine::Material::Array*>(0x0269a3b0, this);
         }
 
+        inline void set_materials(UnityEngine::Material::Array* value) {
+            external<void>(0x0269a400, this, value);
+        }
+
+        inline UnityEngine::Material::Array* get_sharedMaterials() {
+            return external<UnityEngine::Material::Array*>(0x0269a590, this);
+        }
+
+        inline void set_sharedMaterials(UnityEngine::Material::Array* value) {
+            external<void>(0x0269a5e0, this, value);
+        }
+
         inline void set_material(UnityEngine::Material::Object* value) {
             external<void>(0x0269a4a0, this, value);
+        }
+
+        inline void set_sharedMaterial(UnityEngine::Material::Object* value) {
+            external<void>(0x0269a540, this, value);
         }
     };
 }

--- a/src/mod/externals/UnityEngine/Renderer.h
+++ b/src/mod/externals/UnityEngine/Renderer.h
@@ -38,5 +38,9 @@ namespace UnityEngine {
         inline void set_sharedMaterial(UnityEngine::Material::Object* value) {
             external<void>(0x0269a540, this, value);
         }
+
+        inline void set_enabled(bool value) {
+            external<void>(0x0269a090, this, value);
+        }
     };
 }

--- a/src/mod/externals/UnityEngine/Rendering/CompareFunction.h
+++ b/src/mod/externals/UnityEngine/Rendering/CompareFunction.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace UnityEngine::Rendering
+{
+    enum class CompareFunction : int32_t {
+        Disabled = 0,
+        Never = 1,
+        Less = 2,
+        Equal = 3,
+        LessEqual = 4,
+        Greater = 5,
+        NotEqual = 6,
+        GreaterEqual = 7,
+        Always = 8,
+    };
+}

--- a/src/mod/externals/UnityEngine/Rendering/StencilOp.h
+++ b/src/mod/externals/UnityEngine/Rendering/StencilOp.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace UnityEngine::Rendering
+{
+    enum class StencilOp : int32_t {
+        Keep = 0,
+        Zero = 1,
+        Replace = 2,
+        IncrementSaturate = 3,
+        DecrementSaturate = 4,
+        Invert = 5,
+        IncrementWrap = 6,
+        DecrementWrap = 7,
+    };
+}

--- a/src/mod/externals/UnityEngine/_Object.h
+++ b/src/mod/externals/UnityEngine/_Object.h
@@ -4,7 +4,7 @@
 #include "externals/System/String.h"
 
 namespace UnityEngine {
-    struct _Object : ILClass<_Object> {
+    struct _Object : ILClass<_Object, 0x04c571f8> {
         struct Fields {
             intptr_t m_CachedPtr;
         };

--- a/src/mod/externals/XLSXContent/GrowTable.h
+++ b/src/mod/externals/XLSXContent/GrowTable.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+#include "externals/UnityEngine/ScriptableObject.h"
+
+namespace XLSXContent {
+    struct GrowTable : ILClass<GrowTable> {
+        struct SheetData : ILClass<SheetData> {
+            struct Fields {
+                System::UInt32_array* exps;
+            };
+        };
+
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            XLSXContent::GrowTable::SheetData::Array* Data;
+        };
+    };
+}

--- a/src/mod/externals/XLSXContent/LocalKoukanData.h
+++ b/src/mod/externals/XLSXContent/LocalKoukanData.h
@@ -21,7 +21,7 @@ namespace XLSXContent {
                 int32_t rand;
                 uint8_t sex;
                 int32_t language;
-                Pml_WazaNo_array* waza;
+                Pml::WazaNo_array* waza;
             };
         };
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -70,6 +70,9 @@ void exl_evolution_methods_main();
 // Redirects TM learnsets to external JSON files that contain more data.
 void exl_extended_tm_learnsets_main();
 
+// Allows dynamically changing Pokémon icons based on the Pokémon's Form Argument.
+void exl_form_arg_icons_main();
+
 // Adds new Pokémon/held item combos that trigger a form change when held.
 void exl_form_change_held_items_main();
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -121,6 +121,9 @@ void exl_settings_main();
 // Reworks the shiny rates.
 void exl_shiny_rates_main();
 
+// Hijacks the Spinda PatcheelPattern MonoBehaviour to use it with other Pokémon in different ways.
+void exl_spinda_hijacking_main();
+
 // Allows static encounters such as Rotom/Legendary Encounters/Honey Trees to have held items.
 void exl_static_held_items_main();
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -73,6 +73,9 @@ void exl_extended_tm_learnsets_main();
 // Allows dynamically changing Pokémon icons based on the Pokémon's Form Argument.
 void exl_form_arg_icons_main();
 
+// Generates Form Argument data when generating a Pokémon's InitialSpec.
+void exl_form_arg_generation_main();
+
 // Adds new Pokémon/held item combos that trigger a form change when held.
 void exl_form_change_held_items_main();
 

--- a/src/mod/features/form_argument_generation.cpp
+++ b/src/mod/features/form_argument_generation.cpp
@@ -90,6 +90,7 @@ HOOK_DEFINE_REPLACE(Factory$$InitCoreData) {
         // Form Argument
         switch (spec->fields.monsno)
         {
+            case array_index(SPECIES, "Arbok"):
             case array_index(SPECIES, "Magikarp"):
             case array_index(SPECIES, "Scatterbug"):
             case array_index(SPECIES, "Spewpa"):

--- a/src/mod/features/form_argument_generation.cpp
+++ b/src/mod/features/form_argument_generation.cpp
@@ -84,7 +84,7 @@ HOOK_DEFINE_REPLACE(Factory$$InitCoreData) {
         accessor->SetTalentSpAtk(spec->fields.talentPower->m_Items[3]);
         accessor->SetTalentSpDef(spec->fields.talentPower->m_Items[4]);
         accessor->SetTalentAgi(spec->fields.talentPower->m_Items[5]);
-        accessor->SetTokuseiNo(Pml::PokePara::CalcTool::GetTokuseiNo(spec->fields.tokuseiIndex, spec->fields.tokuseiIndex, spec->fields.tokuseiIndex));
+        accessor->SetTokuseiNo(Pml::PokePara::CalcTool::GetTokuseiNo(spec->fields.monsno, accessor->GetFormNo(), spec->fields.tokuseiIndex));
         accessor->SetTokusei1Flag(spec->fields.tokuseiIndex == 0);
         accessor->SetTokusei2Flag(spec->fields.tokuseiIndex == 1);
         accessor->SetTokusei3Flag(spec->fields.tokuseiIndex == 2);

--- a/src/mod/features/form_argument_generation.cpp
+++ b/src/mod/features/form_argument_generation.cpp
@@ -1,0 +1,113 @@
+#include "exlaunch.hpp"
+
+#include "data/species.h"
+#include "data/utils.h"
+
+#include "externals/DPData/Form_Enums.h"
+#include "externals/PlayerWork.h"
+#include "externals/Pml/Personal/GrowTableExtensions.h"
+#include "externals/Pml/Personal/PersonalSystem.h"
+#include "externals/Pml/PmlUse.h"
+#include "externals/Pml/PokePara/Accessor.h"
+#include "externals/Pml/PokePara/CalcTool.h"
+#include "externals/Pml/PokePara/InitialSpec.h"
+#include "logger/logger.h"
+#include "romdata/romdata.h"
+
+HOOK_DEFINE_REPLACE(Factory$$InitCoreData) {
+    static void Callback(System::Byte_array* coreData, Pml::PokePara::InitialSpec::Object* spec) {
+        system_load_typeinfo(0x47e3);
+        Pml::PmlUse::getClass()->initIfNeeded();
+        Pml::PokePara::CalcTool::getClass()->initIfNeeded();
+        Pml::Personal::PersonalSystem::getClass()->initIfNeeded();
+        PlayerWork::getClass()->initIfNeeded();
+
+        auto accessor = Pml::PokePara::Accessor::newInstance();
+        accessor->AttachDecodedData(coreData, nullptr);
+        if (spec->fields.monsno == array_index(SPECIES, "-SPECIES ZERO-"))
+            return;
+
+        accessor->SetPersonalRnd(spec->fields.personalRnd);
+        accessor->SetID(spec->fields.id);
+        accessor->SetColorRnd(spec->fields.rareRnd);
+        accessor->SetMonsNo(spec->fields.monsno);
+
+        // Form No
+        switch (spec->fields.monsno)
+        {
+            case array_index(SPECIES, "Toxtricity"):
+            {
+                if (spec->fields.formno == 255)
+                {
+                    if (Pml::PokePara::CalcTool::IsSeikakuHigh(spec->fields.seikaku))
+                        accessor->SetFormNo((uint16_t)ToxtricityForm::AMPED);
+                    else if (Pml::PokePara::CalcTool::IsSeikakuLow(spec->fields.seikaku))
+                        accessor->SetFormNo((uint16_t)ToxtricityForm::LOW_KEY);
+                    else
+                        accessor->SetFormNo(spec->fields.formno);
+                }
+                else
+                {
+                    accessor->SetFormNo(spec->fields.formno);
+                }
+            }
+            break;
+
+            default:
+            {
+                if (spec->fields.formno == 255)
+                    accessor->SetFormNo(RollForForm(spec->fields.monsno, PlayerWork::get_zoneID()));
+                else
+                    accessor->SetFormNo(spec->fields.formno);
+            }
+            break;
+        }
+
+        accessor->SetLevel(spec->fields.level);
+        accessor->SetSeikaku(spec->fields.seikaku);
+        accessor->SetSeikakuHosei(spec->fields.seikaku);
+        accessor->SetSex((Pml::Sex)spec->fields.sex);
+        accessor->SetGetLevel(spec->fields.level);
+        accessor->SetCassetteVersion(0);
+        accessor->SetFriendship(spec->fields.friendship);
+        accessor->SetLangID((uint8_t)Pml::PmlUse::get_Instance()->get_LangId());
+        accessor->SetEquipRibbonNo(0xFF);
+        accessor->SetTalentHp(spec->fields.talentPower->m_Items[0]);
+        accessor->SetTalentAtk(spec->fields.talentPower->m_Items[1]);
+        accessor->SetTalentDef(spec->fields.talentPower->m_Items[2]);
+        accessor->SetTalentSpAtk(spec->fields.talentPower->m_Items[3]);
+        accessor->SetTalentSpDef(spec->fields.talentPower->m_Items[4]);
+        accessor->SetTalentAgi(spec->fields.talentPower->m_Items[5]);
+        accessor->SetTokuseiNo(Pml::PokePara::CalcTool::GetTokuseiNo(spec->fields.tokuseiIndex, spec->fields.tokuseiIndex, spec->fields.tokuseiIndex));
+        accessor->SetTokusei1Flag(spec->fields.tokuseiIndex == 0);
+        accessor->SetTokusei2Flag(spec->fields.tokuseiIndex == 1);
+        accessor->SetTokusei3Flag(spec->fields.tokuseiIndex == 2);
+        accessor->SetFavoriteFlag(false);
+        accessor->SetExp(Pml::Personal::GrowTableExtensions::GetMinExp(Pml::Personal::PersonalSystem::GetGrowTable(spec->fields.monsno, spec->fields.formno), spec->fields.level));
+        accessor->SetTalentHeight(spec->fields.height);
+        accessor->SetTalentWeight(spec->fields.weight);
+
+        // Form Argument
+        switch (spec->fields.monsno)
+        {
+            case array_index(SPECIES, "Magikarp"):
+            case array_index(SPECIES, "Scatterbug"):
+            case array_index(SPECIES, "Spewpa"):
+            case array_index(SPECIES, "Alcremie"):
+            {
+                accessor->SetMultiPurposeWork(RollForVariant(spec->fields.monsno, spec->fields.formno, PlayerWork::get_zoneID()));
+            }
+            break;
+
+            default:
+            {
+                accessor->SetMultiPurposeWork(0);
+            }
+            break;
+        }
+    }
+};
+
+void exl_form_arg_generation_main() {
+    Factory$$InitCoreData::InstallAtOffset(0x02054140);
+}

--- a/src/mod/features/form_argument_pokemon_icons.cpp
+++ b/src/mod/features/form_argument_pokemon_icons.cpp
@@ -26,6 +26,7 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
         {
             case array_index(SPECIES, "Magikarp"):
             {
+                // TODO: Change this to be a proper two digit number please :(
                 uint32_t formArg = coreParam->GetMultiPurposeWork();
                 assetName = System::String::Concat(assetName, System::String::Create("_0" + nn::to_string(formArg)));
             }
@@ -39,7 +40,7 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
             break;
         }
 
-        Logger::log("Looking for icon %s", assetName->asCString().c_str());
+        Logger::log("Looking for icon %s\n", assetName->asCString().c_str());
         auto sprite = __this->GetAtlasSprite(SpriteAtlasID::TEXTUREMASS, assetName);
         onComplete->Invoke((Il2CppObject*)sprite);
     }

--- a/src/mod/features/form_argument_pokemon_icons.cpp
+++ b/src/mod/features/form_argument_pokemon_icons.cpp
@@ -20,22 +20,23 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
         bool isEgg = coreParam->IsEgg(Pml::PokePara::EggCheckType::BOTH_EGG);
 
         auto data = __this->GetPokemonIconData(monsno, formno, sex, rareType, isEgg);
-        auto assetName = data->fields.AssetName;
+        System::String::Object* assetName = nullptr;
 
         switch (monsno)
         {
+            case array_index(SPECIES, "Arbok"):
             case array_index(SPECIES, "Magikarp"):
+            case array_index(SPECIES, "Alcremie"):
             {
                 // TODO: Change this to be a proper two digit number please :(
                 uint32_t formArg = coreParam->GetMultiPurposeWork();
-                assetName = System::String::Concat(assetName, System::String::Create("_0" + nn::to_string(formArg)));
+                assetName = System::String::Concat(data->fields.AssetName, System::String::Create("_0" + nn::to_string(formArg)));
             }
             break;
 
-            case array_index(SPECIES, "Alcremie"):
+            default:
             {
-                uint32_t formArg = coreParam->GetMultiPurposeWork();
-                assetName = System::String::Concat(assetName, System::String::Create("_0" + nn::to_string(formArg)));
+                assetName = data->fields.AssetName;
             }
             break;
         }

--- a/src/mod/features/form_argument_pokemon_icons.cpp
+++ b/src/mod/features/form_argument_pokemon_icons.cpp
@@ -26,11 +26,11 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
         {
             case array_index(SPECIES, "Arbok"):
             case array_index(SPECIES, "Magikarp"):
+            //case array_index(SPECIES, "Gyarados"): TODO: Eventually add Gyarados icons to this
             case array_index(SPECIES, "Alcremie"):
             {
-                // TODO: Change this to be a proper two digit number please :(
                 uint32_t formArg = coreParam->GetMultiPurposeWork();
-                assetName = System::String::Concat(data->fields.AssetName, System::String::Create("_0" + nn::to_string(formArg)));
+                assetName = System::String::Concat(data->fields.AssetName, System::String::Create("_0" + nn::to_string(formArg, "%02d")));
             }
             break;
 
@@ -41,7 +41,6 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
             break;
         }
 
-        Logger::log("Looking for icon %s\n", assetName->asCString().c_str());
         auto sprite = __this->GetAtlasSprite(SpriteAtlasID::TEXTUREMASS, assetName);
         onComplete->Invoke((Il2CppObject*)sprite);
     }

--- a/src/mod/features/form_argument_pokemon_icons.cpp
+++ b/src/mod/features/form_argument_pokemon_icons.cpp
@@ -1,0 +1,50 @@
+#include "exlaunch.hpp"
+
+#include "data/species.h"
+#include "data/utils.h"
+
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/Events/UnityAction.h"
+#include "logger/logger.h"
+
+HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
+    static void Callback(Dpr::UI::UIManager::Object* __this, Pml::PokePara::PokemonParam::Object* pokemonParam, UnityEngine::Events::UnityAction::Object* onComplete) {
+        system_load_typeinfo(0x9c0b);
+
+        auto coreParam = (Pml::PokePara::CoreParam::Object*)pokemonParam;
+        int32_t monsno = coreParam->GetMonsNo();
+        uint16_t formno = coreParam->GetFormNo();
+        Pml::Sex sex = coreParam->GetSex();
+        Pml::PokePara::RareType rareType = coreParam->GetRareType();
+        bool isEgg = coreParam->IsEgg(Pml::PokePara::EggCheckType::BOTH_EGG);
+
+        auto data = __this->GetPokemonIconData(monsno, formno, sex, rareType, isEgg);
+        auto assetName = data->fields.AssetName;
+
+        switch (monsno)
+        {
+            case array_index(SPECIES, "Magikarp"):
+            {
+                uint32_t formArg = coreParam->GetMultiPurposeWork();
+                assetName = System::String::Concat(assetName, System::String::Create("_0" + nn::to_string(formArg)));
+            }
+            break;
+
+            case array_index(SPECIES, "Alcremie"):
+            {
+                uint32_t formArg = coreParam->GetMultiPurposeWork();
+                assetName = System::String::Concat(assetName, System::String::Create("_0" + nn::to_string(formArg)));
+            }
+            break;
+        }
+
+        Logger::log("Looking for icon %s", assetName->asCString().c_str());
+        auto sprite = __this->GetAtlasSprite(SpriteAtlasID::TEXTUREMASS, assetName);
+        onComplete->Invoke((Il2CppObject*)sprite);
+    }
+};
+
+void exl_form_arg_icons_main() {
+    UIManager$$LoadSpritePokemon_PokemonParam::InstallAtOffset(0x017c3e40);
+}

--- a/src/mod/features/form_argument_pokemon_icons.cpp
+++ b/src/mod/features/form_argument_pokemon_icons.cpp
@@ -30,7 +30,7 @@ HOOK_DEFINE_REPLACE(UIManager$$LoadSpritePokemon_PokemonParam) {
             case array_index(SPECIES, "Alcremie"):
             {
                 uint32_t formArg = coreParam->GetMultiPurposeWork();
-                assetName = System::String::Concat(data->fields.AssetName, System::String::Create("_0" + nn::to_string(formArg, "%02d")));
+                assetName = System::String::Concat(data->fields.AssetName, System::String::Create("_" + nn::to_string(formArg, "%02d")));
             }
             break;
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -96,6 +96,8 @@ void CallFeatureHooks()
         exl_local_trades_main();
     if (IsActivatedFeature(array_index(FEATURES, "Spinda Hijacking")))
         exl_spinda_hijacking_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Form Argument Pokémon Icons")))
+        exl_form_arg_icons_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -94,6 +94,8 @@ void CallFeatureHooks()
         exl_relumi_dex_ui();
     if (IsActivatedFeature(array_index(FEATURES, "Local Trades Extension")))
         exl_local_trades_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Spinda Hijacking")))
+        exl_spinda_hijacking_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -98,6 +98,8 @@ void CallFeatureHooks()
         exl_spinda_hijacking_main();
     if (IsActivatedFeature(array_index(FEATURES, "Form Argument Pokémon Icons")))
         exl_form_arg_icons_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Form Argument Generation")))
+        exl_form_arg_generation_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/more_evolution_methods.cpp
+++ b/src/mod/features/more_evolution_methods.cpp
@@ -1,6 +1,7 @@
 #include "exlaunch.hpp"
 
 #include "data/items.h"
+#include "data/species.h"
 #include "data/types.h"
 #include "data/utils.h"
 #include "externals/DPData/Form_Enums.h"
@@ -134,53 +135,52 @@ bool HasHighContestCondition(Pml::PokePara::CoreParam::Object* poke)
            poke->fields.m_accessor->GetStrong() >= 170;
 }
 
-uint16_t GetAlcremieForm(Pml::PokePara::CoreParam::Object* poke)
+AlcremieCream GetAlcremieCream(Pml::PokePara::CoreParam::Object* poke)
 {
-    AlcremieCream cream;
     if (poke->fields.m_accessor->GetStyle() >= 170)
     {
-        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) cream = AlcremieCream::RUBY_CREAM;
-        else if (extraEvoData.currentEvolutionSituation.isNight) cream = AlcremieCream::SALTED_CREAM;
+        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::RUBY_CREAM;
+        else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::SALTED_CREAM;
     }
     else if (poke->fields.m_accessor->GetBeautiful() >= 170)
     {
-        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) cream = AlcremieCream::RUBY_SWIRL;
-        else if (extraEvoData.currentEvolutionSituation.isNight) cream = AlcremieCream::MINT_CREAM;
+        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::RUBY_SWIRL;
+        else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::MINT_CREAM;
     }
     else if (poke->fields.m_accessor->GetCute() >= 170)
     {
-        cream = AlcremieCream::RAINBOW_SWIRL;
+        return AlcremieCream::RAINBOW_SWIRL;
     }
     else if (poke->fields.m_accessor->GetClever() >= 170)
     {
-        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) cream = AlcremieCream::VANILLA_CREAM;
-        else if (extraEvoData.currentEvolutionSituation.isNight) cream = AlcremieCream::MATCHA_CREAM;
+        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::VANILLA_CREAM;
+        else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::MATCHA_CREAM;
     }
     else if (poke->fields.m_accessor->GetStrong() >= 170)
     {
-        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) cream = AlcremieCream::CARAMEL_SWIRL;
-        else if (extraEvoData.currentEvolutionSituation.isNight) cream = AlcremieCream::LEMON_CREAM;
+        if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::CARAMEL_SWIRL;
+        else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::LEMON_CREAM;
     }
-    else cream = AlcremieCream::VANILLA_CREAM;
+    else return AlcremieCream::VANILLA_CREAM;
+}
 
-    AlcremieSweet sweet;
+AlcremieSweet GetAlcremieSweet(Pml::PokePara::CoreParam::Object* poke)
+{
     if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Strawberry Sweet"))
-        sweet = AlcremieSweet::STRAWBERRY_SWEET;
+        return AlcremieSweet::STRAWBERRY_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Berry Sweet"))
-        sweet = AlcremieSweet::BERRY_SWEET;
+        return AlcremieSweet::BERRY_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Love Sweet"))
-        sweet = AlcremieSweet::LOVE_SWEET;
+        return AlcremieSweet::LOVE_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Star Sweet"))
-        sweet = AlcremieSweet::STAR_SWEET;
+        return AlcremieSweet::STAR_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Clover Sweet"))
-        sweet = AlcremieSweet::CLOVER_SWEET;
+        return AlcremieSweet::CLOVER_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Flower Sweet"))
-        sweet = AlcremieSweet::FLOWER_SWEET;
+        return AlcremieSweet::FLOWER_SWEET;
     else if (poke->fields.m_accessor->GetItemNo() == (uint32_t)array_index(ITEMS, "Ribbon Sweet"))
-        sweet = AlcremieSweet::RIBBON_SWEET;
-    else sweet = AlcremieSweet::STRAWBERRY_SWEET;
-
-    return (uint16_t)cream * 7 + (uint16_t)sweet;
+        return AlcremieSweet::RIBBON_SWEET;
+    else return AlcremieSweet::STRAWBERRY_SWEET;
 }
 
 int32_t FindExtraDataByPoke(Pml::PokePara::CoreParam::Object* poke)
@@ -288,6 +288,7 @@ HOOK_DEFINE_REPLACE(IsSatisfyEvolveConditionLevelUp) {
 
             case Pml::Personal::EvolveCond::LEVELUP: // Pure level up
             case Pml::Personal::EvolveCond::SPECIAL_LEVELUP: // Nincada level up
+            case Pml::Personal::EvolveCond::VARIANT_TO_FORM: // Variant into Form No level up
                 Logger::log("LEVELUP\n");
                 return true;
 
@@ -410,6 +411,7 @@ HOOK_DEFINE_REPLACE(IsSatisfyEvolveConditionLevelUp) {
                     Logger::log("  crits %d\n", extraEvoData.extraPartyEvoData[extraDataIndex].criticalCount);
                     return extraEvoData.extraPartyEvoData[extraDataIndex].criticalCount >= evolutionParam;
                 }
+                return false;
 
             case Pml::Personal::EvolveCond::TOTAL_DAMAGE_RECIEVED: // Total damage received in last battle
                 Logger::log("TOTAL_DAMAGE_RECIEVED\n");
@@ -548,21 +550,30 @@ HOOK_DEFINE_REPLACE(CoreParam_Evolve) {
                 __this->RemoveItem();
                 break;
 
-                // Adjust Alcremie's form
+            // Adjust Alcremie's form
             case Pml::Personal::EvolveCond::AMEZAIKU:
-                Logger::log("Fixing Alcremie form to %d!\n", GetAlcremieForm(__this));
-                __this->ChangeFormNo(GetAlcremieForm(__this), nullptr);
+                Logger::log("Fixing Alcremie form to %d!\n", GetAlcremieCream(__this));
+                __this->ChangeFormNo((uint16_t)GetAlcremieCream(__this), nullptr);
+                __this->SetMultiPurposeWork((uint32_t)GetAlcremieSweet(__this));
                 __this->RemoveItem();
                 break;
 
-                // Remove Bag Item x1
+            // Remove Bag Item x1
             case Pml::Personal::EvolveCond::BAG_ITEM_1:
+                Logger::log("Removing item from bag!\n");
                 ItemWork::SubItem(evolutionParam, 1);
                 break;
 
-                // Remove Bag Item x999
+            // Remove Bag Item x999
             case Pml::Personal::EvolveCond::BAG_ITEM_999:
+                Logger::log("Removing items from bag!\n");
                 ItemWork::SubItem(evolutionParam, 999);
+                break;
+
+            // Variant into Form No
+            case Pml::Personal::EvolveCond::VARIANT_TO_FORM:
+                Logger::log("Made form match variant!\n");
+                __this->ChangeFormNo(__this->GetMultiPurposeWork(), nullptr);
                 break;
 
             default:

--- a/src/mod/features/more_evolution_methods.cpp
+++ b/src/mod/features/more_evolution_methods.cpp
@@ -337,12 +337,12 @@ HOOK_DEFINE_REPLACE(IsSatisfyEvolveConditionLevelUp) {
 
             case Pml::Personal::EvolveCond::MALE: // Male
                 Logger::log("MALE\n");
-                return poke->GetSex() == (uint8_t)Pml::Sex::MALE;
+                return poke->GetSex() == Pml::Sex::MALE;
 
             case Pml::Personal::EvolveCond::FEMALE: // Female
             case Pml::Personal::EvolveCond::FEMALE_FORMCHANGE: // Female (Meowstic, Basculegion, Oinkologne)
                 Logger::log("FEMALE\n");
-                return poke->GetSex() == (uint8_t)Pml::Sex::FEMALE;
+                return poke->GetSex() == Pml::Sex::FEMALE;
 
             case Pml::Personal::EvolveCond::PLACE_MAGNETIC: // Special magnetic field
                 Logger::log("PLACE_MAGNETIC\n");
@@ -471,7 +471,7 @@ HOOK_DEFINE_REPLACE(IsSatisfyEvolveConditionLevelUp) {
                 Logger::log("TOTAL_DAMAGE_RECIEVED_MALE\n");
                 if (extraDataIndex != -1) {
                     Logger::log("  damage: %d\n", extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived);
-                    return extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived >= evolutionParam && poke->GetSex() == (uint8_t)Pml::Sex::MALE;
+                    return extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived >= evolutionParam && poke->GetSex() == Pml::Sex::MALE;
                 }
                 return false;
 
@@ -479,7 +479,7 @@ HOOK_DEFINE_REPLACE(IsSatisfyEvolveConditionLevelUp) {
                 Logger::log("TOTAL_DAMAGE_RECIEVED_FEMALE\n");
                 if (extraDataIndex != -1) {
                     Logger::log("  damage: %d\n", extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived);
-                    return extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived >= evolutionParam && poke->GetSex() == (uint8_t)Pml::Sex::FEMALE;
+                    return extraEvoData.extraPartyEvoData[extraDataIndex].totalDamageReceived >= evolutionParam && poke->GetSex() == Pml::Sex::FEMALE;
                 }
                 return false;
 

--- a/src/mod/features/pla_context_menu.cpp
+++ b/src/mod/features/pla_context_menu.cpp
@@ -145,13 +145,13 @@ void renamePokemon(Dpr::UI::PokemonWindow::DisplayClass25_0::Object * dispClass,
     System::String::Object * headerLabel;
     switch (corePokeParam->GetSex())
     {
-        case 0:
+        case Pml::Sex::MALE:
             headerLabel = System::String::Create("SS_strinput_006");
             break;
-        case 1:
+        case Pml::Sex::FEMALE:
             headerLabel = System::String::Create("SS_strinput_007");
             break;
-        case 2:
+        case Pml::Sex::UNKNOWN:
         default:
             headerLabel = System::String::Create("SS_strinput_005");
             break;

--- a/src/mod/features/pla_context_menu.cpp
+++ b/src/mod/features/pla_context_menu.cpp
@@ -26,7 +26,7 @@ void patchContextMenu(System::Collections::Generic::List$$ContextMenuItem_Param:
 
     Pml::PokePara::CoreParam::Object * pokemonParam;
     pokemonParam = (Pml::PokePara::CoreParam::Object *) dispClass->fields.pokemonParam;
-    System::Collections::Generic::HashSet$$Pml_WazaNo::Object * remindableWaza = pokemonParam->CollectRemindableWaza();
+    System::Collections::Generic::HashSet$$WazaNo::Object * remindableWaza = pokemonParam->CollectRemindableWaza();
 
     if (remindableWaza->fields._count > 0)
     {

--- a/src/mod/features/relearn_tms.cpp
+++ b/src/mod/features/relearn_tms.cpp
@@ -10,7 +10,7 @@
 #include "logger/logger.h"
 
 HOOK_DEFINE_TRAMPOLINE(CollectRemindableWaza) {
-    static System::Collections::Generic::HashSet$$Pml_WazaNo::Object * Callback(Pml::PokePara::CoreParam::Object *__this) {
+    static System::Collections::Generic::HashSet$$WazaNo::Object * Callback(Pml::PokePara::CoreParam::Object *__this) {
         Logger::log("CollectRemindableWaza\n");
         system_load_typeinfo(0x3199);
         

--- a/src/mod/features/relumi_dex_ui.cpp
+++ b/src/mod/features/relumi_dex_ui.cpp
@@ -23,7 +23,7 @@ UnityEngine::Sprite::Object* GetEggGroupSprite(int32_t eggGroup, int32_t langId)
     auto langStr = Dpr::Message::MessageHelper::GetLanguageVariant(langId);
     auto fullStr = System::String::Concat(prefixStr, langStr);
 
-    return Dpr::UI::UIManager::instance()->GetAtlasSprite(6, fullStr);
+    return Dpr::UI::UIManager::instance()->GetAtlasSprite(SpriteAtlasID::ZUKAN, fullStr);
 }
 
 void SetEggGroupIcons(Dpr::UI::TypePanel::Object* panel1, Dpr::UI::TypePanel::Object* panel2, int32_t eggGroup1, int32_t eggGroup2, int32_t getStatus, int32_t langId)

--- a/src/mod/features/relumi_dex_ui.cpp
+++ b/src/mod/features/relumi_dex_ui.cpp
@@ -28,8 +28,6 @@ UnityEngine::Sprite::Object* GetEggGroupSprite(int32_t eggGroup, int32_t langId)
 
 void SetEggGroupIcons(Dpr::UI::TypePanel::Object* panel1, Dpr::UI::TypePanel::Object* panel2, int32_t eggGroup1, int32_t eggGroup2, int32_t getStatus, int32_t langId)
 {
-    Logger::log("SetEggGroupIcons\n");
-
     Dpr::Message::MessageManager::getClass()->initIfNeeded();
 
     if (langId == 11)
@@ -78,8 +76,6 @@ void SetEggGroupIcons(Dpr::UI::TypePanel::Object* panel1, Dpr::UI::TypePanel::Ob
 
 void SetEggGroupIconsFromZukanInfo(Dpr::UI::ZukanInfo::Object* zukanInfo, XLSXContent::PersonalTable::SheetPersonal::Object* personalData, UnityEngine::Transform::Object* statusTf, int32_t langId)
 {
-    Logger::log("SetEggGroupIconsFromZukanInfo\n");
-
     system_load_typeinfo(0x870a);
     system_load_typeinfo(0x505e);
 
@@ -148,8 +144,6 @@ HOOK_DEFINE_TRAMPOLINE(ZukanInfo$$SetupUITexts) {
                          Dpr::UI::UIText::Object* weightText, Dpr::UI::UIText::Object* descText, Dpr::UI::UIText::Object* formNameText) {
         Orig(__this, nameText, classText, heightText, weightText, descText, formNameText);
 
-        Logger::log("ZukanInfo$$SetupUITexts\n");
-
         // We need this UIText to go back up the hierarchy
         // This is null in the compare panel, so we just stop here.
         if (classText == nullptr)
@@ -201,8 +195,6 @@ HOOK_DEFINE_TRAMPOLINE(ZukanDescriptionPanel$$OnSelectLanguageButton) {
     static void Callback(Dpr::UI::ZukanDescriptionPanel::Object* __this, Dpr::UI::ZukanLanguageButton::Object* button) {
         Orig(__this, button);
 
-        Logger::log("ZukanDescriptionPanel$$OnSelectLanguageButton\n");
-
         system_load_typeinfo(0x505e);
 
         if (UnityEngine::_Object::op_Equality((UnityEngine::_Object::Object*)button, nullptr))
@@ -238,8 +230,6 @@ HOOK_DEFINE_TRAMPOLINE(ZukanDescriptionPanel$$MoveCatalogSelect) {
     static bool Callback(Dpr::UI::ZukanDescriptionPanel::Object* __this, int32_t addValue) {
         if (!Orig(__this, addValue))
             return false;
-
-        Logger::log("ZukanDescriptionPanel$$MoveCatalogSelect\n");
 
         system_load_typeinfo(0x505e);
 

--- a/src/mod/features/spinda_hijacking.cpp
+++ b/src/mod/features/spinda_hijacking.cpp
@@ -1,0 +1,85 @@
+#include "exlaunch.hpp"
+
+#include "data/species.h"
+#include "data/utils.h"
+
+#include "externals/Dpr/PatcheelPattern.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/PokemonCustomNodeAnim.h"
+#include "externals/UnityEngine/GameObject.h"
+#include "logger/logger.h"
+
+HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
+    // Third argument is normally a MethodInfo, we are sneaking in the PokemonParam in there :)
+    static void Callback(Dpr::PatcheelPattern::Object* __this, uint32_t personalRand, Pml::PokePara::PokemonParam::Object* param) {
+        if (param == nullptr)
+        {
+            Logger::log("[PatcheelPattern$$SetPattern] Did not receive a PokemonParam...\n");
+            Orig(__this, personalRand, nullptr);
+        }
+        else
+        {
+            switch(((Pml::PokePara::CoreParam::Object*)param)->GetMonsNo())
+            {
+                case array_index(SPECIES, "Spinda"):
+                {
+                    Logger::log("[PatcheelPattern$$SetPattern] Spinda\n");
+                    Orig(__this, personalRand, nullptr);
+                }
+
+                case array_index(SPECIES, "Arbok"):
+                {
+                    Logger::log("[PatcheelPattern$$SetPattern] Arbok\n");
+                    // TODO
+                }
+
+                case array_index(SPECIES, "Magikarp"):
+                {
+                    Logger::log("[PatcheelPattern$$SetPattern] Magikarp\n");
+
+                    auto go = ((UnityEngine::Component::Object *) __this)->get_gameObject()->instance();
+                    auto nodes = go->GetComponent(UnityEngine::Component::Method$$PokemonCustomNodeAnim$$GetComponent)->fields.mCustomNodeMaterials;
+
+                    nn::vector<UnityEngine::Material::Object*> patcheelMats;
+                    for (uint64_t i=0; i<nodes->max_length; i++)
+                    {
+                        if (nodes->m_Items[i]->fields.shaderName->asCString() == "Patcheel")
+                            patcheelMats.push_back(nodes->m_Items[i]->fields.mp->fields.mat);
+                    }
+
+                    if (patcheelMats.size() > 0)
+                    {
+                        uint32_t id = personalRand % patcheelMats.size();
+                        for (uint64_t i=0; i<__this->fields.UVDatas->max_length; i++)
+                            ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->renderer)->set_material(patcheelMats[id]);
+                    }
+                }
+            }
+        }
+    }
+};
+
+HOOK_DEFINE_REPLACE(PatcheelPattern$$Awake) {
+    static void Callback(Dpr::PatcheelPattern::Object* __this) {
+        // Do nothing for now
+    }
+};
+
+void exl_spinda_hijacking_main() {
+    PatcheelPattern$$SetPattern::InstallAtOffset(0x01bcb200);
+
+    using namespace exl::armv8::inst;
+    using namespace exl::armv8::reg;
+    exl::patch::CodePatcher p(0);
+    auto inst = nn::vector<exl::patch::Instruction> {
+        { 0x01e520f0, MovRegister(X2, X20) }, // BOPokemon$$Initialize
+        { 0x01d779f8, MovRegister(X2, X2) }, // BattlePokemonEntity$$SetPatcheelPattern
+        { 0x01d77a0c, MovRegister(X2, X2) }, // BattlePokemonEntity$$SetPatcheelPattern
+        { 0x01add5ac, LdrRegisterImmediate(X2, X20, 0x19 /*X20 + 0xC8*/) }, // Demo_PoffinEat.<Enter>d__16$$MoveNext
+        { 0x01cd94f0, MovRegister(X2, X26) }, // FieldWalkingManager.<CreatePartner>d__43$$MoveNext
+        { 0x01a7fc10, LdrRegisterImmediate(X2, X19, 0x6 /*X19 + 0x30*/) }, // FureaiHiroba_PokeFactory.<AddPoke>d__10$$MoveNext
+        { 0x01a104b8, MovRegister(X2, X19) }, // UIModelViewController$$_SetupPokemonModel
+        { 0x018d6068, LdrRegisterImmediate(X2, X8, 0x2 /*X8 + 0x10*/) }, // UgMainProc.<>c__DisplayClass9_0$$<CreatePoke>b__0
+    };
+    p.WriteInst(inst);
+}

--- a/src/mod/features/spinda_hijacking.cpp
+++ b/src/mod/features/spinda_hijacking.cpp
@@ -30,31 +30,37 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                 break;
 
                 case array_index(SPECIES, "Arbok"):
-                {
-                    Logger::log("[PatcheelPattern$$SetPattern] Arbok\n");
-                    // TODO
-                }
-                break;
-
                 case array_index(SPECIES, "Magikarp"):
                 {
                     Logger::log("[PatcheelPattern$$SetPattern] Magikarp\n");
+                    system_load_typeinfo(0x7deb);
+                    system_load_typeinfo(0x1e84);
+                    system_load_typeinfo(0x1e8d);
+                    system_load_typeinfo(0x221b);
+                    system_load_typeinfo(0x6d4d);
 
                     auto go = ((UnityEngine::Component::Object *) __this)->get_gameObject()->instance();
-                    auto nodes = go->GetComponent(UnityEngine::Component::Method$$PokemonCustomNodeAnim$$GetComponent)->fields.mCustomNodeMaterials;
+                    auto renderers = go->GetComponentsInChildren(true, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
 
-                    auto patcheelMats = nn::vector<UnityEngine::Material::Object*>();
-                    for (uint64_t i=0; i<nodes->max_length; i++)
+                    UnityEngine::Renderer::Object* renderer = nullptr;
+                    if (renderers != nullptr)
                     {
-                        if (nodes->m_Items[i]->fields.shaderName->asCString() == "Patcheel")
-                            patcheelMats.push_back(nodes->m_Items[i]->fields.mp->fields.mat);
+                        for (uint64_t i=0; i<renderers->max_length; i++)
+                        {
+                            renderer = (UnityEngine::Renderer::Object*)renderers->m_Items[i];
+                            if (((UnityEngine::_Object::Object*)renderer)->GetName()->asCString().find("Patcheel") != -1)
+                                break;
+                        }
                     }
 
-                    if (patcheelMats.size() > 0)
+                    if (renderer != nullptr)
                     {
-                        uint32_t id = personalRand % patcheelMats.size();
+                        auto patcheelMats = renderer->get_sharedMaterials();
+                        uint32_t id = personalRand % patcheelMats->max_length;
+                        Logger::log("[PatcheelPattern$$SetPattern] Using id %d\n", id);
+
                         for (uint64_t i=0; i<__this->fields.UVDatas->max_length; i++)
-                            ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->renderer)->set_material(patcheelMats[id]);
+                            ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->fields.renderer)->set_sharedMaterial(patcheelMats->m_Items[id]);
                     }
                 }
                 break;
@@ -66,6 +72,7 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
 HOOK_DEFINE_REPLACE(BattlePokemonEntity$$SetPatcheelPattern) {
     // Third argument is normally a MethodInfo, we are sneaking in the PokemonParam in there :)
     static void Callback(BattlePokemonEntity::Object* __this, uint32_t rand, Pml::PokePara::PokemonParam::Object* param) {
+        Logger::log("BattlePokemonEntity$$SetPatcheelPattern\n");
         system_load_typeinfo(0x2226);
         UnityEngine::_Object::getClass()->initIfNeeded();
 

--- a/src/mod/features/spinda_hijacking.cpp
+++ b/src/mod/features/spinda_hijacking.cpp
@@ -13,6 +13,9 @@
 HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
     // Third argument is normally a MethodInfo, we are sneaking in the PokemonParam in there :)
     static void Callback(Dpr::PatcheelPattern::Object* __this, uint32_t personalRand, Pml::PokePara::PokemonParam::Object* param) {
+        system_load_typeinfo(0x7deb);
+        system_load_typeinfo(0x6d4d);
+
         if (param == nullptr)
         {
             Logger::log("[PatcheelPattern$$SetPattern] Did not receive a PokemonParam...\n");
@@ -33,11 +36,6 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                 case array_index(SPECIES, "Magikarp"):
                 {
                     Logger::log("[PatcheelPattern$$SetPattern] Magikarp\n");
-                    system_load_typeinfo(0x7deb);
-                    system_load_typeinfo(0x1e84);
-                    system_load_typeinfo(0x1e8d);
-                    system_load_typeinfo(0x221b);
-                    system_load_typeinfo(0x6d4d);
 
                     auto go = ((UnityEngine::Component::Object *) __this)->get_gameObject()->instance();
                     auto renderers = go->GetComponentsInChildren(true, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
@@ -68,11 +66,6 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                 case array_index(SPECIES, "Alcremie"):
                 {
                     Logger::log("[PatcheelPattern$$SetPattern] Alcremie\n");
-                    system_load_typeinfo(0x7deb);
-                    system_load_typeinfo(0x1e84);
-                    system_load_typeinfo(0x1e8d);
-                    system_load_typeinfo(0x221b);
-                    system_load_typeinfo(0x6d4d);
 
                     uint32_t id = ((Pml::PokePara::CoreParam::Object*)param)->GetMultiPurposeWork();
                     Logger::log("[PatcheelPattern$$SetPattern] Using id %d\n", id);

--- a/src/mod/features/spinda_hijacking.cpp
+++ b/src/mod/features/spinda_hijacking.cpp
@@ -56,12 +56,29 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                     if (renderer != nullptr)
                     {
                         auto patcheelMats = renderer->get_sharedMaterials();
-                        uint32_t id = personalRand % patcheelMats->max_length;
+                        uint32_t id = ((Pml::PokePara::CoreParam::Object*)param)->GetMultiPurposeWork() % patcheelMats->max_length;
                         Logger::log("[PatcheelPattern$$SetPattern] Using id %d\n", id);
 
                         for (uint64_t i=0; i<__this->fields.UVDatas->max_length; i++)
                             ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->fields.renderer)->set_sharedMaterial(patcheelMats->m_Items[id]);
                     }
+                }
+                break;
+
+                case array_index(SPECIES, "Alcremie"):
+                {
+                    Logger::log("[PatcheelPattern$$SetPattern] Alcremie\n");
+                    system_load_typeinfo(0x7deb);
+                    system_load_typeinfo(0x1e84);
+                    system_load_typeinfo(0x1e8d);
+                    system_load_typeinfo(0x221b);
+                    system_load_typeinfo(0x6d4d);
+
+                    uint32_t id = ((Pml::PokePara::CoreParam::Object*)param)->GetMultiPurposeWork();
+                    Logger::log("[PatcheelPattern$$SetPattern] Using id %d\n", id);
+
+                    for (int i=0; i<__this->fields.UVDatas->max_length; i++)
+                        ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->fields.renderer)->set_enabled(i == id);
                 }
                 break;
             }

--- a/src/mod/features/uniform_ui.cpp
+++ b/src/mod/features/uniform_ui.cpp
@@ -1,49 +1,33 @@
 #include "exlaunch.hpp"
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Contest/ContestPlayerEntity.h"
 #include "externals/Dpr/UI/UIManager.h"
+#include "externals/Dpr/UI/ZukanCompareWeightController.h"
 #include "externals/PlayerWork.h"
 #include "externals/XLSXContent/UIDatabase.h"
 
 #include "logger/logger.h"
 
 System::String::Object* GetWeightSpriteName() {
-    if (PlayerWork::get_playerSex())
-    {
-        // Lucas
+    if (PlayerWork::get_playerSex()) // Lucas
         return System::String::Create("dex_ico_compare_player_01_000_00");
-    }
-    else
-    {
-        // Dawn
+    else // Dawn
         return System::String::Create("dex_ico_compare_player_01_100_00");
-    }
 }
 
 System::String::Object* GetTownMapSpriteName() {
-    if (PlayerWork::get_playerSex())
-    {
-        // Lucas
+    if (PlayerWork::get_playerSex()) // Lucas
         return System::String::Create("map_ico_player_01_000_00");
-    }
-    else
-    {
-        // Dawn
+    else // Dawn
         return System::String::Create("map_ico_player_01_100_00");
-    }
 }
 
 System::String::Object* GetEncSeqPath() {
-    if (PlayerWork::get_playerSex())
-    {
-        // Lucas
+    if (PlayerWork::get_playerSex()) // Lucas
         return System::String::Create("encseq/tex/p0000");
-    }
-    else
-    {
-        // Dawn
+    else // Dawn
         return System::String::Create("encseq/tex/p0100");
-    }
 }
 
 XLSXContent::UIDatabase::SheetCharacterBag::Object* FindBagDataById(XLSXContent::UIDatabase::SheetCharacterBag::Array* source, int id)
@@ -64,16 +48,14 @@ HOOK_DEFINE_REPLACE(Dpr_UI_UIManager_GetCharacterBagData) {
 
         XLSXContent::UIDatabase::SheetCharacterBag::Array* characterBags = __this->fields._mdUis->fields.CharacterBag;
 
-        if (PlayerWork::get_playerSex())
+        if (PlayerWork::get_playerSex()) // Lucas
         {
-            // Lucas
             XLSXContent::UIDatabase::SheetCharacterBag::Object* item = FindBagDataById(characterBags, 0);
             if (item != nullptr) return item;
             else return characterBags->m_Items[0]; // Shouldn't happen
         }
-        else
+        else // Dawn
         {
-            // Dawn
             XLSXContent::UIDatabase::SheetCharacterBag::Object* item = FindBagDataById(characterBags, 100);
             if (item != nullptr) return item;
             else return characterBags->m_Items[0]; // Shouldn't happen
@@ -90,6 +72,43 @@ HOOK_DEFINE_REPLACE(Dpr_UI_UIManager_LoadSpritePokemonDot) {
 HOOK_DEFINE_REPLACE(Dpr_UI_UIManager_LoadSpritePokemonLarge) {
     static void Callback(Dpr::UI::UIManager::Object* __this, int32_t monsNo, uint16_t formNo, uint8_t sex, uint8_t rareType, bool isEgg, UnityEngine::Events::UnityAction::Object* onComplete) {
         __this->LoadSpritePokemon(monsNo, formNo, sex, rareType, isEgg, onComplete);
+    }
+};
+
+HOOK_DEFINE_REPLACE(Dpr_UI_UIManager_LoadSpritePokemonDotParam) {
+    static void Callback(Dpr::UI::UIManager::Object* __this, Pml::PokePara::PokemonParam::Object* pokemonParam, UnityEngine::Events::UnityAction::Object* onComplete) {
+        __this->LoadSpritePokemon(pokemonParam, onComplete);
+    }
+};
+
+HOOK_DEFINE_REPLACE(Dpr_UI_UIManager_LoadSpritePokemonLargeParam) {
+    static void Callback(Dpr::UI::UIManager::Object* __this, Pml::PokePara::PokemonParam::Object* pokemonParam, UnityEngine::Events::UnityAction::Object* onComplete) {
+        __this->LoadSpritePokemon(pokemonParam, onComplete);
+    }
+};
+
+HOOK_DEFINE_REPLACE(ContestPlayerEntity$$AppendLoadPokemonIcon) {
+    static void Callback(Dpr::Contest::ContestPlayerEntity::Object* __this) {
+        system_load_typeinfo(0x2fc3);
+        Dpr::UI::UIManager::getClass()->initIfNeeded();
+
+        auto uiManager = Dpr::UI::UIManager::instance();
+        auto param = __this->fields.playerData->fields.pokemonInfo->fields.pokeParam;
+
+        auto callback = UnityEngine::Events::UnityAction::getClass(UnityEngine::Events::UnityAction::Sprite_TypeInfo)
+                ->newInstance(__this, *Dpr::Contest::ContestPlayerEntity::Method$$AppendLoadPokemonIcon_b_99);
+
+        uiManager->LoadSpritePokemon(param, callback);
+    }
+};
+
+HOOK_DEFINE_INLINE(ZukanCompareWeightController$$RequestLoadModel) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto uiManager = (Dpr::UI::UIManager::Object*)ctx->X[0];
+        auto param = ((Dpr::UI::ZukanCompareWeightController::Object*)ctx->X[19])->fields.currentZukanInfo->GetCurrentPokemonParam();
+        auto callback = (UnityEngine::Events::UnityAction::Object*)ctx->X[6];
+
+        uiManager->LoadSpritePokemon(param, callback);
     }
 };
 
@@ -115,4 +134,20 @@ void exl_uniform_ui_main() {
     // Repoint Large and DP/Pixel sprites to base one
     Dpr_UI_UIManager_LoadSpritePokemonDot::InstallAtOffset(0x017c46a0);
     Dpr_UI_UIManager_LoadSpritePokemonLarge::InstallAtOffset(0x017c4140);
+    Dpr_UI_UIManager_LoadSpritePokemonDotParam::InstallAtOffset(0x017c4600);
+    Dpr_UI_UIManager_LoadSpritePokemonLargeParam::InstallAtOffset(0x017c4090);
+
+    // Repoint all LoadSpritePokemon calls to the PokemonParam overload
+    ContestPlayerEntity$$AppendLoadPokemonIcon::InstallAtOffset(0x01c77ae0);
+    ZukanCompareWeightController$$RequestLoadModel::InstallAtOffset(0x01bb1a0c);
+
+    p.Seek(0x01d8e12c); // PokemonIcon$$Load
+    p.WriteInst(MovRegister(X1, X20));
+    p.WriteInst(MovRegister(X2, X21));
+    p.BranchLinkInst(0x017c3e40); // Address of LoadPokemonIcon with the PokemonParam overload
+
+    p.Seek(0x01d8e4cc); // PokemonIcon$$Load
+    p.WriteInst(MovRegister(X1, X20));
+    p.WriteInst(MovRegister(X2, X22));
+    p.BranchLinkInst(0x017c3e40); // Address of LoadPokemonIcon with the PokemonParam overload
 };

--- a/src/mod/romdata/data/ZoneRates.h
+++ b/src/mod/romdata/data/ZoneRates.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+#include "memory/json.h"
+#include "memory/vector.h"
+
+namespace RomData
+{
+    struct ZoneRates
+    {
+        nn::vector<uint32_t> rates;
+    };
+
+    JSON_TEMPLATE
+    void to_json(GENERIC_JSON& j, const ZoneRates& r) {
+        j = nn::json {
+            {"rates", r.rates},
+        };
+    }
+
+    JSON_TEMPLATE
+    void from_json(const GENERIC_JSON& j, ZoneRates& r) {
+        j.at("rates").get_to(r.rates);
+    }
+}

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -10,6 +10,7 @@
 #include "romdata/data/Starter.h"
 #include "romdata/data/TMLearnset.h"
 #include "romdata/data/UnbreakablePokeItem.h"
+#include "romdata/data/ZoneRates.h"
 
 // Returns the max level based on the given level cap index.
 uint32_t GetLevelCapLevel(uint32_t index);
@@ -61,5 +62,17 @@ RomData::Arena GetExtraArenaData(int32_t arena);
 
 // Returns the extra local trade data.
 RomData::LocalTrade GetExtraLocalTradeData(int32_t tradeId);
+
+// Returns the form rates of the given Pokémon at the given zoneID.
+nn::vector<uint32_t> GetFormRates(int32_t monsno, int32_t zoneID);
+
+// Rolls for a form based on the form rates for the given Pokémon at the given zoneID.
+int32_t RollForForm(int32_t monsno, int32_t zoneID);
+
+// Returns the variant rates of the given Pokémon at the given zoneID.
+nn::vector<uint32_t> GetVariantRates(int32_t monsno, int32_t formno, int32_t zoneID);
+
+// Rolls for a variant based on the form rates for the given Pokémon at the given zoneID.
+int32_t RollForVariant(int32_t monsno, int32_t formno, int32_t zoneID);
 
 void LoadFeaturesFromJSON(nn::json j);

--- a/src/mod/romdata/zone_rates.cpp
+++ b/src/mod/romdata/zone_rates.cpp
@@ -47,10 +47,6 @@ nn::vector<uint32_t> GetFormRates(int32_t monsno, int32_t zoneID)
 
         return zoneRates.rates;
     }
-    else
-    {
-        Logger::log("Error when parsing ZoneForm data!\n");
-    }
 
     // Default - Only Form 0
     return { 100 };
@@ -74,10 +70,6 @@ nn::vector<uint32_t> GetVariantRates(int32_t monsno, int32_t formno, int32_t zon
         zoneRates = j.get<RomData::ZoneRates>();
 
         return zoneRates.rates;
-    }
-    else
-    {
-        Logger::log("Error when parsing ZoneVariant data!\n");
     }
 
     // Default - Only Variant 0

--- a/src/mod/romdata/zone_rates.cpp
+++ b/src/mod/romdata/zone_rates.cpp
@@ -1,0 +1,91 @@
+#include "exlaunch.hpp"
+
+#include "helpers.h"
+#include "memory/json.h"
+#include "memory/string.h"
+
+#include "romdata/data/ZoneRates.h"
+
+#include "externals/UnityEngine/Random.h"
+
+#include "logger/logger.h"
+
+const char* zoneFormsFolderPath = "rom:/Data/ExtraData/Encounters/ZoneForms/";
+const char* zoneVariantsFolderPath = "rom:/Data/ExtraData/Encounters/ZoneVariants/";
+
+int32_t Roll(nn::vector<uint32_t>* rates)
+{
+    int32_t sum = 0;
+    for (auto& rate : *rates)
+        sum += rate;
+
+    auto roll = UnityEngine::Random::Range(0, sum);
+
+    int32_t currentSum = 0;
+    for (size_t i=0; i<(*rates).size(); i++)
+    {
+        if (roll < currentSum + (*rates)[i])
+            return i;
+
+        currentSum += (*rates)[i];
+    }
+
+    // Should only happen if rates is empty or all rates are 0
+    return 0;
+}
+
+nn::vector<uint32_t> GetFormRates(int32_t monsno, int32_t zoneID)
+{
+    nn::string filePath(zoneFormsFolderPath);
+    filePath.append("monsno_" + nn::to_string(monsno) + "_zone_" + nn::to_string(zoneID) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::ZoneRates zoneRates = {};
+        zoneRates = j.get<RomData::ZoneRates>();
+
+        return zoneRates.rates;
+    }
+    else
+    {
+        Logger::log("Error when parsing ZoneForm data!\n");
+    }
+
+    // Default - Only Form 0
+    return { 100 };
+}
+
+int32_t RollForForm(int32_t monsno, int32_t zoneID)
+{
+    auto rates = GetFormRates(monsno, zoneID);
+    return Roll(&rates);
+}
+
+nn::vector<uint32_t> GetVariantRates(int32_t monsno, int32_t formno, int32_t zoneID)
+{
+    nn::string filePath(zoneVariantsFolderPath);
+    filePath.append("monsno_" + nn::to_string(monsno) + "_formno_" + nn::to_string(formno) + "_zone_" + nn::to_string(zoneID) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::ZoneRates zoneRates = {};
+        zoneRates = j.get<RomData::ZoneRates>();
+
+        return zoneRates.rates;
+    }
+    else
+    {
+        Logger::log("Error when parsing ZoneVariant data!\n");
+    }
+
+    // Default - Only Variant 0
+    return { 100 };
+}
+
+int32_t RollForVariant(int32_t monsno, int32_t formno, int32_t zoneID)
+{
+    auto rates = GetVariantRates(monsno, formno, zoneID);
+    return Roll(&rates);
+}

--- a/src/mod/ui/tools/pokemon_tool.h
+++ b/src/mod/ui/tools/pokemon_tool.h
@@ -120,11 +120,11 @@ namespace ui {
                         }
                         core->SetGetBall(ball->selected);
                         if (shiny->selected == array_index(DEBUG_SHINIES, "Non-shiny"))
-                            core->SetRareType(0);
+                            core->SetRareType(Pml::PokePara::RareType::NOT_RARE);
                         else if (shiny->selected == array_index(DEBUG_SHINIES, "Shiny"))
-                            core->SetRareType(1);
+                            core->SetRareType(Pml::PokePara::RareType::CAPTURED);
                         else if (shiny->selected == array_index(DEBUG_SHINIES, "Square Shiny"))
-                            core->SetRareType(2);
+                            core->SetRareType(Pml::PokePara::RareType::DISTRIBUTED);
 
                         auto myStatus = PlayerWork::get_playerStatus();
                         auto zoneID = PlayerWork::get_zoneID();

--- a/src/mod/ui/tools/pokemon_tool.h
+++ b/src/mod/ui/tools/pokemon_tool.h
@@ -60,6 +60,12 @@ namespace ui {
                     _.max = 255;
                     _.value = 70;
                 });
+                auto *formArg = _.InputInt([](InputInt &_) {
+                    _.label = "Variant (Form Argument)";
+                    _.min = -1;
+                    _.max = 255;
+                    _.value = 0;
+                });
                 auto* customMoves = _.Checkbox([](Checkbox &_) {
                     _.label = "Custom moves";
                     _.enabled = false;
@@ -89,9 +95,9 @@ namespace ui {
                     _.selected = array_index(MOVES, "Comet Punch");
                 });
 
-                _.Button([species, form, level, ball, sex, shiny, friendship, customMoves, move1, move2, move3, move4](Button &_) {
+                _.Button([species, form, level, ball, sex, shiny, friendship, formArg, customMoves, move1, move2, move3, move4](Button &_) {
                     _.label = "Give Pokemon";
-                    _.onClick = [species, form, level, ball, sex, shiny, friendship, customMoves, move1, move2, move3, move4]() {
+                    _.onClick = [species, form, level, ball, sex, shiny, friendship, formArg, customMoves, move1, move2, move3, move4]() {
                         system_load_typeinfo(0x43be);
                         auto party = PlayerWork::get_playerParty();
 
@@ -110,6 +116,9 @@ namespace ui {
                         auto core = param->cast<Pml::PokePara::CoreParam>();
 
                         core->SetFriendship(friendship->value);
+
+                        if (formArg->value > -1)
+                            core->SetMultiPurposeWork(formArg->value);
 
                         if (customMoves->enabled)
                         {


### PR DESCRIPTION
Closes #118.

- Makes use of the unused Form Argument (also called Multi-Purpose Work) field in a Pokémon's data structure to keep track of some extra data to do with a Pokémon's form. Sometimes we'll refer to this value as the "Variant".
- Hijacks the Spinda MonoBehaviour "PatcheelPattern" to make visual changes to a Pokémon's materials and renderers depending on the values in its structure.
  - Spinda runs its vanilla code.
  - Arbok and Magikarp swap materials based on variant.
  - Alcremie enables/disables the proper renderers for its sweets.
- Makes a Pokémon's party icon change based on variant when needed.
  - Arbok, Magikarp, and Alcremie add "_xx" to the end of the sprite to look for, with xx being the variant. (01, 02, ... 12, 13, ...)
- Changes the generation of a Pokémon's Core Data to include code related to variants.
  - Form generation was changed.
    - When generated with form 255, Toxtricity generates either form 0 or form 1 depending on nature.
    - When generated with form 255, all other Pokémon randomly roll for form based on JSON files (otherwise will default to form 0)
  - Variant generation was added.
    - Vivillon will always use its form as its variant.
    - All other Pokémon will randomly roll for variant based on JSON files (otherwise will default to variant 0)
- New ExtraData for form and variant rates per zone.
  - Encounters/ZoneForms contains form rates for a monsno and zone combination.
  - Encounters/ZoneVariants contains variant rates for a monsno, formno and zone combination.
- Fixes a few stray calls to large and pixel Pokémon icons, they now properly point to the regular ones.