### PR TITLE
Form Flags for every species

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -46,6 +46,7 @@ static constexpr const char* FEATURES[] = {
     "Spinda Hijacking",
     "Form Argument Pokémon Icons",
     "Form Argument Generation",
+    "Pokédex Form Flags",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/DPData/GET_STATUS.h
+++ b/src/mod/externals/DPData/GET_STATUS.h
@@ -1,7 +1,13 @@
 #pragma once
 
 namespace DPData {
-    typedef int32_t GET_STATUS;
+    enum class GET_STATUS : int32_t
+    {
+        NONE = 0,
+        UWASA = 1,
+        SEE = 2,
+        GET = 3,
+    };
 
     PRIMITIVE_ARRAY(GET_STATUS, 0x04c5a5a8)
 }

--- a/src/mod/externals/Effect/EffectInstance.h
+++ b/src/mod/externals/Effect/EffectInstance.h
@@ -23,7 +23,7 @@ namespace Effect {
         };
 
         inline void Stop(float fadeTime, bool isForce) {
-            return external<void>(0x01efe7b0, this, fadeTime, isForce);
+            external<void>(0x01efe7b0, this, fadeTime, isForce);
         }
     };
 }

--- a/src/mod/externals/PlayerWork.h
+++ b/src/mod/externals/PlayerWork.h
@@ -339,4 +339,8 @@ struct PlayerWork : ILClass<PlayerWork, 0x04c59b58> {
     static inline PlayerWork::Object* get_instance() {
         return SmartPoint::Components::PlayerPrefsProvider<PlayerWork>::get_instance(Method$PlayerWork_get_instance);
     }
+
+    static inline void set_zukan(DPData::ZUKAN_WORK::Object* value) {
+        external<void>(0x02cf0fd0, value);
+    }
 };

--- a/src/mod/externals/ZukanWork.h
+++ b/src/mod/externals/ZukanWork.h
@@ -2,23 +2,36 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/DPData/GET_STATUS.h"
 #include "externals/Dpr/Message/MessageEnumData.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
 
