### PR TITLE
_ADD_POKEMON_UI_EXTRA + _POKEMON_NAME_FORM

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1259,6 +1259,7 @@ namespace Dpr::EvScript {
             _GET_COSTUME_GENDER = 1249,
             _CASE_CALL = 1250,
             _ADD_POKEMON_UI_EXTRA = 1251,
+            _POKEMON_NAME_FORM = 1252,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1258,6 +1258,7 @@ namespace Dpr::EvScript {
             _CHANGE_FORMNO = 1248,
             _GET_COSTUME_GENDER = 1249,
             _CASE_CALL = 1250,
+            _ADD_POKEMON_UI_EXTRA = 1251,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -352,6 +352,7 @@ namespace Dpr::EvScript {
         static inline StaticILMethod<0x04c77ce0, int32_t, int32_t> Method$$EvDataManager_EvCmdNameInPoke_OnInputCheck {};
         static inline StaticILMethod<0x04c7cf70, int32_t, int32_t> Method$$EvDataManager_EvCmdNameInPoke_OnComplete {};
         static inline StaticILMethod<0x04c7cfd0>                   Method$$EvDataManager_CmdFirstPokeSelectProc {};
+        static inline StaticILMethod<0x04c7cfd8, int32_t> Method$$EvDataManager_EvCmdAddPokemonUI {};
 
         inline bool RunEvCmd(int32_t index) {
             return external<bool>(0x02c5b290, this, index);

--- a/src/mod/externals/Dpr/Message/MessageManager.h
+++ b/src/mod/externals/Dpr/Message/MessageManager.h
@@ -4,6 +4,7 @@
 
 #include "externals/Dpr/Message/MessageGlossaryParseDataModel.h"
 #include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/Dpr/Message/MessageMsgFile.h"
 
 namespace Dpr::Message {
     struct MessageManager : ILClass<MessageManager, 0x04c5fe18> {
@@ -32,6 +33,10 @@ namespace Dpr::Message {
 
         inline System::String::Object* GetNameMessage(System::String::Object* fileName, System::String::Object* label) {
             return external<System::String::Object*>(0x0210ce50, this, fileName, label);
+        }
+
+        inline Dpr::Message::MessageMsgFile::Object* GetMsgFile(System::String::Object* fileName) {
+            return external<Dpr::Message::MessageMsgFile::Object*>(0x0210c050, this, fileName);
         }
     };
 }

--- a/src/mod/externals/Dpr/Message/MessageMsgFile.h
+++ b/src/mod/externals/Dpr/Message/MessageMsgFile.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "externals/il2cpp-api.h"
+#include "externals/Dpr/Message/MsbtDataModel.h"
+
+namespace Dpr::Message {
+    struct MessageMsgFile : ILClass<MessageMsgFile> {
+        struct Fields {
+            Dpr::Message::MsbtDataModel::Object* msbtDataModel;
+        };
+    };
+}

--- a/src/mod/externals/Dpr/Message/MessageWordSetHelper.h
+++ b/src/mod/externals/Dpr/Message/MessageWordSetHelper.h
@@ -4,10 +4,16 @@
 
 #include "externals/Pml/PokePara/CoreParam.h"
 #include "externals/System/String.h"
+#include "externals/Dpr/Message/MessageMsgFile.h"
+#include "externals/Dpr/Message/MessageManager.h"
 
 namespace Dpr::Message {
     struct MessageWordSetHelper : ILClass<MessageWordSetHelper, 0x04c5ac68> {
         struct Fields {
+        };
+
+        struct StaticFields {
+            Dpr::Message::MessageManager::Object* manager;
         };
 
         static inline void SetPokemonNickNameWord(int32_t tagIndex, Pml::PokePara::CoreParam::Object* pp, bool isShowNickName) {
@@ -32,6 +38,11 @@ namespace Dpr::Message {
 
         static inline void SetGlossaryWord(int32_t index, System::String::Object* msbtName, int32_t labelIndex) {
             external<void>(0x01f9c410, index, msbtName, labelIndex);
+        }
+
+        static inline void SetStringWordFromMsgFile(int32_t index, Dpr::Message::MessageMsgFile::Object* msgFile,
+                                                    int32_t labelIndex) {
+            external<void>(0x01f9f8e0, index, msgFile, labelIndex);
         }
     };
 }

--- a/src/mod/externals/Dpr/Message/MsbtDataModel.h
+++ b/src/mod/externals/Dpr/Message/MsbtDataModel.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "externals/il2cpp-api.h"
+#include "externals/System/String.h"
+
+namespace Dpr::Message {
+    struct MsbtDataModel : ILClass<MsbtDataModel, 0x04c5fd58> {
+        struct Fields {
+            int32_t langID;
+            System::String::Object* fileName;
+            int32_t hash;
+            void* labelIndexTable;
+            void* labelDataArray;
+            bool bIsResident;
+            bool bIsCreate;
+            int32_t currentIndex;
+        };
+    };
+}

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -15,6 +15,7 @@
 
 namespace Dpr::UI {
     struct ShopBoutiqueChange;
+    struct UIZukanRegister;
 }
 
 namespace Dpr::UI {
@@ -63,6 +64,7 @@ namespace Dpr::UI {
         static inline StaticILMethod<0x04c8ffe8, Dpr::UI::ShopBoutiqueChange> Method$$CreateUIWindow_ShopBoutiqueChange_ {};
         static inline StaticILMethod<0x04c90098, Dpr::UI::UIWazaManage> Method$$CreateUIWindow_UIWazaManage_ {};
 
+        static inline StaticILMethod<0x04c900a8, Dpr::UI::UIZukanRegister> Method$$CreateUIWindow_UIZukanRegister_ {};
         static inline StaticILMethod<0x04c90130, Dpr::UI::UIWindow> Method$$GetCurrentUIWindow_UIWindow_ {};
 
         template <typename T>

--- a/src/mod/externals/Dpr/UI/UIZukanRegister.h
+++ b/src/mod/externals/Dpr/UI/UIZukanRegister.h
@@ -1,0 +1,43 @@
+#pragma once
+#include "externals/il2cpp-api.h"
+#include "externals/Dpr/UI/UIWindow.h"
+#include "externals/Dpr/UI/ZukanDescriptionPanel.h"
+#include "externals/UnityEngine/RectTransform.h"
+#include "externals/Dpr/UI/UIMsgWindowController.h"
+
+namespace Dpr::UI {
+    struct UIZukanRegister : ILClass<UIZukanRegister> {
+        enum class AddMemberResult : int32_t {
+            Party = 0,
+            Box = 1,
+            Cancel = 2
+        };
+
+
+        struct Fields : Dpr::UI::UIWindow::Fields {
+            int32_t _animStateIn;
+            int32_t _animStateOut;
+            Dpr::UI::ZukanDescriptionPanel::Object* descriptionPanel;
+            UnityEngine::RectTransform::Object* descriptionHideModelViewPositionRectTransform;
+            UnityEngine::RectTransform::Object* contextMenuPositionRectTransform;
+            Dpr::UI::UIMsgWindowController::Object* msgWindowController;
+            int32_t bootType;
+            bool isWaitUpdate;
+            bool isRegisterNew;
+            bool isNotAddMember;
+            bool isSkipAddMemberProc;
+            Pml::PokePara::PokemonParam::Object* pokemonParam;
+            int32_t addMemberResult;
+            System::Action::Object* OnComplete;
+        };
+        static_assert(offsetof(Fields, OnComplete) == 0xa0);
+
+        inline void add_OnComplete(System::Action::Object* value) {
+            external<void>(0x01a3cb30, this, value);
+        }
+
+        inline void Open(Pml::PokePara::PokemonParam::Object* pokemonParam, bool isSkipAddMemberProc, int32_t prevWindowId) {
+            external<void>(0x01a3cd30, this, pokemonParam, isSkipAddMemberProc, prevWindowId);
+        }
+    };
+}

--- a/src/mod/externals/PlayerWork.h
+++ b/src/mod/externals/PlayerWork.h
@@ -304,4 +304,8 @@ struct PlayerWork : ILClass<PlayerWork, 0x04c59b58> {
     static inline Dpr::Message::MessageEnumData::MsgLangId get_msgLangID() {
         return external<Dpr::Message::MessageEnumData::MsgLangId>(0x02ce2c20);
     }
+
+    static inline PLAYREPORT_DATA::Object* get_playReportDataRef() {
+        return external<PLAYREPORT_DATA::Object*>(0x02cf6530);
+    }
 };

--- a/src/mod/externals/System/Action.h
+++ b/src/mod/externals/System/Action.h
@@ -13,6 +13,7 @@ namespace System {
         static const inline long void_TypeInfo = 0x04c56040;
         static const inline long ContextMenuID_TypeInfo = 0x04c627e0;
         static const inline long WazaNo_WazaNo_TypeInfo = 0x04c5eff0;
+        static const inline long UIZukanRegister_AddMemberResult_TypeInfo = 0x04c5edb0;
 
         template <typename T, typename... Args>
         inline void ctor(T* target, ILMethod<T, Args...>& mi) {

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -72,6 +72,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(ChangeFormNo(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_GET_COSTUME_GENDER:
                     return HandleCmdStepper(GetCostumeGender(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_UI_EXTRA:
+                    return HandleCmdStepper(AddPokemonUIExtra(__this));
                 default:
                     break;
             }
@@ -108,4 +110,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CASE_CALL);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHANGE_FORMNO);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_COSTUME_GENDER);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_UI_EXTRA);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -74,6 +74,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(GetCostumeGender(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_UI_EXTRA:
                     return HandleCmdStepper(AddPokemonUIExtra(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_POKEMON_NAME_FORM:
+                    return HandleCmdStepper(PokemonNameForm(__this));
                 default:
                     break;
             }
@@ -111,4 +113,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHANGE_FORMNO);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_COSTUME_GENDER);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_UI_EXTRA);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_POKEMON_NAME_FORM);
 }

--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -39,7 +39,6 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
                     System::Action::UIZukanRegister_AddMemberResult_TypeInfo)->newInstance(manager, mi);
 
             uiZukanReg->add_OnComplete(onComplete);
-            Logger::log("[_ADD_POKEMON_UI_EXTRA] OnComplete Added.\n");
 
             auto monsNo = GetWorkOrIntValue(args->m_Items[1]);
             auto formNo = GetWorkOrIntValue(args->m_Items[2]);
@@ -54,7 +53,6 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             initialSpec->fields.level = level;
             initialSpec->fields.talentVNum = maxIVs;
             auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
-            Logger::log("[_ADD_POKEMON_UI_EXTRA] CoreParam Created.\n");
             if (item != 0) coreParam->SetItem(item);
             coreParam->SetGetBall(ball);
 
@@ -62,16 +60,13 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto pMyStatus = PlayerWork::get_playerStatus();
             auto placeNo = PlayerWork::get_zoneID();
             poketool::poke_memo::poketool_poke_memo::SetFromCapture(coreParam, pMyStatus, placeNo);
-            Logger::log("[_ADD_POKEMON_UI_EXTRA] Capture Set.\n");
 
             if (FlagWork::GetWork(FlagWork_Work::WK_SCENE_KASEKI_MONSNO) == monsNo) {
                 auto playReport = PlayerWork::get_playReportDataRef();
                 playReport->fields.fossil_restore += 1;
             }
 
-            Logger::log("[_ADD_POKEMON_UI_EXTRA] Pre-Open.\n");
             uiZukanReg->Open(reinterpret_cast<Pml::PokePara::PokemonParam::Object*>(coreParam), false, -1);
-            Logger::log("[_ADD_POKEMON_UI_EXTRA] ZukanReg Opened.\n");
             azukariyaSeq = 0;
             manager->fields._azukariyaSequence = 1;
         }

--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -71,5 +71,5 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             manager->fields._azukariyaSequence = 1;
         }
     }
-    return azukariyaSeq < 1;
+    return azukariyaSeq < 0;
 }

--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -71,5 +71,5 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             manager->fields._azukariyaSequence = 1;
         }
     }
-    return static_cast<bool>(static_cast<uint>(azukariyaSeq) >> 0x1f);
+    return azukariyaSeq < 1;
 }

