### PR TITLE
Dialog text color & Battle UI fixes

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -49,6 +49,7 @@ static constexpr const char* FEATURES[] = {
     "Form Argument Pokémon Icons",
     "Form Argument Generation",
     "Pokédex Form Flags",
+    "Dialog Text Color",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/data/outfits.h
+++ b/src/mod/data/outfits.h
@@ -7,6 +7,8 @@ static constexpr const char *OUTFITS[] = {
     "Contest Style Feminine",
     "Pikachu Hoodie Style Masculine",
     "Pikachu Hoodie Style Feminine",
+    "Eevee Hoodie Style Masculine",
+    "Eevee Hoodie Style Feminine",
     "Platinum Style Masculine",
     "Platinum Style Feminine",
     "Overalls Style Masculine",
@@ -31,6 +33,10 @@ static constexpr const char *OUTFITS[] = {
     "Bicycle Style Feminine",
     "Cyber Style 2.0 Masculine",
     "Cyber Style 2.0 Feminine",
+    "Renegade Style Masculine",
+    "Renegade Style Feminine",
+    "Vintage Style Masculine",
+    "Vintage Style Feminine",
 };
 
 const int OUTFIT_COUNT = sizeof(OUTFITS) / sizeof(OUTFITS[0]);

--- a/src/mod/externals/Dpr/Message/FontManager.h
+++ b/src/mod/externals/Dpr/Message/FontManager.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/TMPro/TextMeshProUGUI.h"
+
+namespace Dpr::Message {
+    struct FontManager : ILClass<FontManager, 0x04c59b38> {
+        struct Fields : SmartPoint::AssetAssistant::SingletonMonoBehaviour::Fields{
+            void* textFontData;
+            void* fontMaterialData;
+            void* spriteFontAsset;
+            void* fontInfoTable;
+            void* materialPropertyTable;
+            void* materialTable;
+            void* fontAssetLoader;
+            int32_t useEFIGSCount;
+        };
+
+        static inline StaticILMethod<0x04c676d8, FontManager> Method$$FontManager$$get_Instance {};
+
+        static inline FontManager::Object* get_Instance() {
+            return SmartPoint::AssetAssistant::SingletonMonoBehaviour::get_Instance(Method$$FontManager$$get_Instance);
+        }
+
+        inline void ChangeFontMaterial(TMPro::TextMeshProUGUI::Object* text, int32_t materialIndex) {
+            external<void>(0x01cab970, this, text, materialIndex);
+        }
+    };
+}
+

--- a/src/mod/externals/Dpr/MsgWindow/WindowMsgText.h
+++ b/src/mod/externals/Dpr/MsgWindow/WindowMsgText.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/TMPro/TextMeshProUGUI.h"
+#include "externals/UnityEngine/Color.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/RectTransform.h"
+
+namespace Dpr::MsgWindow {
+    struct WindowMsgText : ILClass<WindowMsgText> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            TMPro::TextMeshProUGUI::Object* text;
+            UnityEngine::RectTransform::Object* textRect;
+            UnityEngine::Color::Object defaultColor;
+        };
+
+        static_assert(offsetof(Fields, defaultColor) == 0x18);
+    };
+
+}

--- a/src/mod/externals/Dpr/UI/CharacterModelView.h
+++ b/src/mod/externals/Dpr/UI/CharacterModelView.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/ModelViewBase.h"
+#include "externals/System/String.h"
+#include "externals/UnityEngine/Transform.h"
+#include "externals/XLSXContent/CharacterDressData.h"
+
+namespace Dpr::UI {
+    struct CharacterModelView : ILClass<CharacterModelView> {
+        struct Param : ILClass<Param> {
+            struct Fields {
+                int32_t type;
+                XLSXContent::CharacterDressData::SheetData::Object* characterDressData;
+                int32_t modelType;
+                void* canvas;
+                float offsetZ;
+                bool isAutoUpdateTexture;
+            };
+
+            static_assert(offsetof(Fields, isAutoUpdateTexture) == 0x24);
+        };
+
+        struct Fields : Dpr::UI::ModelViewBase::Fields {
+            UnityEngine::Transform::Object* _transModel;
+            float _fov;
+            float _rotateSpeed;
+            int32_t _saveModelViewCacheNum;
+            Param::Object* _param;
+            System::String::Object* _clipName;
+        };
+
+        static_assert(offsetof(Fields, _clipName) == 0x40);
+    };
+
+}

