### PR TITLE
Language UI fixes

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -51,6 +51,7 @@ static constexpr const char* FEATURES[] = {
     "AYou Patches",
     "Pokédex Form Flags",
     "Dialog Text Color",
+    "Language UI Fixes",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/Dpr/UI/LevelUpPokemonPanel.h
+++ b/src/mod/externals/Dpr/UI/LevelUpPokemonPanel.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/PokemonIcon.h"
+#include "externals/Dpr/UI/UILevelUp.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/UI/Image.h"
+#include "externals/UnityEngine/UI/Slider.h"
+#include "externals/System/Action.h"
+#include "externals/TMPro/TextMeshProUGUI.h"
+
+namespace Dpr::UI {
+    struct LevelUpPokemonPanel : ILClass<LevelUpPokemonPanel> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            PokemonIcon::Object* pokemonIcon;
+            TMPro::TextMeshProUGUI::Object* nameText;
+            UnityEngine::UI::Image::Object* genderIconImage;
+            TMPro::TextMeshProUGUI::Object* levelText;
+            TMPro::TextMeshProUGUI::Object* addExpText;
+            UnityEngine::UI::Slider::Object* expBar;
+            void* levelUpImageCanvasGroup;
+            bool isAnimationGauge;
+            bool isSkipAnimation;
+            bool isExpBarTweenBoost;
+            uint32_t minExp;
+            uint32_t maxExp;
+            float expBarTweenDuration;
+            void* newLearnWazaResultList;
+            Pml::PokePara::PokemonParam::Object* _PokemonParam_k__BackingField;
+            UILevelUp::PokemonStatus::Object _CurrentPokemonStatus_k__BackingField;
+            UILevelUp::PokemonStatus::Object _BeforePokemonStatus_k__BackingField;
+            System::Action::Object* _OnGaugeUp_k__BackingField;
+            System::Action::Object* _OnLevelUp_k__BackingField;
+            bool _IsLevelUp_k__BackingField;
+            bool _IsAnimation_k__BackingField;
+            bool _IsActive_k__BackingField;
+        };
+    };
+}