-struct ZukanWork : ILClass<ZukanWork> {
+struct ZukanWork : ILClass<ZukanWork, 0x04c5b488> {
     static inline bool GetZenkokuFlag() {
         return external<bool>(0x017db490);
     }
 
     static inline void SetPoke(uint32_t monsno, int32_t get, uint8_t sex, int32_t form, bool color) {
-        return external<void>(0x017dbce0, monsno, get, sex, form, color);
+        external<void>(0x017dbce0, monsno, get, sex, form, color);
     }
 
     static inline void SetPoke(Pml::PokePara::PokemonParam::Object* mons, int32_t get) {
-        return external<void>(0x017dc560, mons, get);
+        external<void>(0x017dc560, mons, get);
     }
 
     static inline void AddLangFlag(uint32_t monsno, Dpr::Message::MessageEnumData::MsgLangId msglang) {
-        return external<void>(0x017dc870, monsno, msglang);
+        external<void>(0x017dc870, monsno, msglang);
+    }
+
+    static inline void DebugSet(uint32_t monsno, DPData::GET_STATUS get, Pml::Sex sex, int32_t form, bool color, bool isGet) {
+        external<void>(0x017dd7e0, monsno, get, sex, form, color, isGet);
+    }
+
+    static inline void ZukanON() {
+        external<void>(0x017db250);
+    }
+
+    static inline void ZenkokuON() {
+        external<void>(0x017db310);
     }
 };

--- a/src/mod/features/dex_form_flags.cpp
+++ b/src/mod/features/dex_form_flags.cpp
@@ -1,0 +1,98 @@
+#include "exlaunch.hpp"
+
+#include "externals/PlayerWork.h"
+#include "externals/Pml/Sex.h"
+#include "externals/ZukanWork.h"
+
+#include "save/save.h"
+
+void SetCaughtFlags(DPData::ZUKAN_WORK::Object* zukanData, uint32_t monsno, Pml::Sex sex, int32_t form, bool color, bool isGet) {
+    switch (sex)
+    {
+        case Pml::Sex::MALE:
+            if (color)
+                zukanData->fields.male_color_flag->m_Items[monsno-1] = isGet;
+            else
+                zukanData->fields.male_flag->m_Items[monsno-1] = isGet;
+            break;
+
+        case Pml::Sex::FEMALE:
+            if (color)
+                zukanData->fields.female_color_flag->m_Items[monsno-1] = isGet;
+            else
+                zukanData->fields.female_flag->m_Items[monsno-1] = isGet;
+            break;
+
+        case Pml::Sex::UNKNOWN:
+            if (color)
+            {
+                zukanData->fields.male_color_flag->m_Items[monsno-1] = isGet;
+                zukanData->fields.female_color_flag->m_Items[monsno-1] = isGet;
+            }
+            else
+            {
+                zukanData->fields.male_flag->m_Items[monsno-1] = isGet;
+                zukanData->fields.female_flag->m_Items[monsno-1] = isGet;
+            }
+            break;
+
+        default:
+            break;
+    }
+
+    getCustomSaveData()->dexForms.elements[monsno-1].setFlag(form, color, isGet);
+}
+
+HOOK_DEFINE_REPLACE(ZukanWork$$SetPoke) {
+    static void Callback(uint32_t monsno, DPData::GET_STATUS get, Pml::Sex sex, int32_t form, bool color) {
+        system_load_typeinfo(0xac82);
+        PlayerWork::getClass()->initIfNeeded();
+        ZukanWork::getClass()->initIfNeeded();
+
+        if (monsno > DexSize)
+            return;
+
+        auto zukanData = PlayerWork::get_zukan();
+
+        if (zukanData->fields.get_status->m_Items[monsno-1] <= get)
+            zukanData->fields.get_status->m_Items[monsno-1] = get;
+
+        SetCaughtFlags(zukanData, monsno, sex, form, color, true);
+
+        PlayerWork::set_zukan(zukanData);
+    }
+};
+
+HOOK_DEFINE_REPLACE(ZukanWork$$IsGet) {
+    static bool Callback(uint32_t monsno, Pml::Sex sex, int32_t form, bool color) {
+        if (monsno > DexSize)
+            return false;
+
+        return getCustomSaveData()->dexForms.elements[monsno-1].getFlag(form, color);
+    }
+};
+
+HOOK_DEFINE_REPLACE(ZukanWork$$DebugSet) {
+    static void Callback(uint32_t monsno, DPData::GET_STATUS get, Pml::Sex sex, int32_t form, bool color, bool isGet) {
+        system_load_typeinfo(0xac6f);
+        PlayerWork::getClass()->initIfNeeded();
+        ZukanWork::getClass()->initIfNeeded();
+
+        if (monsno > DexSize)
+            return;
+
+        auto zukanData = PlayerWork::get_zukan();
+
+        zukanData->fields.get_status->m_Items[monsno-1] = get;
+
+        SetCaughtFlags(zukanData, monsno, sex, form, color, isGet);
+
+        PlayerWork::set_zukan(zukanData);
+    }
+};
+
+void exl_dex_form_flags_main() {
+    ZukanWork$$SetPoke::InstallAtOffset(0x017dbce0);
+    ZukanWork$$IsGet::InstallAtOffset(0x017dcc90);
+    ZukanWork$$DebugSet::InstallAtOffset(0x017dd7e0);
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -57,6 +57,9 @@ void exl_commands_main();
 // Adds support for contest NPCs to have alternate forms of Pokémon.
 void exl_contest_npc_forms_main();
 
+// Adds support for form flags for every species in the Pokédex.
+void exl_dex_form_flags_main();
+
 // Rewrites the methods that deal with determining a zone's encounter slots.
 // Defaults to changing slots how Luminescent does it.
 void exl_encounter_slots_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -100,6 +100,8 @@ void CallFeatureHooks()
         exl_form_arg_icons_main();
     if (IsActivatedFeature(array_index(FEATURES, "Form Argument Generation")))
         exl_form_arg_generation_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Pokédex Form Flags")))
+        exl_dex_form_flags_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/save/data/dex_form/dex_form.cpp
+++ b/src/mod/save/data/dex_form/dex_form.cpp
@@ -1,0 +1,12 @@
+#include "helpers/fsHelper.h"
+#include "save/save.h"
+
+void loadDexFormsFromJson(const nn::json& saveFile) {
+    if (saveFile.contains("lumi") && saveFile["lumi"].contains("dexForms")) {
+        getCustomSaveData()->dexForms.FromJson(saveFile["lumi"]["dexForms"]);
+    }
+}
+
+nn::json getDexFormsAsJson() {
+    return getCustomSaveData()->dexForms.ToJson();
+}

--- a/src/mod/save/data/dex_form/dex_form.h
+++ b/src/mod/save/data/dex_form/dex_form.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "externals/PlayerWork.h"
+
+#include "logger/logger.h"
+#include "memory/json.h"
+
+struct DexFormSaveDataElement {
+    std::vector<System::Boolean> regularFlags; // Doesn't compile with nn::vector (no allocator for bool)
+    std::vector<System::Boolean> shinyFlags; // Doesn't compile with nn::vector (no allocator for bool)
+
+    void Initialize() {
+        // Nothing?
+    }
+
+    [[nodiscard]] nn::json ToJson() const {
+        return {
+            {"regularFlags", regularFlags},
+            {"shinyFlags", shinyFlags},
+        };
+    }
+
+    void FromJson(const nn::json& dexForms) {
+        Initialize();
+        regularFlags = dexForms["regularFlags"].get<std::vector<bool>>();
+        shinyFlags = dexForms["shinyFlags"].get<std::vector<bool>>();
+    }
+
+    bool getFlag(int32_t formno, bool shiny) {
+        if (shiny) {
+            for (int32_t i=shinyFlags.size(); i<=formno; i++) {
+                shinyFlags.push_back(false);
+            }
+            return shinyFlags[formno];
+        }
+        else {
+            for (int32_t i=regularFlags.size(); i<=formno; i++) {
+                regularFlags.push_back(false);
+            }
+            return regularFlags[formno];
+        }
+    }
+
+    void setFlag(int32_t formno, bool shiny, bool value) {
+        if (shiny) {
+            for (int32_t i=shinyFlags.size(); i<=formno; i++) {
+                shinyFlags.push_back(false);
+            }
+            shinyFlags[formno] = value;
+        }
+        else {
+            for (int32_t i=regularFlags.size(); i<=formno; i++) {
+                regularFlags.push_back(false);
+            }
+            regularFlags[formno] = value;
+        }
+    }
+};
+
+template <int32_t size>
+struct DexFormSaveData {
+    DexFormSaveDataElement elements[size];
+
+    void Initialize() {
+        for (int32_t i=0; i<size; i++)
+        {
+            elements[i].Initialize();
+        }
+    }
+
+    [[nodiscard]] nn::json ToJson() const {
+        nn::json dexForms;
+
+        for (int32_t i=0; i<size; i++)
+            dexForms.push_back(elements[i].ToJson());
+
+        return {
+                { "dexForms", dexForms }
+        };
+    }
+
+    void FromJson(const nn::json& dexForms) {
+        Initialize();
+        for (uint64_t i=0; i<size && i<dexForms.size(); i++)
+            elements[i].FromJson(dexForms[i]);
+    }
+};
+
+void loadDexFormsFromJson(const nn::json& saveFile);
+nn::json getDexFormsAsJson();

--- a/src/mod/save/save.h
+++ b/src/mod/save/save.h
@@ -3,10 +3,12 @@
 #include "externals/PlayerWork.h"
 
 #include "save/data/color_variation/color_variation.h"
+#include "save/data/dex_form/dex_form.h"
 #include "save/data/main/main.h"
 
 #include "logger/logger.h"
 
+// Current sizes
 constexpr int32_t DexSize = 1025;
 constexpr int32_t WorkCount = 5000;
 constexpr int32_t FlagCount = 15000;
@@ -22,6 +24,7 @@ struct CustomSaveData {
     static constexpr const char* saveMountName = "SaveData";
     MainSaveData main;
     ColorVariationSaveData playerColorVariation;
+    DexFormSaveData<DexSize> dexForms;
 };
 
 CustomSaveData* getCustomSaveData();

--- a/src/mod/save/save_hooks.cpp
+++ b/src/mod/save/save_hooks.cpp
@@ -63,16 +63,22 @@ void FailedLoad() {
 }
 
 void LoadCustomSaveData(nn::json& saveFile) {
+    Logger::log("[LoadCustomSaveData] Loading custom data...\n");
     loadMainFromJson(saveFile);
     loadPlayerColorVariationFromJson(saveFile);
+    loadDexFormsFromJson(saveFile);
+    Logger::log("[LoadCustomSaveData] Custom data loaded successfully.\n");
 }
 
 nn::json WriteCustomSaveData() {
+    Logger::log("[WriteCustomSaveData] Converting custom data...\n");
     nn::json lumiObject = nn::json::object();
     nn::vector<nn::json> saveFunctions = {
         getMainAsJson(),
         getPlayerColorVariationAsJson(),
+        getDexFormsAsJson(),
     };
+    Logger::log("[WriteCustomSaveData] Custom data converted successfully.\n");
 
     for (const auto& jsonStructure : saveFunctions) {
         lumiObject.update(jsonStructure);

--- a/src/mod/ui/debug_menu_hooks.cpp
+++ b/src/mod/ui/debug_menu_hooks.cpp
@@ -69,18 +69,10 @@ void setFlyOverride(bool b) {
     flyOverride = b;
 }
 
-static bool dexGetStatusOverride = false;
-
-void setDexGetStatusOverride(bool b) {
-    dexGetStatusOverride = b;
-}
-
-void setFullDex(int32_t getStatus) {
+void setFullDex(int getStatus) {
     for (int i=1; i<=DexSize; i++) {
-        ZukanWork::SetPoke(i, getStatus, 0, 0, true);
-        ZukanWork::SetPoke(i, getStatus, 1, 0, true);
-        ZukanWork::SetPoke(i, getStatus, 0, 0, false);
-        ZukanWork::SetPoke(i, getStatus, 1, 0, false);
+        ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, 0, true, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
+        ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, 0, false, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
 
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::JPN);
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::USA);
@@ -91,117 +83,13 @@ void setFullDex(int32_t getStatus) {
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::KOR);
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::SCH);
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::TCH);
-
-        if (i == array_index(SPECIES, "Unown")) {
-            for (int j=1; j<=(int)UnownForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Castform")) {
-            for (int j=1; j<=(int)CastformForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Deoxys")) {
-            for (int j=1; j<=(int)DeoxysForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Burmy")) {
-            for (int j=1; j<=(int)BurmyForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Wormadam")) {
-            for (int j=1; j<=(int)WormadamForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Mothim")) {
-            for (int j=1; j<=(int)MothimForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Cherrim")) {
-            for (int j=1; j<=(int)CherrimForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Shellos")) {
-            for (int j=1; j<=(int)ShellosForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Gastrodon")) {
-            for (int j=1; j<=(int)GastrodonForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Rotom")) {
-            for (int j=1; j<=(int)RotomForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Giratina")) {
-            for (int j=1; j<=(int)GiratinaForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Shaymin")) {
-            for (int j=1; j<=(int)ShayminForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
-        else if (i == array_index(SPECIES, "Arceus")) {
-            for (int j=1; j<=(int)ArceusForm::MAX; j++) {
-                ZukanWork::SetPoke(i, getStatus, 0, j, true);
-                ZukanWork::SetPoke(i, getStatus, 1, j, true);
-                ZukanWork::SetPoke(i, getStatus, 0, j, false);
-                ZukanWork::SetPoke(i, getStatus, 1, j, false);
-            }
-        }
     }
 
-    ZukanWork::SetPoke(25, 3, 0, 0, true);
-    ZukanWork::SetPoke(25, 3, 1, 0, true);
-    ZukanWork::SetPoke(25, 3, 0, 0, false);
-    ZukanWork::SetPoke(25, 3, 1, 0, false);
+    ZukanWork::DebugSet(25, DPData::GET_STATUS::GET, Pml::Sex::UNKNOWN, 0, true, true);
+    ZukanWork::DebugSet(25, DPData::GET_STATUS::GET, Pml::Sex::UNKNOWN, 0, false, true);
+
+    ZukanWork::DebugSet(25, DPData::GET_STATUS::GET, Pml::Sex::UNKNOWN, 3, true, true);
+    ZukanWork::DebugSet(25, DPData::GET_STATUS::GET, Pml::Sex::UNKNOWN, 3, false, true);
 }
 
 HOOK_DEFINE_TRAMPOLINE(FlyOverride) {
@@ -222,19 +110,6 @@ HOOK_DEFINE_TRAMPOLINE(FlyOverride2) {
     }
 };
 
-HOOK_DEFINE_INLINE(ZukanWork$$SetPokeOverride) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto getStatusPtr = (DPData::GET_STATUS*)ctx->X[9];
-        auto maxValue = (DPData::GET_STATUS)ctx->W[10];
-        auto newValue = (DPData::GET_STATUS)ctx->W[23];
-
-        if (dexGetStatusOverride)
-            *getStatusPtr = newValue;
-        else
-            *getStatusPtr = maxValue;
-    }
-};
-
 void exl_debug_menu_main() {
     ArenaHook::InstallAtOffset(0x02c3abc0);
     CollissionOverride::InstallAtOffset(0x01a763a0);
@@ -242,5 +117,4 @@ void exl_debug_menu_main() {
     LastAreaName::InstallAtOffset(0x01786970);
     FlyOverride::InstallAtOffset(0x0184e780);
     FlyOverride2::InstallAtOffset(0x01850250);
-    ZukanWork$$SetPokeOverride::InstallAtOffset(0x017dbe30);
 }

--- a/src/mod/ui/tools/misc_tool.h
+++ b/src/mod/ui/tools/misc_tool.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "externals/ZukanWork.h"
+
 #include "ui/base/collapsing_header.h"
 #include "ui/base/element.h"
 #include "ui/ui.h"
@@ -33,38 +35,39 @@ namespace ui {
                 });
 
                 _.Button([](Button &_) {
+                    _.label = "Give Pokédex";
+                    _.onClick = []() {
+                        FlagWork::SetFlag(FlagWork_Flag::FE_ZUKAN_GET, true);
+                        ZukanWork::ZukanON();
+                        ZukanWork::ZenkokuON();
+                    };
+                });
+
+                _.Button([](Button &_) {
                     _.label = "Set full Pokédex to None";
                     _.onClick = []() {
-                        setDexGetStatusOverride(true);
-                        setFullDex(0);
-                        setDexGetStatusOverride(false);
+                        setFullDex((int32_t)DPData::GET_STATUS::NONE);
                     };
                 });
 
                 _.Button([](Button &_) {
                     _.label = "Set full Pokédex to \"Uwasa\"";
                     _.onClick = []() {
-                        setDexGetStatusOverride(true);
-                        setFullDex(1);
-                        setDexGetStatusOverride(false);
+                        setFullDex((int32_t)DPData::GET_STATUS::UWASA);
                     };
                 });
 
                 _.Button([](Button &_) {
                     _.label = "Set full Pokédex to Seen";
                     _.onClick = []() {
-                        setDexGetStatusOverride(true);
-                        setFullDex(2);
-                        setDexGetStatusOverride(false);
+                        setFullDex((int32_t)DPData::GET_STATUS::SEE);
                     };
                 });
 
                 _.Button([](Button &_) {
                     _.label = "Set full Pokédex to Caught";
                     _.onClick = []() {
-                        setDexGetStatusOverride(true);
-                        setFullDex(3);
-                        setDexGetStatusOverride(false);
+                        setFullDex((int32_t)DPData::GET_STATUS::GET);
                     };
                 });
             });

--- a/src/mod/ui/ui.h
+++ b/src/mod/ui/ui.h
@@ -1,9 +1,11 @@
 #pragma once
 
-#include "externals/UnityEngine/Transform.h"
-
 namespace ui {
     struct Root;
+}
+
+namespace UnityEngine {
+    struct Transform;
 }
 
 ui::Root* getRootElement();
@@ -15,7 +17,6 @@ void ui_inspect(UnityEngine::Transform* transform);
 void setArenaSettings(bool enabled, int id);
 void showAreaName();
 void setFlyOverride(bool enabled);
-void setDexGetStatusOverride(bool enabled);
-void setFullDex(int32_t getStatus);
+void setFullDex(int getStatus);
 
 #define ROOT getRootElement()


### PR DESCRIPTION
Closes #122.
- Adds arrays of regular form flags and shiny form flags for every species in the custom part of the save.
  - It is found at lumi/dexForms, with the fields regularFlags and shinyFlags.
- Adds a debug option in Misc Tool to give the Pokédex.
  - This also sets the national dex flag.
- Changes the behavior of the buttons in Misc Tool that set the dex status for all species.
  - Only form 0 of every species is changed, except for form 3 Pikachu which gets set to caught like its form 0.