--- a/src/mod/externals/Dpr/UI/ModelViewBase.h
+++ b/src/mod/externals/Dpr/UI/ModelViewBase.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/String.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/Transform.h"
+#include "externals/UnityEngine/UI/Image.h"
+#include "externals/XLSXContent/CharacterDressData.h"
+
+namespace Dpr::UI {
+    struct ModelViewBase : ILClass<ModelViewBase> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            UnityEngine::UI::Image::Object* _imageModelBg;
+            void* _rawImageModelView;
+            UnityEngine::Transform::Object* _transBg;
+        };
+
+        static_assert(offsetof(Fields, _transBg) == 0x18);
+
+        inline void OnDisable() {
+            external<void>(0x01c5cd70, this);
+        }
+    };
+
+}

--- a/src/mod/externals/Dpr/UI/UIModelViewController.h
+++ b/src/mod/externals/Dpr/UI/UIModelViewController.h
@@ -71,5 +71,9 @@ namespace Dpr::UI {
         inline int32_t GetAnimationIndexByClipName(System::String::Object* clipName) {
             return external<int32_t>(0x01a0e950, this, clipName);
         }
+
+        inline int32_t ResetCaches(int32_t num, bool isUnload) {
+            return external<int32_t>(0x01a0f140, this, num, isUnload);
+        }
     };
 }

--- a/src/mod/externals/TMPro/TextMeshProUGUI.h
+++ b/src/mod/externals/TMPro/TextMeshProUGUI.h
@@ -30,6 +30,12 @@ namespace TMPro {
             void* OnPreRenderText; //System_Action_TMP_TextInfo__o*
         };
 