--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -1,0 +1,80 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/PlayerWork.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/Dpr/UI/UIZukanRegister.h"
+#include "externals/poketool/poke_memo/poketool_poke_memo.h"
+#include "externals/FlagWork_Enums.h"
+#include "externals/FlagWork.h"
+
+
+void EvCmdAddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager, int32_t addMemberResult) {
+    EvData::Aregment::Array* args = manager->fields._evArg;
+    if (args->max_length >= 7) {
+        manager->fields._azukariyaSequence = -1;
+        return;
+    }
+}
+
+bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_ADD_POKEMON_UI_EXTRA\n");
+    system_load_typeinfo(0x43bd);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+    auto azukariyaSeq = manager->fields._azukariyaSequence;
+
+    if (args->max_length >= 7) {
+        if (azukariyaSeq == 0) {
+            SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
+            auto uiManager = Dpr::UI::UIManager::instance();
+            Dpr::UI::UIZukanRegister::Object* uiZukanReg = uiManager->CreateUIWindow(
+                    UIWindowID::ZUKAN_REGISTER, Dpr::UI::UIManager::Method$$CreateUIWindow_UIZukanRegister_);
+
+            MethodInfo* mi = (*Dpr::EvScript::EvDataManager::Method$$EvDataManager_EvCmdAddPokemonUI)->copyWith((Il2CppMethodPointer) &EvCmdAddPokemonUIExtra);
+            auto onComplete = System::Action::getClass(
+                    System::Action::UIZukanRegister_AddMemberResult_TypeInfo)->newInstance(manager, mi);
+
+            uiZukanReg->add_OnComplete(onComplete);
+            Logger::log("[_ADD_POKEMON_UI_EXTRA] OnComplete Added.\n");
+
+            auto monsNo = GetWorkOrIntValue(args->m_Items[1]);
+            auto formNo = GetWorkOrIntValue(args->m_Items[2]);
+            auto level = GetWorkOrIntValue(args->m_Items[3]);
+            auto item = GetWorkOrIntValue(args->m_Items[4]);
+            auto maxIVs = GetWorkOrIntValue(args->m_Items[5]);
+            auto ball = GetWorkOrIntValue(args->m_Items[6]);
+
+            Pml::PokePara::InitialSpec::Object* initialSpec = Pml::PokePara::InitialSpec::newInstance();
+            initialSpec->fields.monsno = monsNo;
+            initialSpec->fields.formno = formNo;
+            initialSpec->fields.level = level;
+            initialSpec->fields.talentVNum = maxIVs;
+            auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
+            Logger::log("[_ADD_POKEMON_UI_EXTRA] CoreParam Created.\n");
+            if (item != 0) coreParam->SetItem(item);
+            coreParam->SetGetBall(ball);
+
+            PlayerWork::getClass()->initIfNeeded();
+            auto pMyStatus = PlayerWork::get_playerStatus();
+            auto placeNo = PlayerWork::get_zoneID();
+            poketool::poke_memo::poketool_poke_memo::SetFromCapture(coreParam, pMyStatus, placeNo);
+            Logger::log("[_ADD_POKEMON_UI_EXTRA] Capture Set.\n");
+
+            if (FlagWork::GetWork(FlagWork_Work::WK_SCENE_KASEKI_MONSNO) == monsNo) {
+                auto playReport = PlayerWork::get_playReportDataRef();
+                playReport->fields.fossil_restore += 1;
+            }
+
+            Logger::log("[_ADD_POKEMON_UI_EXTRA] Pre-Open.\n");
+            uiZukanReg->Open(reinterpret_cast<Pml::PokePara::PokemonParam::Object*>(coreParam), false, -1);
+            Logger::log("[_ADD_POKEMON_UI_EXTRA] ZukanReg Opened.\n");
+            azukariyaSeq = 0;
+            manager->fields._azukariyaSequence = 1;
+        }
+    }
+    return static_cast<bool>(static_cast<uint>(azukariyaSeq) >> 0x1f);
+}

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -116,3 +116,13 @@ bool ChangeFormNo(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] index: The index of the outfit to check.
 //   [Work] result: The gender of the outfit, where 0 is masculine and 1 is feminine.
 bool GetCostumeGender(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gives a Pokémon to the Player.
+// Arguments:
+//   [Work, Number] monsno: ID of the species to give.
+//   [Work, Number] formno: ID of the form the species is in.
+//   [Work, Number] level: Level of the Pokémon to give
+//   [Work, Number] item: ID of the item the Pokémon is to hold
+//   [Work, Number] maxIVs: Number of max IVs the Pokémon will have.
+//   [Work, Number] ball: ID of the ball the Pokémon will reside in.
+bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -121,8 +121,15 @@ bool GetCostumeGender(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [Work, Number] monsno: ID of the species to give.
 //   [Work, Number] formno: ID of the form the species is in.
-//   [Work, Number] level: Level of the Pokémon to give
+//   [Work, Number] level: Level of the Pokémon to give.
 //   [Work, Number] item: ID of the item the Pokémon is to hold
 //   [Work, Number] maxIVs: Number of max IVs the Pokémon will have.
 //   [Work, Number] ball: ID of the ball the Pokémon will reside in.
 bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Inserts a string of the specified Pokémon's form name into the supplied tagIndex.
+// Arguments:
+//   [Work, Number] tagIndex: The tagIndex where the string will be set into.
+//   [Work, Number] monsno: ID of the species to look up.
+//   [Work, Number] formno: ID of the form the species is in.
+bool PokemonNameForm(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/pokemon_name_form.cpp
+++ b/src/mod/features/commands/pokemon_name_form.cpp
@@ -1,0 +1,31 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+#include "externals/Pml/Personal/PersonalSystem.h"
+#include "externals/Dpr/Message/MessageWordSetHelper.h"
+
+bool PokemonNameForm(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_POKEMON_NAME_FORM\n");
+    system_load_typeinfo(0x44ac);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    if (args->max_length >= 4) {
+        auto tagIndex = GetWorkOrIntValue(args->m_Items[1]);
+        auto monsNo = GetWorkOrIntValue(args->m_Items[2]);
+        auto formNo = GetWorkOrIntValue(args->m_Items[3]);
+
+        auto sheetPersonal = Pml::Personal::PersonalSystem::GetPersonalData(monsNo, formNo);
+        auto formIndex = sheetPersonal->fields.form_index;
+
+        int32_t formTextIndex = (formNo == 0 || formIndex == 0) ? monsNo : (formNo + formIndex - 1);
+
+        Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+        auto msgManager = Dpr::Message::MessageWordSetHelper::getClass()->static_fields->manager;
+        auto msgFile = msgManager->GetMsgFile(System::String::Create("ss_zkn_form"));
+
+        Dpr::Message::MessageWordSetHelper::SetStringWordFromMsgFile(tagIndex, msgFile, formTextIndex);
+    }
+    return true;
+}


### PR DESCRIPTION
New Commands
-
- `_ADD_POKEMON_UI_EXTRA`
  - An extension of `_ADD_POKEMON_UI` which allows additional parameters including formNo and ballId.
- `_POKEMON_NAME_FORM`
  - An extension of `_POKEMON_NAME` which will lookup the formIndex and return the relevant form name.
  - E.g. Mega Mewtwo X