--- a/src/mod/externals/Dpr/UI/UILevelUp.h
+++ b/src/mod/externals/Dpr/UI/UILevelUp.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/UIMsgWindowController.h"
+#include "externals/Dpr/UI/UIWindow.h"
+#include "externals/Pml/PokeParty.h"
+#include "externals/System/Primitives.h"
+
+namespace Dpr::UI {
+    struct LevelUpPokemonPanel;
+
+    struct UILevelUp : ILClass<UILevelUp> {
+        struct Param : ILStruct<Param> {
+            struct Fields {
+                System::UInt32_array* AddExpValues;
+                int32_t TargetIndex;
+                int32_t LevelUpCount;
+                Pml::PokeParty::Object* PokeParty;
+                void* BattleExpGetResult;
+            };
+        };
+
+        struct PokemonStatus : ILStruct<PokemonStatus> {
+            struct Fields {
+                uint32_t Level;
+                uint32_t Exp;
+                uint32_t Hp;
+                uint32_t Attack;
+                uint32_t Deffence;
+                uint32_t SpecialAttack;
+                uint32_t SpecialDeffence;
+                uint32_t Agility;
+            };
+        };
+
+        struct Fields : Dpr::UI::UIWindow::Fields {
+            int32_t _animStateIn;
+            int32_t _animStateOut;
+            void* levelUpPokemonPanels; // This causes a circular definition, since it has to be an array
+            void* statusPanel;
+            Param::Object param;
+            UIMsgWindowController::Object* msgWindowController;
+            bool isAnimateGauge;
+            bool isPlayGaugeUpSe;
+            bool isPlayLevelUpSe;
+            bool isWaitExit;
+        };
+
+        inline void Set(Pml::PokePara::PokemonParam::Object* param, int32_t index) {
+            external<void>(0x01c5a4f0, this, param, index);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -59,7 +59,7 @@ namespace Dpr::UI {
             void* _comparerPlaceName; // Dpr_UI_UIManager_ComparerPlaceName_o*
         };
 
-        static inline Dpr::UI::UIManager::Object* instance() {
+        static inline Dpr::UI::UIManager::Object* get_Instance() {
             return SmartPoint::AssetAssistant::SingletonMonoBehaviour::get_Instance(SmartPoint::AssetAssistant::SingletonMonoBehaviour::Method$$UIManager$$get_Instance);
         }
 

--- a/src/mod/externals/System/String.h
+++ b/src/mod/externals/System/String.h
@@ -48,6 +48,14 @@ namespace System {
             return external<String::Object*>(0x026f4560, this, startIndex, length);
         }
 
+        inline String::Object* Substring(int32_t startIndex) {
+            return external<String::Object*>(0x026f46d0, this, startIndex);
+        }
+
+        inline int32_t LastIndexOf(uint16_t value) {
+            return external<int32_t>(0x026f6ef0, this, value);
+        }
+
         inline String::Object* Truncate(int32_t maxLength) {
             String::Object* str = this->instance();
             if (IsNullOrEmpty(str))

--- a/src/mod/features/battle/battle_situation.cpp
+++ b/src/mod/features/battle/battle_situation.cpp
@@ -175,7 +175,7 @@ HOOK_DEFINE_TRAMPOLINE(BUISituationButton_Initialize) {
         auto coreParam = (Pml::PokePara::CoreParam::Object*)btlParam->GetSrcData();
         MethodInfo* mi = Dpr::UI::PokemonIcon::getMethod$$BUISituationLoadIcon((Il2CppMethodPointer) &LoadSpriteToImage);
         auto onLoad = UnityEngine::Events::UnityAction::getClass(UnityEngine::Events::UnityAction::Sprite_TypeInfo)->newInstance(__this->fields._pokeIcon, mi);
-        auto uiManager = Dpr::UI::UIManager::instance();
+        auto uiManager = Dpr::UI::UIManager::get_Instance();
 
         uiManager->LoadSpritePokemon(coreParam->GetMonsNo(), coreParam->GetFormNo(), coreParam->GetSex(), coreParam->GetRareType(), coreParam->IsEgg(Pml::PokePara::EggCheckType::BOTH_EGG), onLoad);
         Logger::log("BUISituationButton_Initialize END\n");

--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -29,7 +29,7 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
     if (args->max_length >= 7) {
         if (azukariyaSeq == 0) {
             SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
-            auto uiManager = Dpr::UI::UIManager::instance();
+            auto uiManager = Dpr::UI::UIManager::get_Instance();
             Dpr::UI::UIZukanRegister::Object* uiZukanReg = uiManager->CreateUIWindow(
                     UIWindowID::ZUKAN_REGISTER, Dpr::UI::UIManager::Method$$CreateUIWindow_UIZukanRegister_);
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -104,6 +104,9 @@ void exl_madrid_ui_main();
 //
 void exl_mega_evolution_main();
 
+// Fixes bugs with specific UI elements not matching the player's language.
+void exl_language_ui_fixes_main();
+
 // Uniformizes local trades across languages and allows extending the table in RomFS.
 void exl_local_trades_main();
 

--- a/src/mod/features/form_argument_generation.cpp
+++ b/src/mod/features/form_argument_generation.cpp
@@ -4,6 +4,7 @@
 #include "data/utils.h"
 
 #include "externals/DPData/Form_Enums.h"
+#include "externals/Dpr/UI/ZukanInfo.h"
 #include "externals/GFL.h"
 #include "externals/PlayerWork.h"
 #include "externals/Pml/Personal/GrowTableExtensions.h"
@@ -133,7 +134,16 @@ HOOK_DEFINE_INLINE(EggGenerator$$CreateEgg_CoreParam_Variants) {
     }
 };
 
+HOOK_DEFINE_TRAMPOLINE(ZukanInfo$$GetCurrentPokemonParam) {
+    static Pml::PokePara::PokemonParam::Object* Callback(Dpr::UI::ZukanInfo::Object* __this) {
+        auto param = Orig(__this);
+        param->fields.m_accessor->SetMultiPurposeWork(0); // Hardcode the variant to 0 in the dex
+        return param;
+    }
+};
+
 void exl_form_arg_generation_main() {
     Factory$$InitCoreData::InstallAtOffset(0x02054140);
     EggGenerator$$CreateEgg_CoreParam_Variants::InstallAtOffset(0x0204e28c);
+    ZukanInfo$$GetCurrentPokemonParam::InstallAtOffset(0x01bb04e0);
 }

--- a/src/mod/features/language_ui_fixes.cpp
+++ b/src/mod/features/language_ui_fixes.cpp
@@ -1,0 +1,31 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/UI/LevelUpPokemonPanel.h"
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/UnityEngine/UI/Image.h"
+
+UnityEngine::Transform::Object* NavigateToLevelUpImage(UnityEngine::Transform::Object* root) {
+    return root->Find(System::String::Create("Panel"))
+        ->Find(System::String::Create("Base"))
+        ->Find(System::String::Create("LevelUp"))
+        ->Find(System::String::Create("TextImage"));
+}
+
+HOOK_DEFINE_TRAMPOLINE(LevelUpPokemonPanel$$Set) {
+    static void Callback(Dpr::UI::LevelUpPokemonPanel::Object* __this, Pml::PokePara::PokemonParam::Object* param, int32_t index) {
+        system_load_typeinfo(0xab8f);
+
+        auto tf = NavigateToLevelUpImage(__this->cast<UnityEngine::Component>()->get_transform()->instance());
+        auto image = tf->cast<UnityEngine::Component>()->GetComponent(UnityEngine::Component::Method$$Image$$GetComponent);
+
+        Dpr::UI::UIManager::getClass()->initIfNeeded();
+        auto sprite = Dpr::UI::UIManager::get_Instance()->GetAtlasSprite(SpriteAtlasID::COMMON_LANG, System::String::Create("cmn_txt_LvUp_01_01"));
+        image->set_sprite(sprite);
+
+        Orig(__this, param, index);
+    }
+};
+
+void exl_language_ui_fixes_main() {
+    LevelUpPokemonPanel$$Set::InstallAtOffset(0x01c5a4f0);
+}

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -110,6 +110,8 @@ void CallFeatureHooks()
         exl_dex_form_flags_main();
     if (IsActivatedFeature(array_index(FEATURES, "Dialog Text Color")))
         exl_text_color_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Language UI Fixes")))
+        exl_language_ui_fixes_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/more_settings.cpp
+++ b/src/mod/features/more_settings.cpp
@@ -33,16 +33,16 @@ void OnValueChanged(int32_t configId, int32_t value) {
 void SetSetting(DPData::CONFIG::Object* config, ExtraSettingsSaveData* extraSettings, int32_t configId, int32_t value) {
     switch (configId) {
         case array_index(SETTINGS, "EXP Share"):
-            extraSettings->expShareEnabled = value != 0;
+            extraSettings->expShareEnabled = value == 0; // Index 0 is "On" and index 1 is "Off"
             break;
         case array_index(SETTINGS, "Affection"):
-            extraSettings->affectionEnabled = value != 0;
+            extraSettings->affectionEnabled = value == 0; // Index 0 is "On" and index 1 is "Off"
             break;
         case array_index(SETTINGS, "Level Cap"):
-            extraSettings->levelCapEnabled = value != 0;
+            extraSettings->levelCapEnabled = value == 0; // Index 0 is "On" and index 1 is "Off"
             break;
         case array_index(SETTINGS, "Visible Shiny Eggs"):
-            extraSettings->shinyEggsEnabled = value != 0;
+            extraSettings->shinyEggsEnabled = value == 0; // Index 0 is "On" and index 1 is "Off"
             break;
         case array_index(SETTINGS, "Trainer Sets"):
             extraSettings->gameMode = (ExtraSettingsSaveData::GameMode)value;
@@ -59,13 +59,13 @@ void SetSetting(DPData::CONFIG::Object* config, ExtraSettingsSaveData* extraSett
 int32_t GetSetting(DPData::CONFIG::Object* config, ExtraSettingsSaveData* extraSettings, int32_t configId) {
     switch (configId) {
         case array_index(SETTINGS, "EXP Share"):
-            return extraSettings->expShareEnabled ? 1 : 0;
+            return extraSettings->expShareEnabled ? 0 : 1; // Index 0 is "On" and index 1 is "Off"
         case array_index(SETTINGS, "Affection"):
-            return extraSettings->affectionEnabled ? 1 : 0;
+            return extraSettings->affectionEnabled ? 0 : 1; // Index 0 is "On" and index 1 is "Off"
         case array_index(SETTINGS, "Level Cap"):
-            return extraSettings->levelCapEnabled ? 1 : 0;
+            return extraSettings->levelCapEnabled ? 0 : 1; // Index 0 is "On" and index 1 is "Off"
         case array_index(SETTINGS, "Visible Shiny Eggs"):
-            return extraSettings->shinyEggsEnabled ? 1 : 0;
+            return extraSettings->shinyEggsEnabled ? 0 : 1; // Index 0 is "On" and index 1 is "Off"
         case array_index(SETTINGS, "Trainer Sets"):
             return (int32_t)extraSettings->gameMode;
         case array_index(SETTINGS, "Team Randomization"):

--- a/src/mod/features/more_settings.cpp
+++ b/src/mod/features/more_settings.cpp
@@ -373,7 +373,7 @@ HOOK_DEFINE_REPLACE(SettingWindow_OpOpen$$MoveNext) {
                 window->cast<Dpr::UI::UIWindow>()->OnOpen(__this->fields.prevWindowId);
 
                 Dpr::UI::UIManager::getClass()->initIfNeeded();
-                auto keyguide = Dpr::UI::UIManager::instance()->GetKeyguide(nullptr, true)->instance();
+                auto keyguide = Dpr::UI::UIManager::get_Instance()->GetKeyguide(nullptr, true)->instance();
                 keyguide->cast<UnityEngine::Component>()->get_transform()->SetParent(
                         window->cast<UnityEngine::Component>()->get_transform(), false);
 

--- a/src/mod/features/pla_context_menu.cpp
+++ b/src/mod/features/pla_context_menu.cpp
@@ -91,7 +91,7 @@ void EvDataManager_EvCmdCallWazaOmoidashiUi_b__1539_0(Dpr::EvScript::EvDataManag
     };
 
     SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
-    auto uiManager = Dpr::UI::UIManager::instance();
+    auto uiManager = Dpr::UI::UIManager::get_Instance();
     auto uiWazaManage = (Dpr::UI::UIWazaManage::Object *) uiManager->CreateUIWindow(UIWindowID::WAZA_MANAGE, Dpr::UI::UIManager::Method$$CreateUIWindow_UIWazaManage_);
 
     // nullptr on the MethodInfo here doesn't crash somehow
@@ -123,7 +123,7 @@ void createMoveRelearnerWindow(Dpr::UI::PokemonWindow::DisplayClass25_0::Object 
     };
 
     SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
-    auto uiManager = Dpr::UI::UIManager::instance();
+    auto uiManager = Dpr::UI::UIManager::get_Instance();
     auto uiWazaManage = uiManager->CreateUIWindow<Dpr::UI::UIWazaManage>(UIWindowID::WAZA_MANAGE, Dpr::UI::UIManager::Method$$CreateUIWindow_UIWazaManage_);
 
     // nullptr on the MethodInfo here doesn't crash somehow

--- a/src/mod/features/poketch_back_button.cpp
+++ b/src/mod/features/poketch_back_button.cpp
@@ -114,7 +114,7 @@ HOOK_DEFINE_REPLACE(PoketchWindow_OnUpdate) {
             return;
         }
 
-        auto uiManager = Dpr::UI::UIManager::instance();
+        auto uiManager = Dpr::UI::UIManager::get_Instance();
         auto currentWindow = (UnityEngine::_Object::Object *)uiManager->GetCurrentUIWindow<Dpr::UI::UIWindow>(Dpr::UI::UIManager::Method$$GetCurrentUIWindow_UIWindow_);
         bool isCurrentWindowPoketch = !UnityEngine::_Object::op_Inequality(currentWindow, (UnityEngine::_Object::Object *)__this);
         if (isCurrentWindowPoketch)

--- a/src/mod/features/relumi_dex_ui.cpp
+++ b/src/mod/features/relumi_dex_ui.cpp
@@ -23,7 +23,7 @@ UnityEngine::Sprite::Object* GetEggGroupSprite(int32_t eggGroup, int32_t langId)
     auto langStr = Dpr::Message::MessageHelper::GetLanguageVariant(langId);
     auto fullStr = System::String::Concat(prefixStr, langStr);
 
-    return Dpr::UI::UIManager::instance()->GetAtlasSprite(SpriteAtlasID::ZUKAN, fullStr);
+    return Dpr::UI::UIManager::get_Instance()->GetAtlasSprite(SpriteAtlasID::ZUKAN, fullStr);
 }
 
 void SetEggGroupIcons(Dpr::UI::TypePanel::Object* panel1, Dpr::UI::TypePanel::Object* panel2, int32_t eggGroup1, int32_t eggGroup2, int32_t getStatus, int32_t langId)

--- a/src/mod/features/small_patches.cpp
+++ b/src/mod/features/small_patches.cpp
@@ -39,6 +39,13 @@ HOOK_DEFINE_INLINE(DoEvolve_ItemCancelCheck) {
     }
 };
 
+HOOK_DEFINE_INLINE(BoxSearchPanel_CreateSearchDataListCore_MonIcon) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto str = (System::String::Object*)ctx->X[0];
+        ctx->X[0] = (uint64_t)str->Substring(str->LastIndexOf('_') + 1);
+    }
+};
+
 void exl_patches_main() {
     using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;
@@ -65,4 +72,5 @@ void exl_patches_main() {
 
     GetMessageLangIdFromIetfCode::InstallAtOffset(0x017c21f0); // Always returns first boot language as English
     DoEvolve_ItemCancelCheck::InstallAtOffset(0x0177f16c); // All evolutions by item make the evolution non-cancellable with B, not just vanilla items
+    BoxSearchPanel_CreateSearchDataListCore_MonIcon::InstallAtOffset(0x01caf0b8); // Box Search checks all characters after "_" to get monsno and not just the last 3
 }

--- a/src/mod/features/uniform_ui.cpp
+++ b/src/mod/features/uniform_ui.cpp
@@ -92,7 +92,7 @@ HOOK_DEFINE_REPLACE(ContestPlayerEntity$$AppendLoadPokemonIcon) {
         system_load_typeinfo(0x2fc3);
         Dpr::UI::UIManager::getClass()->initIfNeeded();
 
-        auto uiManager = Dpr::UI::UIManager::instance();
+        auto uiManager = Dpr::UI::UIManager::get_Instance();
         auto param = __this->fields.playerData->fields.pokemonInfo->fields.pokeParam;
 
         auto callback = UnityEngine::Events::UnityAction::getClass(UnityEngine::Events::UnityAction::Sprite_TypeInfo)

--- a/src/mod/ui/components/element_inspector.h
+++ b/src/mod/ui/components/element_inspector.h
@@ -35,7 +35,7 @@ namespace ui {
                     ImGui::TreePop();
                 }
 
-                auto manager = Dpr::UI::UIManager::instance();
+                auto manager = Dpr::UI::UIManager::get_Instance();
                 drawElement(manager->fields._activeRoot);
             }
         }

--- a/src/mod/ui/tools/animation_tool.h
+++ b/src/mod/ui/tools/animation_tool.h
@@ -42,7 +42,7 @@ namespace ui {
                 _.Button([fieldAnimationId, loopAnim](Button &_) {
                     _.label = "Play Field Animation";
                     _.onClick = [fieldAnimationId, loopAnim]() {
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         Logger::log("Playing Field Animation %s (%d)\n", FIELD_MON_CLIPS[fieldAnimationId->selected], fieldAnimationId->selected);
                         uiManager->fields._modelView->PlayAnimation(fieldAnimationId->selected, loopAnim->enabled);
                     };
@@ -51,7 +51,7 @@ namespace ui {
                 _.Button([battleAnimationId, loopAnim](Button &_) {
                     _.label = "Play Battle Animation";
                     _.onClick = [battleAnimationId, loopAnim]() {
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         Logger::log("Playing Battle Animation %s (%d)\n", BATTLE_MON_CLIPS[battleAnimationId->selected], battleAnimationId->selected);
                         uiManager->fields._modelView->PlayAnimation(battleAnimationId->selected, loopAnim->enabled);
                     };

--- a/src/mod/ui/tools/material_tool.h
+++ b/src/mod/ui/tools/material_tool.h
@@ -22,7 +22,7 @@ namespace ui {
                         system_load_typeinfo(0x1e84);
                         system_load_typeinfo(0x1e8d);
 
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         UnityEngine::GameObject::Object* go = uiManager->fields._modelView->fields._modelParam->fields.gameObject;
                         auto unityObj = (UnityEngine::_Object::Object*)go;
                         Logger::log("GameObject %s\n", unityObj->GetName()->asCString().c_str());
@@ -86,7 +86,7 @@ namespace ui {
                         system_load_typeinfo(0x1e84);
                         system_load_typeinfo(0x1e8d);
 
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         UnityEngine::GameObject::Object* go = uiManager->fields._modelView->fields._modelParam->fields.gameObject;
                         auto renderers = go->GetComponentsInChildren(false, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
 
@@ -125,7 +125,7 @@ namespace ui {
                         system_load_typeinfo(0x1e84);
                         system_load_typeinfo(0x1e8d);
 
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         UnityEngine::GameObject::Object* go = uiManager->fields._modelView->fields._modelParam->fields.gameObject;
                         auto renderers = go->GetComponentsInChildren(false, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
 
@@ -174,7 +174,7 @@ namespace ui {
                         system_load_typeinfo(0x1e84);
                         system_load_typeinfo(0x1e8d);
 
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         UnityEngine::GameObject::Object* go = uiManager->fields._modelView->fields._modelParam->fields.gameObject;
                         auto renderers = go->GetComponentsInChildren(false, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
 
@@ -213,7 +213,7 @@ namespace ui {
                         system_load_typeinfo(0x1e84);
                         system_load_typeinfo(0x1e8d);
 
-                        auto uiManager = Dpr::UI::UIManager::instance();
+                        auto uiManager = Dpr::UI::UIManager::get_Instance();
                         UnityEngine::GameObject::Object* go = uiManager->fields._modelView->fields._modelParam->fields.gameObject;
                         auto renderers = go->GetComponentsInChildren(false, UnityEngine::GameObject::Method$$SkinnedMeshRenderer$$GetComponentsInChildren);
 


### PR DESCRIPTION
- Makes the level-up image that depends on language work without needing a direct dependency to common_lang in the UI bundle.
- Fixes inverted settings (again) (for the final time)
- Makes the box search UI able to find Pokémon icons for NatDex numbers with 4+ digits.
  - Instead of doing a substring grabbing the last 3 digits of the name label (ew), we grab everything after the last underscore (still ugly, but better)
- Hardcodes the Pokémon models in the Pokédex to use variant 0.