+        struct VirtualInvokeData_get_color {
+            typedef UnityEngine::Color::Fields(*Il2CppMethodPointer)(TMPro::TextMeshProUGUI::Object* __this, const MethodInfo*);
+            Il2CppMethodPointer methodPtr;
+            const MethodInfo* method;
+        };
+
         struct VirtualInvokeData_set_text {
             typedef void(*Il2CppMethodPointer)(TMPro::TextMeshProUGUI::Object* __this, System::String::Object* value, const MethodInfo*);
             Il2CppMethodPointer methodPtr;
@@ -59,7 +65,7 @@ namespace TMPro {
             VirtualInvokeData _19_unknown;
             VirtualInvokeData _20_unknown;
             VirtualInvokeData _21_unknown;
-            VirtualInvokeData _22_get_color;
+            VirtualInvokeData_get_color _22_get_color;
             VirtualInvokeData _23_set_color;
             VirtualInvokeData _24_get_raycastTarget;
             VirtualInvokeData _25_set_raycastTarget;
@@ -181,6 +187,13 @@ namespace TMPro {
             VirtualInvokeData _141_unknown;
             VirtualInvokeData _142_GenerateTextMesh;
         };
+
+        inline UnityEngine::Color::Object virtual_get_color() {
+            return {
+                .fields = (*(this->instance()->klass->vtable)._22_get_color.methodPtr)
+                            (this->instance(), this->instance()->klass->vtable._22_get_color.method)
+            };
+        }
 
         inline void virtual_set_text(System::String::Object* value) {
             (*(this->instance()->klass->vtable)._66_set_text.methodPtr)

--- a/src/mod/externals/TMPro/TextMeshProUGUI.h
+++ b/src/mod/externals/TMPro/TextMeshProUGUI.h
@@ -36,6 +36,12 @@ namespace TMPro {
             const MethodInfo* method;
         };
 
+        struct VirtualInvokeData_set_color {
+            typedef void(*Il2CppMethodPointer)(TMPro::TextMeshProUGUI::Object* __this, UnityEngine::Color::Fields value, const MethodInfo*);
+            Il2CppMethodPointer methodPtr;
+            const MethodInfo* method;
+        };
+
         struct VirtualInvokeData_set_text {
             typedef void(*Il2CppMethodPointer)(TMPro::TextMeshProUGUI::Object* __this, System::String::Object* value, const MethodInfo*);
             Il2CppMethodPointer methodPtr;
@@ -66,7 +72,7 @@ namespace TMPro {
             VirtualInvokeData _20_unknown;
             VirtualInvokeData _21_unknown;
             VirtualInvokeData_get_color _22_get_color;
-            VirtualInvokeData _23_set_color;
+            VirtualInvokeData_set_color _23_set_color;
             VirtualInvokeData _24_get_raycastTarget;
             VirtualInvokeData _25_set_raycastTarget;
             VirtualInvokeData _26_SetAllDirty;
@@ -193,6 +199,17 @@ namespace TMPro {
                 .fields = (*(this->instance()->klass->vtable)._22_get_color.methodPtr)
                             (this->instance(), this->instance()->klass->vtable._22_get_color.method)
             };
+        }
+
+        inline void virtual_set_color(UnityEngine::Color::Object value) {
+            UnityEngine::Color::Fields proxy = { .r = value.fields.r, .g = value.fields.g, .b = value.fields.b, .a = value.fields.a };
+            (*(this->instance()->klass->vtable)._23_set_color.methodPtr)
+                    (this->instance(), proxy, this->instance()->klass->vtable._23_set_color.method);
+        }
+
+        inline void virtual_set_color(UnityEngine::Color::Fields value) {
+            (*(this->instance()->klass->vtable)._23_set_color.methodPtr)
+                    (this->instance(), value, this->instance()->klass->vtable._23_set_color.method);
         }
 
         inline void virtual_set_text(System::String::Object* value) {

--- a/src/mod/externals/UnityEngine/Component.h
+++ b/src/mod/externals/UnityEngine/Component.h
@@ -26,6 +26,10 @@ namespace Dpr::UI {
     struct UIText;
 }
 
+namespace TMPro {
+    struct TextMeshProUGUI;
+}
+
 namespace UnityEngine {
     struct Transform;
     struct RectTransform;
@@ -45,6 +49,7 @@ namespace UnityEngine {
         static inline StaticILMethod<0x04c667c0, Dpr::UI::SelectLanguageItem> Method$$SelectLanguageItem$$GetComponent {};
         static inline StaticILMethod<0x04c667d0, Dpr::UI::SettingMenuItem> Method$$SettingMenuItem$$GetComponent {};
         static inline StaticILMethod<0x04c667e0, Dpr::UI::UIText> Method$$UIText$$GetComponent {};
+        static inline StaticILMethod<0x04c66890, TMPro::TextMeshProUGUI> Method$$TextMeshProUGUI$$GetComponent {};
         static inline StaticILMethod<0x04c66970, UnityEngine::UI::HorizontalLayoutGroup> Method$$HorizontalLayoutGroup$$GetComponent {};
         static inline StaticILMethod<0x04c66980, UnityEngine::UI::Image> Method$$Image$$GetComponent {};
         static inline StaticILMethod<0x04c66918, UnityEngine::RectTransform> Method$$RectTransform$$GetComponent {};

--- a/src/mod/externals/UnityEngine/UI/Image.h
+++ b/src/mod/externals/UnityEngine/UI/Image.h
@@ -25,6 +25,115 @@ namespace UnityEngine::UI {
             float m_CachedReferencePixelsPerUnit;
         };
 
+        struct VirtualInvokeData_set_color {
+            typedef void(*Il2CppMethodPointer)(UnityEngine::UI::Image::Object* __this, UnityEngine::Color::Fields value, const MethodInfo*);
+            Il2CppMethodPointer methodPtr;
+            const MethodInfo* method;
+        };
+
+        struct VTable {
+            VirtualInvokeData _0_Equals;
+            VirtualInvokeData _1_Finalize;
+            VirtualInvokeData _2_GetHashCode;
+            VirtualInvokeData _3_ToString;
+            VirtualInvokeData _4_Awake;
+            VirtualInvokeData _5_OnEnable;
+            VirtualInvokeData _6_Start;
+            VirtualInvokeData _7_OnDisable;
+            VirtualInvokeData _8_OnDestroy;
+            VirtualInvokeData _9_IsActive;
+            VirtualInvokeData _10_OnRectTransformDimensionsChange;
+            VirtualInvokeData _11_OnBeforeTransformParentChanged;
+            VirtualInvokeData _12_OnTransformParentChanged;
+            VirtualInvokeData _13_OnDidApplyAnimationProperties;
+            VirtualInvokeData _14_OnCanvasGroupChanged;
+            VirtualInvokeData _15_OnCanvasHierarchyChanged;
+            VirtualInvokeData _16_IsDestroyed;
+            VirtualInvokeData _17_unknown;
+            VirtualInvokeData _18_UnityEngine_UI_ICanvasElement_get_transform;
+            VirtualInvokeData _19_unknown;
+            VirtualInvokeData _20_unknown;
+            VirtualInvokeData _21_unknown;
+            VirtualInvokeData _22_get_color;
+            VirtualInvokeData_set_color _23_set_color;
+            VirtualInvokeData _24_get_raycastTarget;
+            VirtualInvokeData _25_set_raycastTarget;
+            VirtualInvokeData _26_SetAllDirty;
+            VirtualInvokeData _27_SetLayoutDirty;
+            VirtualInvokeData _28_SetVerticesDirty;
+            VirtualInvokeData _29_SetMaterialDirty;
+            VirtualInvokeData _30_get_rectTransform;
+            VirtualInvokeData _31_get_defaultMaterial;
+            VirtualInvokeData _32_get_material;
+            VirtualInvokeData _33_set_material;
+            VirtualInvokeData _34_get_materialForRendering;
+            VirtualInvokeData _35_get_mainTexture;
+            VirtualInvokeData _36_OnCullingChanged;
+            VirtualInvokeData _37_Rebuild;
+            VirtualInvokeData _38_LayoutComplete;
+            VirtualInvokeData _39_GraphicUpdateComplete;
+            VirtualInvokeData _40_UpdateMaterial;
+            VirtualInvokeData _41_UpdateGeometry;
+            VirtualInvokeData _42_OnFillVBO;
+            VirtualInvokeData _43_OnPopulateMesh;
+            VirtualInvokeData _44_OnPopulateMesh;
+            VirtualInvokeData _45_SetNativeSize;
+            VirtualInvokeData _46_Raycast;
+            VirtualInvokeData _47_CrossFadeColor;
+            VirtualInvokeData _48_CrossFadeColor;
+            VirtualInvokeData _49_CrossFadeAlpha;
+            VirtualInvokeData _50_UnityEngine_UI_IClippable_get_gameObject;
+            VirtualInvokeData _51_unknown;
+            VirtualInvokeData _52_unknown;
+            VirtualInvokeData _53_unknown;
+            VirtualInvokeData _54_unknown;
+            VirtualInvokeData _55_unknown;
+            VirtualInvokeData _56_unknown;
+            VirtualInvokeData _57_unknown;
+            VirtualInvokeData _58_GetModifiedMaterial;
+            VirtualInvokeData _59_Cull;
+            VirtualInvokeData _60_SetClipRect;
+            VirtualInvokeData _61_SetClipSoftness;
+            VirtualInvokeData _62_ParentMaskStateChanged;
+            VirtualInvokeData _63_RecalculateClipping;
+            VirtualInvokeData _64_RecalculateMasking;
+            VirtualInvokeData _65_unknown;
+            VirtualInvokeData _66_unknown;
+            VirtualInvokeData _67_unknown;
+            VirtualInvokeData _68_unknown;
+            VirtualInvokeData _69_unknown;
+            VirtualInvokeData _70_unknown;
+            VirtualInvokeData _71_unknown;
+            VirtualInvokeData _72_unknown;
+            VirtualInvokeData _73_unknown;
+            VirtualInvokeData _74_unknown;
+            VirtualInvokeData _75_unknown;
+            VirtualInvokeData _76_unknown;
+            VirtualInvokeData _77_OnBeforeSerialize;
+            VirtualInvokeData _78_OnAfterDeserialize;
+            VirtualInvokeData _79_CalculateLayoutInputHorizontal;
+            VirtualInvokeData _80_CalculateLayoutInputVertical;
+            VirtualInvokeData _81_get_minWidth;
+            VirtualInvokeData _82_get_preferredWidth;
+            VirtualInvokeData _83_get_flexibleWidth;
+            VirtualInvokeData _84_get_minHeight;
+            VirtualInvokeData _85_get_preferredHeight;
+            VirtualInvokeData _86_get_flexibleHeight;
+            VirtualInvokeData _87_get_layoutPriority;
+            VirtualInvokeData _88_IsRaycastLocationValid;
+        };
+
+        inline void virtual_set_color(UnityEngine::Color::Object value) {
+            UnityEngine::Color::Fields proxy = { .r = value.fields.r, .g = value.fields.g, .b = value.fields.b, .a = value.fields.a };
+            (*(this->instance()->klass->vtable)._23_set_color.methodPtr)
+                    (this->instance(), proxy, this->instance()->klass->vtable._23_set_color.method);
+        }
+
+        inline void virtual_set_color(UnityEngine::Color::Fields value) {
+            (*(this->instance()->klass->vtable)._23_set_color.methodPtr)
+                    (this->instance(), value, this->instance()->klass->vtable._23_set_color.method);
+        }
+
         inline void set_sprite(UnityEngine::Sprite::Object* value) {
             external<void>(0x024b8ed0, this, value);
         }

--- a/src/mod/features/battle/battle_situation.cpp
+++ b/src/mod/features/battle/battle_situation.cpp
@@ -480,7 +480,7 @@ void exl_battle_situation_main() {
 
     //BUISituation_OnUpdate::InstallAtOffset(0x01d23280);
 
-    //BUISituationButton_Initialize::InstallAtOffset(0x01d22fb0);
+    BUISituationButton_Initialize::InstallAtOffset(0x01d22fb0);
 
     BUISituationDetail_ctor_fieldIDs::InstallAtOffset(0x01d26780);
     BUISituationDetail_ctor_weatherIDs::InstallAtOffset(0x01d26868);

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -148,6 +148,9 @@ void exl_sounds_main();
 // Adds support for alternate forms for the field swarm models.
 void exl_swarm_forms_main();
 
+// Changes the defaulkt text color for dialog boxes.
+void exl_text_color_main();
+
 // Allows double battles on trainers.
 void exl_trainer_double_battles_main();
 

--- a/src/mod/features/gender_neutral_boutique.cpp
+++ b/src/mod/features/gender_neutral_boutique.cpp
@@ -21,11 +21,10 @@ HOOK_DEFINE_REPLACE(Dpr_UI_ShopBoutiqueChange_SetupBoutiqueItemParams) {
 
         for (int32_t dressId = 0; dressId < OUTFIT_COUNT; dressId++)
         {
-            if (dressId == array_index(OUTFITS, "Contest Style Masculine") ||
-                dressId == array_index(OUTFITS, "Contest Style Feminine") ||
-                dressId == array_index(OUTFITS, "Bicycle Style Masculine") ||
+            if (dressId == array_index(OUTFITS, "Bicycle Style Masculine") ||
                 dressId == array_index(OUTFITS, "Bicycle Style Feminine") ||
-                dressId == array_index(OUTFITS, "Cyber Style 2.0 Masculine"))
+                dressId == array_index(OUTFITS, "Cyber Style 2.0 Masculine")||
+                dressId == array_index(OUTFITS, "Renegade Style Feminine"))
             {
                 // Don't add these outfits
                 continue;

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -106,6 +106,8 @@ void CallFeatureHooks()
         exl_form_arg_generation_main();
     if (IsActivatedFeature(array_index(FEATURES, "Pokédex Form Flags")))
         exl_dex_form_flags_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Dialog Text Color")))
+        exl_text_color_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/mega_evolution.cpp
+++ b/src/mod/features/mega_evolution.cpp
@@ -30,7 +30,7 @@
 #include "helpers/fsHelper.h"
 #include "memory/json.h"
 
-const int32_t mega_flag_loc = 34; // Assuming the first 34 bits are used.
+/*const int32_t mega_flag_loc = 34; // Assuming the first 34 bits are used.
 const long mega_flag_mask = 1L << mega_flag_loc;
 
 const int32_t ultra_burst_flag_loc = 30;
@@ -464,7 +464,7 @@ HOOK_DEFINE_TRAMPOLINE(SetupBattleTrainer) {
 
         Orig(battleSetupParam, arenaID, mapAttrib, weatherType, rule, enemyID0, enemyID1, partnerID);
     }
-};
+};*/
 
 void exl_mega_evolution_main() {
     /*OnSubmitWazaButton::InstallAtOffset(0x01d2cee8);

--- a/src/mod/features/text_color.cpp
+++ b/src/mod/features/text_color.cpp
@@ -1,0 +1,31 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Message/FontManager.h"
+#include "externals/Dpr/MsgWindow/WindowMsgText.h"
+#include "externals/UnityEngine/UI/LayoutRebuilder.h"
+
+#include "logger/logger.h"
+
+HOOK_DEFINE_REPLACE(WindowMsgText$$Initialize) {
+    static void Callback(Dpr::MsgWindow::WindowMsgText::Object* __this) {
+        Logger::log("[WindowMsgText$$Initialize]\n");
+        system_load_typeinfo(0xab43);
+
+        __this->fields.textRect = __this->cast<UnityEngine::Component>()->GetComponent(UnityEngine::Component::Method$$RectTransform$$GetComponent);
+        __this->fields.text = __this->cast<UnityEngine::Component>()->GetComponent(UnityEngine::Component::Method$$TextMeshProUGUI$$GetComponent);
+
+        // New Color
+        __this->fields.defaultColor.fields.r = 1.0f;
+        __this->fields.defaultColor.fields.g = 1.0f;
+        __this->fields.defaultColor.fields.b = 1.0f;
+        __this->fields.defaultColor.fields.a = 1.0f;
+
+        Dpr::Message::FontManager::getClass()->initIfNeeded();
+        auto fontManager = Dpr::Message::FontManager::get_Instance();
+        fontManager->ChangeFontMaterial(__this->fields.text, 0);
+    }
+};
+
+void exl_text_color_main() {
+    WindowMsgText$$Initialize::InstallAtOffset(0x01ddddb0);
+}

--- a/src/mod/features/ui/madrid_battle_ui.cpp
+++ b/src/mod/features/ui/madrid_battle_ui.cpp
@@ -390,6 +390,41 @@ HOOK_DEFINE_REPLACE(BUIActionList$$OnUpdate) {
     }
 };
 
+HOOK_DEFINE_TRAMPOLINE(BUIActionList$$OnSubmitPokeBall) {
+    static void Callback(Dpr::Battle::View::UI::BUIActionList::Object* __this) {
+        Logger::log("[BUIActionList$$OnSubmitPokeBall] we're in\n");
+
+        if (__this->fields._IsFocus_k__BackingField && __this->fields._isBallEnable && !__this->fields.isButtonAction)
+        {
+            Orig(__this);
+
+            Logger::log("[BUIActionList$$OnSubmitPokeBall] custom stuff\n");
+            Dpr::Battle::View::BattleViewCore::getClass()->initIfNeeded();
+            auto battleViewCore = Dpr::Battle::View::BattleViewCore::get_Instance();
+            ((Dpr::Battle::View::UI::BattleViewUICanvasBase::Object*)battleViewCore->fields._UISystem_k__BackingField->fields._wazaList)->Hide(false, nullptr);
+        }
+    }
+};
+
+
+HOOK_DEFINE_TRAMPOLINE(BUIPokeBallList$$OnCancel) {
+    static void Callback(Dpr::Battle::View::UI::BUIPokeBallList::Object* __this) {
+        Logger::log("[BUIPokeBallList$$OnCancel] we're in\n");
+
+        if (__this->fields.isAction) {
+            return;
+        }
+
+        Orig(__this);
+
+        Logger::log("[BUIPokeBallList$$OnCancel] custom stuff\n");
+        Dpr::Battle::View::BattleViewCore::getClass()->initIfNeeded();
+        auto battleViewCore = Dpr::Battle::View::BattleViewCore::get_Instance();
+        ((Dpr::Battle::View::UI::BattleViewUICanvasBase::Object*)battleViewCore->fields._UISystem_k__BackingField->fields._wazaList)->Show(nullptr);
+    }
+};
+
+
 HOOK_DEFINE_REPLACE(BUIWazaList$$OnUpdate) {
     static void Callback(Dpr::Battle::View::UI::BUIWazaList::Object* __this, float deltatime) {
         // Do nothing, the OnUpdate is done in BUIActionList$$OnUpdate
@@ -670,6 +705,8 @@ HOOK_DEFINE_REPLACE(BattleViewUISystem$$CMD_UI_SelectWaza_Wait) {
             __this->fields._targetSelect->fields._IsValid_k__BackingField = false;
             __this->fields._wazaList->OnCancel();
         }
+
+        // TODO: Situation Detail cancel
         return true;
     }
 };
@@ -700,6 +737,9 @@ HOOK_DEFINE_REPLACE(BattleViewUISystem$$CMD_UI_SelectWaza_ForceQuit) {
 
 void exl_madrid_ui_main() {
     BUIActionList$$OnUpdate::InstallAtOffset(0x01e8bdb0);
+    BUIActionList$$OnSubmitPokeBall::InstallAtOffset(0x01e8c1b0);
+
+    BUIPokeBallList$$OnCancel::InstallAtOffset(0x01d221b0);
 
     BUIWazaList$$OnUpdate::InstallAtOffset(0x01d2c490);
     BUIWazaList$$OnShow::InstallAtOffset(0x01d2cb70);

--- a/src/mod/features/ui/madrid_battle_ui.cpp
+++ b/src/mod/features/ui/madrid_battle_ui.cpp
@@ -16,6 +16,7 @@
 #include "externals/Dpr/Battle/View/UI/BUIWazaList.h"
 #include "externals/Dpr/Message/MessageWordSetHelper.h"
 #include "externals/Dpr/NetworkUtils/NetworkManager.h"
+#include "externals/Dpr/UI/CharacterModelView.h"
 #include "externals/Dpr/UI/UIManager.h"
 #include "externals/FlagWork.h"
 #include "externals/GameController.h"
@@ -36,11 +37,20 @@ const uint32_t AK_EVENTS_UI_COMMON_MENU_OPEN = 0x132562f0;
 const uint32_t AK_EVENTS_UI_COMMON_SELECT = 0xb7533038;
 const uint32_t AK_EVENTS_UI_COMMON_SLIDE = 0x19377fd7;
 
+const UnityEngine::Color::Fields SELECTED_MOVE_BACKGROUND_COLOR = { .r = 1, .g = 1, .b = 1, .a = 1 };
+const UnityEngine::Color::Fields NOT_SELECTED_MOVE_BACKGROUND_COLOR = { .r = 0.4, .g = 0.4, .b = 0.4, .a = 1 };
+const UnityEngine::Color::Fields SELECTED_MOVE_TEXT_COLOR = { .r = 0, .g = 0, .b = 0, .a = 1 };
+const UnityEngine::Color::Fields NOT_SELECTED_MOVE_TEXT_COLOR = { .r = 1, .g = 1, .b = 1, .a = 1 };
+
 static int32_t selectedGimmick = array_index(GIMMICKS, "None");
 
 UnityEngine::Transform::Object* GetWazaButtonBackgroundRoot(Dpr::Battle::View::UI::BUIWazaButton::Object* btn) {
     return ((UnityEngine::Component::Object*)btn)->get_transform()
             ->Find(System::String::Create("background"));
+}
+
+UnityEngine::Transform::Object* GetWazaButtonArrowRoot(Dpr::Battle::View::UI::BUIWazaButton::Object* btn) {
+    return GetWazaButtonBackgroundRoot(btn)->Find(System::String::Create("DirectionArrow"));
 }
 
 void SubmitActionButton(Dpr::Battle::View::UI::BUIActionList::Object* actionList, int32_t index) {
@@ -65,7 +75,11 @@ void SelectWazaButton(Dpr::Battle::View::UI::BUIWazaList::Object* wazaList, int3
             if (btn->fields._isSelected && btn->fields._onSelected != nullptr)
                 btn->fields._onSelected->Invoke();
 
-            ((UnityEngine::Component::Object*)GetWazaButtonBackgroundRoot(btn))->get_gameObject()->SetActive(btn->fields._isSelected);
+            ((UnityEngine::Component::Object*)GetWazaButtonArrowRoot(btn))->get_gameObject()->SetActive(btn->fields._isSelected);
+            GetWazaButtonBackgroundRoot(btn)->GetComponent(UnityEngine::Component::Method$$Image$$GetComponent)
+                ->virtual_set_color(btn->fields._isSelected ? SELECTED_MOVE_BACKGROUND_COLOR : NOT_SELECTED_MOVE_BACKGROUND_COLOR);
+
+            btn->fields._text->virtual_set_color(btn->fields._isSelected ? SELECTED_MOVE_TEXT_COLOR : NOT_SELECTED_MOVE_TEXT_COLOR);
         }
 
         Dpr::Battle::View::BattleViewCore::getClass()->initIfNeeded();
@@ -338,11 +352,18 @@ HOOK_DEFINE_REPLACE(BUIActionList$$OnUpdate) {
 
         if (Dpr::Battle::View::BtlvInput::GetPush(Dpr::UI::UIManager::getClass()->static_fields->ButtonA, true)) {
             Logger::log("[BUIActionList$$OnUpdate] Submit waza\n");
-            wazaList->OnSubmit();
-            if (wazaList->fields._IsValid_k__BackingField) {
-                Logger::log("[BUIActionList$$OnUpdate] Fight\n");
-                SubmitActionButton(__this, 0);
-                return;
+            if (wazaList->fields._CurrentIndex_k__BackingField >= 0 && wazaList->fields._CurrentIndex_k__BackingField < wazaList->fields._wazaCount)
+            {
+                wazaList->OnSubmit();
+                if (wazaList->fields._IsValid_k__BackingField) {
+                    Logger::log("[BUIActionList$$OnUpdate] Fight\n");
+                    SubmitActionButton(__this, 0);
+                    return;
+                }
+            }
+            else
+            {
+                battleViewCore->fields._UISystem_k__BackingField->PlaySe(AK_EVENTS_UI_COMMON_BEEP);
             }
         }
 
@@ -384,8 +405,6 @@ HOOK_DEFINE_REPLACE(BUIWazaList$$OnShow) {
         __this->fields._IsShow_k__BackingField = true;
         __this->fields._animationState_k__BackingField = 2;
 
-        SelectWazaButton(__this, 0, false);
-
         auto battleViewCore = Dpr::Battle::View::BattleViewCore::get_Instance();
         battleViewCore->fields._UISystem_k__BackingField->fields._cursor->SetActive(false);
     }
@@ -404,6 +423,11 @@ HOOK_DEFINE_TRAMPOLINE(BUIWazaList$$Initialize) {
             SetGimmickIconBackgroundActive(__this, i, false);
 
         UnityEngine::UI::LayoutRebuilder::ForceRebuildLayoutImmediate((UnityEngine::RectTransform::Object*)GetGimmickRoot(__this));
+
+        if (__this->fields._CurrentIndex_k__BackingField < 0 || __this->fields._CurrentIndex_k__BackingField >= __this->fields._wazaCount)
+            SelectWazaButton(__this, 0, false);
+        else
+            SelectWazaButton(__this, __this->fields._CurrentIndex_k__BackingField, false);
     }
 };
 


### PR DESCRIPTION
- Adjusts the outfit order and the list of disabled ones.
- Adds a feature to make the dialog text white.
- Hides the move list in battle when in the Poké Ball selection menu.
- Fixes crashes with the Battle Situation UI.