### PR TITLE
Player's ColorVariation in the JSON save

### DIFF
--- a/src/mod/externals/UnityEngine/Color.h
+++ b/src/mod/externals/UnityEngine/Color.h
@@ -3,6 +3,7 @@
 #include <cmath>
 
 #include "externals/il2cpp-api.h"
+#include "memory/json.h"
 
 namespace UnityEngine {
     struct Color : ILStruct<Color> {
@@ -68,6 +69,29 @@ namespace UnityEngine {
                 newFields.g = 0+m;
                 newFields.b = x+m;
             }
+
+            return *(Color::Object*)&newFields;
+        }
+
+        [[nodiscard]] nn::json ToJson() const {
+            auto fields = *(Color::Fields*)this;
+
+            return {
+                {"r", fields.r},
+                {"g", fields.g},
+                {"b", fields.b},
+                {"a", fields.a},
+            };
+        }
+
+        static Color::Object FromJson(const nn::json& color) {
+            Color::Fields newFields = {};
+            newFields = {
+                .r = color["r"].get<float>(),
+                .g = color["g"].get<float>(),
+                .b = color["b"].get<float>(),
+                .a = color["a"].get<float>()
+            };
 
             return *(Color::Object*)&newFields;
         }

--- a/src/mod/save/data/color_variation/color_variation.cpp
+++ b/src/mod/save/data/color_variation/color_variation.cpp
@@ -1,0 +1,12 @@
+#include "helpers/fsHelper.h"
+#include "save/save.h"
+
+void loadPlayerColorVariationFromJson(const nn::json& saveFile) {
+    if (saveFile.contains("lumi") && saveFile["lumi"].contains("playerColorVariation")) {
+        getCustomSaveData()->playerColorVariation.FromJson(saveFile["lumi"]["playerColorVariation"]);
+    }
+}
+
+nn::json getPlayerColorVariationAsJson() {
+    return getCustomSaveData()->playerColorVariation.ToJson();
+}

--- a/src/mod/save/data/color_variation/color_variation.h
+++ b/src/mod/save/data/color_variation/color_variation.h
@@ -7,7 +7,6 @@
 #include "logger/logger.h"
 
 struct ColorVariationSaveData {
-
     System::Int32 playerColorID;
 
     UnityEngine::Color::Object fSkinFace;
@@ -41,4 +40,48 @@ struct ColorVariationSaveData {
         bSkinBody.fields =    { .r = 1.0f, .g = 1.0f, .b = 1.0f, .a = 1.0f };
         bHair.fields =        { .r = 1.0f, .g = 1.0f, .b = 1.0f, .a = 1.0f };
     }
+
+    [[nodiscard]] nn::json ToJson() const {
+        return {
+                {"playerColorVariation", {
+                        {"playerColorID", playerColorID},
+
+                        {"fSkinFace", fSkinFace.ToJson()},
+                        {"fSkinMouth", fSkinMouth.ToJson()},
+                        {"fEyes", fEyes.ToJson()},
+                        {"fEyebrows", fEyebrows.ToJson()},
+                        {"fSkinBody", fSkinBody.ToJson()},
+                        {"fHair", fHair.ToJson()},
+
+                        {"bSkinFace", bSkinFace.ToJson()},
+                        {"bHairExtra", bHairExtra.ToJson()},
+                        {"bEyeLeft", bEyeLeft.ToJson()},
+                        {"bEyeRight", bEyeRight.ToJson()},
+                        {"bSkinBody", bSkinBody.ToJson()},
+                        {"bHair", bHair.ToJson()},
+                }}
+        };
+    }
+
+    void FromJson(const nn::json& playerColorVariation) {
+        Initialize();
+        playerColorID = playerColorVariation["playerColorID"].get<int32_t>();
+
+        fSkinFace = UnityEngine::Color::FromJson(playerColorVariation["fSkinFace"]);
+        fSkinMouth = UnityEngine::Color::FromJson(playerColorVariation["fSkinMouth"]);
+        fEyes = UnityEngine::Color::FromJson(playerColorVariation["fEyes"]);
+        fEyebrows = UnityEngine::Color::FromJson(playerColorVariation["fEyebrows"]);
+        fSkinBody = UnityEngine::Color::FromJson(playerColorVariation["fSkinBody"]);
+        fHair = UnityEngine::Color::FromJson(playerColorVariation["fHair"]);
+
+        bSkinFace = UnityEngine::Color::FromJson(playerColorVariation["bSkinFace"]);
+        bHairExtra = UnityEngine::Color::FromJson(playerColorVariation["bHairExtra"]);
+        bEyeLeft = UnityEngine::Color::FromJson(playerColorVariation["bEyeLeft"]);
+        bEyeRight = UnityEngine::Color::FromJson(playerColorVariation["bEyeRight"]);
+        bSkinBody = UnityEngine::Color::FromJson(playerColorVariation["bSkinBody"]);
+        bHair = UnityEngine::Color::FromJson(playerColorVariation["bHair"]);
+    }
 };
+
+void loadPlayerColorVariationFromJson(const nn::json& saveFile);
+nn::json getPlayerColorVariationAsJson();

--- a/src/mod/save/data/main/main.cpp
+++ b/src/mod/save/data/main/main.cpp
@@ -1,26 +1,12 @@
 #include "helpers/fsHelper.h"
 #include "save/save.h"
 
-void loadMain(bool isBackup) {
-
-    if (!isBackup && FsHelper::isFileExist(CustomSaveData::mainSaveName)) {
-        nn::json jData = FsHelper::loadJsonFileFromPath(CustomSaveData::mainSaveName);
-        if (jData.contains("lumi") && jData["lumi"].contains("main")) {
-            getCustomSaveData()->main.FromJson(jData["lumi"]["main"]);
-            Logger::log("Loaded Lumi_Main!\n");
-        }
-    }
-
-    else if (FsHelper::isFileExist(CustomSaveData::backupSaveName)) {
-        nn::json jData = FsHelper::loadJsonFileFromPath(CustomSaveData::backupSaveName);
-        if (jData.contains("lumi") && jData["lumi"].contains("main")) {
-            getCustomSaveData()->main.FromJson(jData["lumi"]["main"]);
-            Logger::log("Loaded Lumi_Main_BK!\n");
-        }
+void loadMainFromJson(const nn::json& saveFile) {
+    if (saveFile.contains("lumi") && saveFile["lumi"].contains("main")) {
+        getCustomSaveData()->main.FromJson(saveFile["lumi"]["main"]);
     }
 }
 
-nn::json saveMain()
-{
+nn::json getMainAsJson() {
     return getCustomSaveData()->main.ToJson();
 }

--- a/src/mod/save/data/main/main.h
+++ b/src/mod/save/data/main/main.h
@@ -36,8 +36,7 @@ struct MainSaveData {
         Initialize();
         version = static_cast<ModVersion>(main["version"].get<int32_t>());
     }
-
 };
 
-void loadMain(bool isBackup);
-nn::json saveMain();
+void loadMainFromJson(const nn::json& saveFile);
+nn::json getMainAsJson();

--- a/src/mod/save/migration/future.cpp
+++ b/src/mod/save/migration/future.cpp
@@ -5,10 +5,10 @@
 #include "logger/logger.h"
 
 void migrateToFuture(PlayerWork::Object* playerWork) {
-    Logger::log("Migrating from Storage to Future...\n");
+    Logger::log("Migrating from Re:Lease to Future...\n");
     CustomSaveData* save = getCustomSaveData();
 
     // Insert new migration code here
 
-    Logger::log("Migration from Storage to Future done!\n");
+    Logger::log("Migration from Re:Lease to Future done!\n");
 }

--- a/src/mod/save/migration/save_migration.h
+++ b/src/mod/save/migration/save_migration.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "externals/PlayerWork.h"
 
 // Main function to migrate the save file.


### PR DESCRIPTION
- Re-adds the player's ColorVariation data to the save, in the JSON version of it this time
- Simplified the manipulation on the custom section of the save JSON
  - Specifically, keeps the JSON in memory after loading it from the file instead of re-reading it for every part of the custom section