### PR TITLE
Move Tutor UI

### DIFF
--- a/src/common/memory/string.cpp
+++ b/src/common/memory/string.cpp
@@ -17,4 +17,12 @@ namespace nn {
         else
             return string("");
     }
+
+    string to_string(uint32_t value, const char* format) {
+        char buffer[100] = {};
+        if (nn::util::SNPrintf(buffer, sizeof(buffer), format, value) >= 0)
+            return string(buffer);
+        else
+            return string("");
+    }
 }

--- a/src/common/memory/string.h
+++ b/src/common/memory/string.h
@@ -8,4 +8,5 @@ namespace nn {
 
     string to_string(int32_t value);
     string to_string(int32_t value, const char* format);
+    string to_string(uint32_t value, const char* format);
 }

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -52,6 +52,7 @@ static constexpr const char* FEATURES[] = {
     "Pokédex Form Flags",
     "Dialog Text Color",
     "Language UI Fixes",
+    "Move Tutor Relearner",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1263,6 +1263,8 @@ namespace Dpr::EvScript {
             _SET_AYOU_NAME = 1253,
             _AYOU_NAME = 1254,
             _GET_CAUGHT_LOCATION = 1255,
+            _CHECK_TUTOR_MOVE = 1256,
+            _MOVE_TUTOR_UI = 1257,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -8,6 +8,7 @@
 #include "externals/EventCameraTable.h"
 #include "externals/EvData.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/System/Action.h"
 #include "externals/System/MulticastDelegate.h"
 #include "externals/System/Primitives.h"
 #include "externals/System/String.h"
@@ -356,6 +357,7 @@ namespace Dpr::EvScript {
         static inline StaticILMethod<0x04c7cf70, bool, System::String::Object*>    Method$$EvDataManager_EvCmdNameInPoke_OnComplete {};
         static inline StaticILMethod<0x04c7cfd0>                                   Method$$EvDataManager_CmdFirstPokeSelectProc {};
         static inline StaticILMethod<0x04c7cfd8, int32_t>                          Method$$EvDataManager_EvCmdAddPokemonUI {};
+        static inline StaticILMethod<0x04c7d040, int32_t, int32_t>                 Method$$EvDataManager_EvCmdCallWazaOmoidashiUi {};
 
         static inline MethodInfo* Method$$EvCmdCallWazaOmoidashiUiParty = nullptr;
         static MethodInfo* getMethod$$EvCmdCallWazaOmoidashiUiParty(Il2CppMethodPointer method) {
@@ -427,6 +429,10 @@ namespace Dpr::EvScript {
 
         inline void SetBattleReturn() {
             external<void>(0x02c45c90, this);
+        }
+
+        inline bool CallWazaUICommon(int32_t bootType, Pml::PokePara::PokemonParam::Object* pokemonParam, System::Action::Object* resultCallback, int32_t oshieWazaNo) {
+            return external<bool>(0x02c92530, this, bootType, pokemonParam, resultCallback, oshieWazaNo);
         }
 
         static inline Dpr::EvScript::EvDataManager::Object* get_Instanse() {

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -366,11 +366,25 @@ namespace Dpr::EvScript {
             return Method$$EvCmdCallWazaOmoidashiUiParty;
         };
 
+        static inline MethodInfo* Method$$EvCmdCallWazaOmoidashiUiTutor = nullptr;
+        static MethodInfo* getMethod$$EvCmdCallWazaOmoidashiUiTutor(Il2CppMethodPointer method) {
+            if (Method$$EvCmdCallWazaOmoidashiUiTutor == nullptr)
+                Method$$EvCmdCallWazaOmoidashiUiTutor = (*PTR_Method$$EvDataManager_EvCmdCallWazaOmoidashiUi)->copyWith(method);
+            return Method$$EvCmdCallWazaOmoidashiUiTutor;
+        };
+
         static inline MethodInfo* Method$$EvCmdCallWazaOshieUiParty = nullptr;
         static MethodInfo* getMethod$$EvCmdCallWazaOshieUiParty(Il2CppMethodPointer method) {
             if (Method$$EvCmdCallWazaOshieUiParty == nullptr)
                 Method$$EvCmdCallWazaOshieUiParty = (*PTR_Method$$EvDataManager_EvCmdCallWazaOshieUi)->copyWith(method);
             return Method$$EvCmdCallWazaOshieUiParty;
+        };
+
+        static inline MethodInfo* Method$$EvCmdCallWazaOshieUiTutor = nullptr;
+        static MethodInfo* getMethod$$EvCmdCallWazaOshieUiTutor(Il2CppMethodPointer method) {
+            if (Method$$EvCmdCallWazaOshieUiTutor == nullptr)
+                Method$$EvCmdCallWazaOshieUiTutor = (*PTR_Method$$EvDataManager_EvCmdCallWazaOshieUi)->copyWith(method);
+            return Method$$EvCmdCallWazaOshieUiTutor;
         };
 
         static inline MethodInfo* Method$$EvCmdNameInPoke_OnCompleteAYou = nullptr;

--- a/src/mod/externals/Dpr/Message/MessageWordSetHelper.h
+++ b/src/mod/externals/Dpr/Message/MessageWordSetHelper.h
@@ -48,5 +48,9 @@ namespace Dpr::Message {
         static inline void SetTrainerNameWord(int32_t tagIndex, System::String::Object* labelName) {
             external<void>(0x01f9bf50, tagIndex, labelName);
         }
+
+        static inline void SetWazaNameWord(int32_t tagIndex, int32_t wazaNo) {
+            external<void>(0x01f9a650, tagIndex, wazaNo);
+        }
     };
 }

--- a/src/mod/externals/Dpr/UI/PokemonSick.h
+++ b/src/mod/externals/Dpr/UI/PokemonSick.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+#include "externals/UnityEngine/UI/Image.h"
+
+namespace Dpr::UI {
+    struct PokemonSick : ILClass<PokemonSick> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            void* _canvasGroup; // UnityEngine_CanvasGroup_o*
+            UnityEngine::UI::Image::Object* _image;
+            void* _fadeTw; // DG_Tweening_Core_TweenerCore_float__float__FloatOptions__o*
+            int32_t _sick;
+        };
+
+        inline void Setup(Pml::PokePara::PokemonParam::Object* pokemonParam) {
+            external<void>(0x01d93960, this, pokemonParam);
+        }
+
+        inline void Setup(Dpr::Battle::Logic::BTL_POKEPARAM::Object* btlParam) {
+            external<void>(0x01d938e0, this, btlParam);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -2,6 +2,7 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
 #include "externals/Dpr/Message/MessageEnumData.h"
 #include "externals/Dpr/UI/UIModelViewController.h"
 #include "externals/Dpr/UI/UIWazaManage.h"
@@ -109,6 +110,22 @@ namespace Dpr::UI {
 
         static inline Dpr::Message::MessageEnumData::MsgLangId GetCurrentLangId() {
             return external<Dpr::Message::MessageEnumData::MsgLangId>(0x017be8c0);
+        }
+
+        inline UnityEngine::Sprite::Object* GetSpritePokemonSex(Pml::Sex sex) {
+            return external<UnityEngine::Sprite::Object*>(0x017c11f0, this, sex);
+        }
+
+        static inline Dpr::Battle::Logic::BTL_POKEPARAM::Object* ToBattlePokemonParam(Pml::PokePara::PokemonParam::Object* pokemonParam) {
+            return external<Dpr::Battle::Logic::BTL_POKEPARAM::Object*>(0x017c2ea0, pokemonParam);
+        }
+
+        inline UnityEngine::Sprite::Object* GetSpritePokemonLanguage(Dpr::Message::MessageEnumData::MsgLangId langId) {
+            return external<UnityEngine::Sprite::Object*>(0x017c2720, this, langId);
+        }
+
+        inline UnityEngine::Sprite::Object* GetSpriteMonsterBall(uint8_t ballId) {
+            return external<UnityEngine::Sprite::Object*>(0x017c2300, this, ballId);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/UIMsgWindowController.h
+++ b/src/mod/externals/Dpr/UI/UIMsgWindowController.h
@@ -30,6 +30,10 @@ namespace Dpr::UI {
         inline void CloseMsgWindow() {
             external<void>(0x01a13610, this);
         }
+
+        inline bool OnUpdate(float deltaTime) {
+            return external<bool>(0x01a13de0, this, deltaTime);
+        }
     };
 }
 

--- a/src/mod/externals/Dpr/UI/UIText.h
+++ b/src/mod/externals/Dpr/UI/UIText.h
@@ -2,6 +2,7 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Message/MessageEnumData.h"
 #include "externals/System/Collections/Generic/List.h"
 #include "externals/System/String.h"
 #include "externals/TMPro/TextMeshProUGUI.h"
@@ -11,7 +12,6 @@
 namespace Dpr::UI {
     struct UIText : ILClass<UIText> {
         struct Fields : TMPro::TextMeshProUGUI::Fields {
-            // TODO: The class this inherits from has misaligned fields because of missing classes/structs. Do not use the below fields until this is fixed.
             int32_t _sizeId;
             bool _useMessage;
             System::String::Object* _messageFile;
@@ -23,6 +23,9 @@ namespace Dpr::UI {
             void* _msgFile;
             int32_t _messageIndex;
         };
+
+        static_assert(offsetof(Fields, _useMessage) == 0x76c);
+        static_assert(offsetof(Fields, _messageIndex) == 0x798);
 
         struct VirtualInvokeData_set_color {
             typedef void(*Il2CppMethodPointer)(UIText::Object*, UnityEngine::Color::Fields, const MethodInfo*);
@@ -207,6 +210,10 @@ namespace Dpr::UI {
 
         inline void SetFormattedText(UnityEngine::Events::UnityAction::Object* onSet, System::String::Object* messageFile, System::String::Object* messageId) {
             external<void>(0x01dc76c0, this, onSet, messageFile, messageId);
+        }
+
+        inline void UpdateMessage(bool isForce, Dpr::Message::MessageEnumData::MsgLangId langId) {
+            external<void>(0x01dd1480, this, isForce, langId);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/UIWazaManage.h
+++ b/src/mod/externals/Dpr/UI/UIWazaManage.h
@@ -2,9 +2,13 @@
 
 #include "externals/il2cpp.h"
 
+#include "externals/Dpr/UI/PokemonSick.h"
 #include "externals/Dpr/UI/UIMsgWindowController.h"
 #include "externals/Dpr/UI/UIText.h"
 #include "externals/Dpr/UI/UIWindow.h"
+#include "externals/Dpr/UI/WazaManageCondition.h"
+#include "externals/Dpr/UI/WazaManagePokemonStausPanel.h"
+#include "externals/Dpr/UI/WazaManageWazaStatusPanel.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
 #include "externals/System/Action.h"
 #include "externals/UnityEngine/GameObject.h"
@@ -13,7 +17,17 @@
 
 namespace Dpr::UI {
     struct UIWazaManage : ILClass<UIWazaManage> {
-        struct __c__DisplayClass39_0 : ILClass<__c__DisplayClass39_0> {
+        struct __c__DisplayClass35_0 : ILClass<__c__DisplayClass35_0, 0x04c63240> {
+            struct Fields {
+                Pml::PokePara::PokemonParam::Object* pokemonParam;
+            };
+
+            inline void ctor() {
+                external<void>(0x01a34470, this);
+            }
+        };
+
+        struct __c__DisplayClass39_0 : ILClass<__c__DisplayClass39_0, 0x04c63258> {
             struct Fields {
                 int32_t selectWazaNo;
                 int32_t learnWazaNo;
@@ -22,6 +36,10 @@ namespace Dpr::UI {
                 System::Action::Object* __9__4;
                 System::Action::Object* __9__3;
             };
+
+            inline void ctor() {
+                external<void>(0x01a34580, this);
+            }
         };
 
         struct Param : ILStruct<Param> {
@@ -40,17 +58,17 @@ namespace Dpr::UI {
             void* categoryTabs; // Dpr_UI_PokemonStatusTab_array*
             UnityEngine::GameObject::Array* statusPanelObjects;
             UnityEngine::UI::Image::Array* categoryTabCornerImages;
-            void* wazaStatusPanels; // Dpr_UI_WazaManageWazaStatusPanel_array*
+            WazaManageWazaStatusPanel::Array* wazaStatusPanels;
             UnityEngine::UI::Image::Object* pokemonInfoMonsterBallImage;
             UnityEngine::RectTransform::Object* pokemonInfoSelectArrowRoot;
             Dpr::UI::UIText::Object* pokemonInfoName;
             Dpr::UI::UIText::Object* pokemonInfoLevel;
             UnityEngine::UI::Image::Object* pokemonInfoSex;
             UnityEngine::UI::Image::Object* pokemonInfoLanguage;
-            void* pokemonInfoSick; // Dpr_UI_PokemonSick_o*
-            void* battlePokemonStatusPanel; // Dpr_UI_WazaManagePokemonStausPanel_o*
-            void* contestPokemonStatusPanel; // Dpr_UI_WazaManagePokemonStausPanel_o*
-            void* statusPanelCondition; // Dpr_UI_WazaManageCondition_o*
+            Dpr::UI::PokemonSick::Object* pokemonInfoSick;
+            WazaManagePokemonStausPanel::Object* battlePokemonStatusPanel;
+            WazaManagePokemonStausPanel::Object* contestPokemonStatusPanel;
+            WazaManageCondition::Object* statusPanelCondition;
             Dpr::UI::UIMsgWindowController::Object* msgWindowController;
             void* activeTabs; // System_Collections_Generic_List_PokemonStatusTab__o*
             int32_t _animStateIn;
@@ -59,10 +77,20 @@ namespace Dpr::UI {
             Dpr::UI::UIWazaManage::Param::Object param;
         };
 
+        static inline StaticILMethod<0x04c80ca0> Method$$OnUpdate$$b__2 {};
         static inline StaticILMethod<0x04c80cc8> Method$$OnUpdate$$b__39_0 {};
+        static inline StaticILMethod<0x04c80cd0> Method$$OnUpdate$$b__39_1 {};
 
         inline void Open(Dpr::UI::UIWazaManage::Param::Object param, MethodInfo* method) {
             external<void>(0x01dd3d80, this, param, method);
+        }
+
+        inline void UpdateSelectTab(float deltaTime) {
+            external<void>(0x01dd5150, this, deltaTime);
+        }
+
+        inline void Close(UnityEngine::Events::UnityAction::Object* onClosed_) {
+            external<void>(0x01dd4970, this, onClosed_);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/UIWazaManage.h
+++ b/src/mod/externals/Dpr/UI/UIWazaManage.h
@@ -13,6 +13,17 @@
 
 namespace Dpr::UI {
     struct UIWazaManage : ILClass<UIWazaManage> {
+        struct __c__DisplayClass39_0 : ILClass<__c__DisplayClass39_0> {
+            struct Fields {
+                int32_t selectWazaNo;
+                int32_t learnWazaNo;
+                int32_t unlearnWazaNo;
+                Dpr::UI::UIWazaManage::Object* __4__this;
+                System::Action::Object* __9__4;
+                System::Action::Object* __9__3;
+            };
+        };
+
         struct Param : ILStruct<Param> {
             struct Fields {
                 int32_t BootType;
@@ -47,6 +58,8 @@ namespace Dpr::UI {
             int32_t selectTabIndex;
             Dpr::UI::UIWazaManage::Param::Object param;
         };
+
+        static inline StaticILMethod<0x04c80cc8> Method$$OnUpdate$$b__39_0 {};
 
         inline void Open(Dpr::UI::UIWazaManage::Param::Object param, MethodInfo* method) {
             external<void>(0x01dd3d80, this, param, method);

--- a/src/mod/externals/Dpr/UI/UIWazaManage.h
+++ b/src/mod/externals/Dpr/UI/UIWazaManage.h
@@ -77,6 +77,8 @@ namespace Dpr::UI {
             Dpr::UI::UIWazaManage::Param::Object param;
         };
 
+        static_assert(offsetof(Fields, param) == 0x100);
+
         static inline StaticILMethod<0x04c80ca0> Method$$OnUpdate$$b__2 {};
         static inline StaticILMethod<0x04c80cc8> Method$$OnUpdate$$b__39_0 {};
         static inline StaticILMethod<0x04c80cd0> Method$$OnUpdate$$b__39_1 {};

--- a/src/mod/externals/Dpr/UI/WazaManageCondition.h
+++ b/src/mod/externals/Dpr/UI/WazaManageCondition.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp.h"
+
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+
+namespace Dpr::UI {
+    struct WazaManageCondition : ILClass<WazaManageCondition> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            // TODO
+        };
+
+        inline void Setup(Pml::PokePara::PokemonParam::Object* pokemonParam) {
+            external<void>(0x01a41350, this, pokemonParam);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/WazaManagePokemonStausPanel.h
+++ b/src/mod/externals/Dpr/UI/WazaManagePokemonStausPanel.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp.h"
+
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+
+namespace Dpr::UI {
+    struct WazaManagePokemonStausPanel : ILClass<WazaManagePokemonStausPanel> {
+        struct Fields : UnityEngine::MonoBehaviour::Fields {
+            // TODO
+        };
+
+        inline void Setup(Pml::PokePara::PokemonParam::Object* param, bool isWazaActive) {
+            external<void>(0x01a41520, this, param, isWazaActive);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/UI/WazaManageWazaStatusPanel.h
+++ b/src/mod/externals/Dpr/UI/WazaManageWazaStatusPanel.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "externals/il2cpp.h"
+
+#include "externals/Dpr/UI/PokemonStatusPanel.h"
+#include "externals/Pml/PokePara/PokemonParam.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+
+namespace Dpr::UI {
+    struct WazaManageWazaStatusPanel : ILClass<WazaManageWazaStatusPanel> {
+        struct Fields : Dpr::UI::PokemonStatusPanel::Fields {
+            // TODO
+        };
+
+        inline void Initialize() {
+            external<void>(0x01a42550, this);
+        }
+
+        inline void Setup(Pml::PokePara::PokemonParam::Object* pokemonParam, Pml::WazaNo_array* wazaNos, int32_t newWazaIndex) {
+            external<void>(0x01a42640, this, pokemonParam, wazaNos, newWazaIndex);
+        }
+
+        inline void UpdateSelect(float deltaTime, bool isPlaySound) {
+            external<void>(0x01a426a0, this, deltaTime, isPlaySound);
+        }
+
+        inline int32_t GetSelectedWazaNo() {
+            return external<int32_t>(0x01a432a0, this);
+        }
+    };
+}

--- a/src/mod/externals/Pml/PokePara/CoreParam.h
+++ b/src/mod/externals/Pml/PokePara/CoreParam.h
@@ -228,7 +228,19 @@ namespace Pml::PokePara {
         }
 
         inline uint32_t GetMemories(int32_t memoriesKind) {
-            return external<uint32_t>(0x204ac30, this, memoriesKind);
+            return external<uint32_t>(0x0204ac30, this, memoriesKind);
+        }
+
+        inline uint32_t GetGetBall() {
+            return external<uint32_t>(0x0204b830, this);
+        }
+
+        inline uint8_t GetWazaCount() {
+            return external<uint8_t>(0x02045e10, this);
+        }
+
+        inline bool HaveWaza(int32_t wazano) {
+            return external<bool>(0x02045ea0, this, wazano);
         }
     };
 }

--- a/src/mod/externals/System/Action.h
+++ b/src/mod/externals/System/Action.h
@@ -30,7 +30,7 @@ namespace System {
         }
 
         inline void Invoke(Pml::WazaNo arg0, Pml::WazaNo arg1) {
-            external<void>(0x023feb50, this, arg0, arg1);
+            external<void>(0x0263da30, this, arg0, arg1);
         }
     };
 }

--- a/src/mod/externals/System/Action.h
+++ b/src/mod/externals/System/Action.h
@@ -2,6 +2,7 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Pml/WazaNo.h"
 #include "externals/System/MulticastDelegate.h"
 
 namespace System {
@@ -26,6 +27,10 @@ namespace System {
 
         inline void Invoke() {
             external<void>(0x023feb50, this);
+        }
+
+        inline void Invoke(Pml::WazaNo arg0, Pml::WazaNo arg1) {
+            external<void>(0x023feb50, this, arg0, arg1);
         }
     };
 }

--- a/src/mod/externals/System/Collections/Generic/IEnumerable.h
+++ b/src/mod/externals/System/Collections/Generic/IEnumerable.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+
 #include "externals/System/Primitives.h"
 
 namespace System::Collections::Generic {

--- a/src/mod/externals/System/Collections/Generic/List.h
+++ b/src/mod/externals/System/Collections/Generic/List.h
@@ -63,11 +63,11 @@ namespace System::Collections::Generic {
         static inline StaticILMethod<0x04c8a3b8> Method$$Clear {};
 
         inline void Add(int32_t item) {
-            external<void>(0x02a70aa0, this, item, Method$$Add);
+            external<void>(0x02a70aa0, this, item, *Method$$Add);
         }
 
         inline void Clear() {
-            external<void>(0x02a70e40, this, Method$$Clear);
+            external<void>(0x02a70e40, this, *Method$$Clear);
         }
     };
 }

--- a/src/mod/externals/System/Collections/Generic/List.h
+++ b/src/mod/externals/System/Collections/Generic/List.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+
+#include "externals/System/Collections/Generic/IEnumerable.h"
 #include "externals/System/Primitives.h"
 
 namespace System::Collections::Generic {
@@ -68,6 +70,42 @@ namespace System::Collections::Generic {
 
         inline void Clear() {
             external<void>(0x02a70e40, this, *Method$$Clear);
+        }
+    };
+
+    struct List$$WazaNo : ILClass<List$$WazaNo, 0x04c63248> {
+        struct Fields {
+            System::Int32_array* _items;
+            int32_t _size;
+            int32_t _version;
+            Il2CppObject* _syncRoot;
+        };
+
+        static inline StaticILMethod<0x04c68988> Method$$ToArray {};
+        static inline StaticILMethod<0x04c8a0a0> Method$$ctor {};
+        static inline StaticILMethod<0x04c8a0a8> Method$$Add {};
+        static inline StaticILMethod<0x04c8a0b0> Method$$AddRange {};
+        static inline StaticILMethod<0x04c8a0b8> Method$$Clear {};
+
+        inline void ctor() {
+            external<void>(0x02a72c00, this, *Method$$ctor);
+        }
+
+        inline void Add(int32_t item) {
+            external<void>(0x02a70aa0, this, item, *Method$$Add);
+        }
+
+        // Argument is IEnumerable<T>*
+        inline void AddRange(void* item) {
+            external<void>(0x02a73b10, this, item, *Method$$AddRange);
+        }
+
+        inline void Clear() {
+            external<void>(0x02a70e40, this, *Method$$Clear);
+        }
+
+        inline System::Int32_array* ToArray() {
+            return external<System::Int32_array*>(0x02a75910, this, *Method$$ToArray);
         }
     };
 }

--- a/src/mod/externals/TMPro/Extents.h
+++ b/src/mod/externals/TMPro/Extents.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Vector2.h"
+
+namespace TMPro {
+    struct Extents : ILStruct<Extents> {
+        struct Fields {
+            UnityEngine::Vector2::Object min;
+            UnityEngine::Vector2::Object max;
+        };
+
+        static_assert(offsetof(Fields, max) == 0x8);
+    };
+}

--- a/src/mod/externals/TMPro/HighlightState.h
+++ b/src/mod/externals/TMPro/HighlightState.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/TMPro/TMP_Offset.h"
+#include "externals/UnityEngine/Color32.h"
+
+namespace TMPro {
+    struct HighlightState : ILStruct<HighlightState> {
+        struct Fields {
+            UnityEngine::Color32::Object color;
+            TMP_Offset::Object padding;
+        };
+
+        static_assert(sizeof(Fields) == 0x14);
+    };
+}

--- a/src/mod/externals/TMPro/TMP_ColorGradient.h
+++ b/src/mod/externals/TMPro/TMP_ColorGradient.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Color.h"
+#include "externals/UnityEngine/ScriptableObject.h"
+
+namespace TMPro {
+    struct TMP_ColorGradient : ILClass<TMP_ColorGradient> {
+        struct Fields : UnityEngine::ScriptableObject::Fields {
+            int32_t colorMode;
+            UnityEngine::Color::Object topLeft;
+            UnityEngine::Color::Object topRight;
+            UnityEngine::Color::Object bottomLeft;
+            UnityEngine::Color::Object bottomRight;
+        };
+    };
+}

--- a/src/mod/externals/TMPro/TMP_FontStyleStack.h
+++ b/src/mod/externals/TMPro/TMP_FontStyleStack.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace TMPro {
+    struct TMP_FontStyleStack : ILStruct<TMP_FontStyleStack> {
+        struct Fields {
+            uint8_t bold;
+            uint8_t italic;
+            uint8_t underline;
+            uint8_t strikethrough;
+            uint8_t highlight;
+            uint8_t superscript;
+            uint8_t subscript;
+            uint8_t uppercase;
+            uint8_t lowercase;
+            uint8_t smallcaps;
+        };
+
+        static_assert(offsetof(Fields, smallcaps) == 0x9);
+    };
+}

--- a/src/mod/externals/TMPro/TMP_Offset.h
+++ b/src/mod/externals/TMPro/TMP_Offset.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Color32.h"
+
+namespace TMPro {
+    struct TMP_Offset : ILStruct<TMP_Offset> {
+        struct Fields {
+            float m_Left;
+            float m_Right;
+            float m_Top;
+            float m_Bottom;
+        };
+
+        static_assert(sizeof(Fields) == 0x10);
+    };
+}

--- a/src/mod/externals/TMPro/TMP_Text.h
+++ b/src/mod/externals/TMPro/TMP_Text.h
@@ -1,12 +1,37 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+
+#include "externals/TMPro/Extents.h"
+#include "externals/TMPro/TMP_ColorGradient.h"
+#include "externals/TMPro/TMP_FontStyleStack.h"
+#include "externals/TMPro/TMP_TextInfo.h"
+#include "externals/TMPro/TMP_TextProcessingStack.h"
 #include "externals/TMPro/VertexGradient.h"
-#include "externals/UnityEngine/UI/MaskableGraphic.h"
 #include "externals/UnityEngine/Color32.h"
+#include "externals/UnityEngine/Material.h"
+#include "externals/UnityEngine/Matrix4x4.h"
+#include "externals/UnityEngine/UI/MaskableGraphic.h"
+#include "externals/UnityEngine/Vector4.h"
 
 namespace TMPro {
     struct TMP_Text : ILClass<TMP_Text> {
+        struct SpecialCharacter : ILStruct<SpecialCharacter> {
+            struct Fields {
+                void* character;
+                void* fontAsset;
+                UnityEngine::Material::Object* material;
+                int32_t materialIndex;
+            };
+        };
+
+        struct TextBackingContainer : ILStruct<TextBackingContainer> {
+            struct Fields {
+                System::UInt32_array* m_Array;
+                int32_t m_Count;
+            };
+        };
+
         struct Fields : UnityEngine::UI::MaskableGraphic::Fields {
             System::String::Object* m_text;
             bool m_IsTextBackingStringDirty;
@@ -38,18 +63,16 @@ namespace TMPro {
             void* m_TextStyle; //TMPro_TMP_Style_o*
             int32_t m_TextStyleHashCode;
             bool m_overrideHtmlColors;
-            UnityEngine::Color32::Object m_faceColor; //UnityEngine_Color32_o
-            UnityEngine::Color32::Object m_outlineColor; //UnityEngine_Color32_o
+            UnityEngine::Color32::Object m_faceColor;
+            UnityEngine::Color32::Object m_outlineColor;
             float m_outlineWidth;
             float m_fontSize;
             float m_currentFontSize;
             float m_fontSizeBase;
-            void* m_sizeStack; //TMPro_TMP_TextProcessingStack_float__o
+            TMP_TextProcessingStack_float::Object m_sizeStack;
             int32_t m_fontWeight;
             int32_t m_FontWeightInternal;
-
-            // TODO: Insert missing classes/structs so that the rest below are aligned.
-            void* m_FontWeightStack; //TMPro_TMP_TextProcessingStack_FontWeight__o
+            TMP_TextProcessingStack_int32_t::Object m_FontWeightStack;
             bool m_enableAutoSizing;
             float m_maxFontSize;
             float m_minFontSize;
@@ -60,14 +83,14 @@ namespace TMPro {
             float m_fontSizeMax;
             int32_t m_fontStyle;
             int32_t m_FontStyleInternal;
-            void* m_fontStyleStack; //TMPro_TMP_FontStyleStack_o
+            TMP_FontStyleStack::Object m_fontStyleStack;
             bool m_isUsingBold;
             int32_t m_HorizontalAlignment;
             int32_t m_VerticalAlignment;
             int32_t m_textAlignment;
             int32_t m_lineJustification;
-            void* m_lineJustificationStack; //TMPro_TMP_TextProcessingStack_HorizontalAlignmentOptions__o
-            void* m_textContainerLocalCorners; //UnityEngine_Vector3_array*
+            TMP_TextProcessingStack_int32_t::Object m_lineJustificationStack;
+            UnityEngine::Vector3::Array* m_textContainerLocalCorners;
             float m_characterSpacing;
             float m_cSpacing;
             float m_monoSpacing;
@@ -87,8 +110,8 @@ namespace TMPro {
             float m_wordWrappingRatios;
             int32_t m_overflowMode;
             int32_t m_firstOverflowCharacterIndex;
-            void* m_linkedTextComponent; //TMPro_TMP_Text_o*
-            void* parentLinkedComponent; //TMPro_TMP_Text_o*
+            TMP_Text::Object* m_linkedTextComponent;
+            TMP_Text::Object* parentLinkedComponent;
             bool m_isTextTruncated;
             bool m_enableKerning;
             float m_GlyphHorizontalAdvanceAdjustment;
@@ -116,19 +139,19 @@ namespace TMPro {
             bool m_useMaxVisibleDescender;
             int32_t m_pageToDisplay;
             bool m_isNewPage;
-            void* m_margin; //UnityEngine_Vector4_o
+            UnityEngine::Vector4::Object m_margin;
             float m_marginLeft;
             float m_marginRight;
             float m_marginWidth;
             float m_marginHeight;
             float m_width;
-            void* m_textInfo; //TMPro_TMP_TextInfo_o*
+            TMP_TextInfo::Object* m_textInfo;
             bool m_havePropertiesChanged;
             bool m_isUsingLegacyAnimationComponent;
             void* m_transform; //UnityEngine_Transform_o*
             void* m_rectTransform; //UnityEngine_RectTransform_o*
-            void* m_PreviousRectTransformSize; //UnityEngine_Vector2_o
-            void* m_PreviousPivotPosition; //UnityEngine_Vector2_o
+            UnityEngine::Vector2::Object m_PreviousRectTransformSize;
+            UnityEngine::Vector2::Object m_PreviousPivotPosition;
             bool _autoSizeTextContainer_k__BackingField;
             bool m_autoSizeTextContainer;
             void* m_mesh; //UnityEngine_Mesh_o*
@@ -157,10 +180,10 @@ namespace TMPro {
             float m_fontScaleMultiplier;
             float tag_LineIndent;
             float tag_Indent;
-            void* m_indentStack; //TMPro_TMP_TextProcessingStack_float__o
+            TMP_TextProcessingStack_float::Object m_indentStack;
             bool tag_NoParsing;
             bool m_isParsingText;
-            void* m_FXMatrix; //UnityEngine_Matrix4x4_o
+            UnityEngine::Matrix4x4::Object m_FXMatrix;
             bool m_isFXMatrixSet;
             void* m_TextProcessingArray; //TMPro_TMP_Text_UnicodeChar_array*
             int32_t m_InternalTextProcessingArraySize;
@@ -184,39 +207,45 @@ namespace TMPro {
             float m_startOfLineAscender;
             float m_startOfLineDescender;
             float m_lineOffset;
-            void* m_meshExtents; //TMPro_Extents_o
+            Extents::Object m_meshExtents;
             UnityEngine::Color32::Object m_htmlColor;
-            void* m_colorStack; //TMPro_TMP_TextProcessingStack_Color32__o
-            void* m_underlineColorStack; //TMPro_TMP_TextProcessingStack_Color32__o
-            void* m_strikethroughColorStack; //TMPro_TMP_TextProcessingStack_Color32__o
-            void* m_HighlightStateStack; //TMPro_TMP_TextProcessingStack_HighlightState__o
-            void* m_colorGradientPreset; //TMPro_TMP_ColorGradient_o*
-            void* m_colorGradientStack; //TMPro_TMP_TextProcessingStack_TMP_ColorGradient__o
+            TMP_TextProcessingStack_Color32::Object m_colorStack;
+            TMP_TextProcessingStack_Color32::Object m_underlineColorStack;
+            TMP_TextProcessingStack_Color32::Object m_strikethroughColorStack;
+            TMP_TextProcessingStack_HighlightState::Object m_HighlightStateStack;
+            TMP_ColorGradient::Object* m_colorGradientPreset;
+            TMP_TextProcessingStack_TMP_ColorGradient::Object m_colorGradientStack;
             bool m_colorGradientPresetIsTinted;
             float m_tabSpacing;
             float m_spacing;
             void* m_TextStyleStacks; //TMPro_TMP_TextProcessingStack_int__array*
             int32_t m_TextStyleStackDepth;
-            void* m_ItalicAngleStack; //TMPro_TMP_TextProcessingStack_int__o
+            TMP_TextProcessingStack_int32_t::Object m_ItalicAngleStack;
             int32_t m_ItalicAngle;
-            void* m_actionStack; //TMPro_TMP_TextProcessingStack_int__o
+            TMP_TextProcessingStack_int32_t::Object m_actionStack;
             float m_padding;
             float m_baselineOffset;
-            void* m_baselineOffsetStack; //TMPro_TMP_TextProcessingStack_float__o
+            TMP_TextProcessingStack_float::Object m_baselineOffsetStack;
             float m_xAdvance;
             int32_t m_textElementType;
             void* m_cached_TextElement; //TMPro_TMP_TextElement_o*
-            void* m_Ellipsis; //TMPro_TMP_Text_SpecialCharacter_o
-            void* m_Underline; //TMPro_TMP_Text_SpecialCharacter_o
+            SpecialCharacter::Object m_Ellipsis;
+            SpecialCharacter::Object m_Underline;
             void* m_defaultSpriteAsset; //TMPro_TMP_SpriteAsset_o*
             void* m_currentSpriteAsset; //TMPro_TMP_SpriteAsset_o*
             int32_t m_spriteCount;
             int32_t m_spriteIndex;
             int32_t m_spriteAnimationID;
             bool m_ignoreActiveState;
-            void* m_TextBackingArray; //TMPro_TMP_Text_TextBackingContainer_o
+            TextBackingContainer::Object m_TextBackingArray; //TMPro_TMP_Text_TextBackingContainer_o
             void* k_Power; //System_Decimal_array*
         };
+
+        static_assert(offsetof(Fields, tag_NoParsing) == 0x408);
+        static_assert(offsetof(Fields, m_isParsingText) == 0x409);
+        static_assert(offsetof(Fields, m_FXMatrix) == 0x40c);
+        static_assert(offsetof(Fields, m_totalCharacterCount) == 0x468);
+        static_assert(offsetof(Fields, k_Power) == 0x698);
 
         inline void set_text(System::String::Object* value) {
             external<void>(0x01e94520, this, value);

--- a/src/mod/externals/TMPro/TMP_TextInfo.h
+++ b/src/mod/externals/TMPro/TMP_TextInfo.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace TMPro {
+    struct TMP_Text;
+
+    struct TMP_TextInfo : ILClass<TMP_TextInfo> {
+        struct Fields {
+            TMP_Text* textComponent;
+            int32_t characterCount;
+            int32_t spriteCount;
+            int32_t spaceCount;
+            int32_t wordCount;
+            int32_t linkCount;
+            int32_t lineCount;
+            int32_t pageCount;
+            int32_t materialCount;
+            void* characterInfo; // TMP_CharacterInfo::Array*
+            void* wordInfo; // TMP_WordInfo::Array*
+            void* linkInfo; // TMP_LinkInfo::Array*
+            void* lineInfo; // TMP_LineInfo::Array*
+            void* pageInfo; // TMP_PageInfo::Array*
+            void* meshInfo; // TMP_MeshInfo::Array*
+            void* m_CachedMeshInfo; // TMP_MeshInfo::Array*
+        };
+
+        static_assert(offsetof(Fields, m_CachedMeshInfo) == 0x58);
+    };
+}

--- a/src/mod/externals/TMPro/TMP_TextProcessingStack.h
+++ b/src/mod/externals/TMPro/TMP_TextProcessingStack.h
@@ -1,0 +1,75 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/System/Primitives.h"
+#include "externals/TMPro/HighlightState.h"
+#include "externals/UnityEngine/Color32.h"
+
+namespace TMPro {
+    // Not making this generic bc I don't wanna deal with all that
+    struct TMP_TextProcessingStack_int32_t : ILStruct<TMP_TextProcessingStack_int32_t> {
+        struct Fields {
+            System::Int32_array* itemStack;
+            int32_t index;
+            int32_t m_DefaultItem;
+            int32_t m_Capacity;
+            int32_t m_RolloverSize;
+            int32_t m_Count;
+        };
+
+        static_assert(sizeof(Fields) == 0x20);
+    };
+
+    struct TMP_TextProcessingStack_float : ILStruct<TMP_TextProcessingStack_float> {
+        struct Fields {
+            System::Single_array* itemStack;
+            int32_t	index;
+            float m_DefaultItem;
+            int32_t	m_Capacity;
+            int32_t	m_RolloverSize;
+            int32_t m_Count;
+        };
+
+        static_assert(sizeof(Fields) == 0x20);
+    };
+
+    struct TMP_TextProcessingStack_Color32 : ILStruct<TMP_TextProcessingStack_Color32> {
+        struct Fields {
+            UnityEngine::Color32::Array* itemStack;
+            int32_t	index;
+            UnityEngine::Color32::Object m_DefaultItem;
+            int32_t	m_Capacity;
+            int32_t	m_RolloverSize;
+            int32_t m_Count;
+        };
+
+        static_assert(sizeof(Fields) == 0x20);
+    };
+
+    struct TMP_TextProcessingStack_HighlightState : ILStruct<TMP_TextProcessingStack_HighlightState> {
+        struct Fields {
+            HighlightState::Array* itemStack;
+            int32_t	index;
+            HighlightState::Object m_DefaultItem;
+            int32_t	m_Capacity;
+            int32_t	m_RolloverSize;
+            int32_t m_Count;
+        };
+
+        static_assert(sizeof(Fields) == 0x30);
+    };
+
+    struct TMP_TextProcessingStack_TMP_ColorGradient : ILStruct<TMP_TextProcessingStack_TMP_ColorGradient> {
+        struct Fields {
+            TMP_ColorGradient::Array* itemStack;
+            int32_t	index;
+            TMP_ColorGradient::Object* m_DefaultItem;
+            int32_t	m_Capacity;
+            int32_t	m_RolloverSize;
+            int32_t m_Count;
+        };
+
+        static_assert(sizeof(Fields) == 0x28);
+    };
+}

--- a/src/mod/externals/TMPro/TextMeshProUGUI.h
+++ b/src/mod/externals/TMPro/TextMeshProUGUI.h
@@ -8,7 +8,6 @@
 namespace TMPro {
     struct TextMeshProUGUI : ILClass<TextMeshProUGUI, 0x04c59018> {
         struct Fields : TMPro::TMP_Text::Fields {
-            // TODO: Insert missing classes/structs so that the rest below are aligned.
             bool m_hasFontAssetChanged;
             void* m_subTextObjects; //TMPro_TMP_SubMeshUI_array*
             float m_previousLossyScaleY;
@@ -19,8 +18,8 @@ namespace TMPro {
             int32_t m_max_characters;
             void* m_baseMaterial; //UnityEngine_Material_o*
             bool m_isScrollRegionSet;
-            void* m_maskOffset; //UnityEngine_Vector4_o
-            void* m_EnvMapMatrix; //UnityEngine_Matrix4x4_o
+            UnityEngine::Vector4::Object m_maskOffset;
+            UnityEngine::Matrix4x4::Object m_EnvMapMatrix; //UnityEngine_Matrix4x4_o
             bool m_isRegisteredForEvents;
             bool m_isRebuildingLayout;
             UnityEngine::Coroutine::Object* m_DelayedGraphicRebuild;
@@ -29,6 +28,8 @@ namespace TMPro {
             bool m_ValidRect;
             void* OnPreRenderText; //System_Action_TMP_TextInfo__o*
         };
+
+        static_assert(offsetof(Fields, OnPreRenderText) == 0x760);
 
         struct VirtualInvokeData_get_color {
             typedef UnityEngine::Color::Fields(*Il2CppMethodPointer)(TMPro::TextMeshProUGUI::Object* __this, const MethodInfo*);

--- a/src/mod/externals/UnityEngine/Color32.h
+++ b/src/mod/externals/UnityEngine/Color32.h
@@ -3,13 +3,19 @@
 #include "externals/il2cpp-api.h"
 
 namespace UnityEngine {
+    // The proper fields are separate r, g, b, and a, but this messes up alignment it seems?
     struct Color32 : ILStruct<Color32> {
+        #pragma pack(push, 1)
         struct Fields {
-            int32_t rgba;
+            //int32_t rgba;
             uint8_t r;
             uint8_t g;
             uint8_t b;
             uint8_t a;
         };
+        #pragma pack(pop)
+
+        static_assert(offsetof(Fields, a) == 0x3);
+        static_assert(sizeof(Fields) == 0x4);
     };
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -82,6 +82,10 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(AYouName(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_GET_CAUGHT_LOCATION:
                     return HandleCmdStepper(GetCaughtLocation(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_CHECK_TUTOR_MOVE:
+                    return HandleCmdStepper(CheckTutorMove(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI:
+                    return HandleCmdStepper(MoveTutorUI(__this));
                 default:
                     break;
             }
@@ -124,4 +128,6 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_AYOU_NAME);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_AYOU_NAME);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_CAUGHT_LOCATION);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHECK_TUTOR_MOVE);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI);
 }

--- a/src/mod/features/commands/check_tutor_move.cpp
+++ b/src/mod/features/commands/check_tutor_move.cpp
@@ -1,0 +1,23 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/ZukanWork.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+#include "romdata/romdata.h"
+
+bool CheckTutorMove(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_CHECK_TUTOR_MOVE\n");
+
+    system_load_typeinfo(0x4495);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    int32_t monsno = GetWorkOrIntValue(args->m_Items[1]);
+    int32_t formno = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t moveid = GetWorkOrIntValue(args->m_Items[3]);
+
+    bool result = IsMoveLearnableByTutor(monsno, formno, moveid);
+    SetWorkToValue(args->m_Items[4], (int32_t)result);
+
+    return true;
+}

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -149,3 +149,19 @@ bool AYouName(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work] Location: The work in which to put the location index in.
 //   [Work, Number] index: The index that points to the given Pokémon.
 bool GetCaughtLocation(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Checks if a specific species learns the specified move by tutor.
+// Arguments:
+//   [Work, Number] monsno: ID of the species to look up.
+//   [Work, Number] formno: ID of the form the species is in.
+//   [Work, Number] move: ID of the move to check.
+//   [Work] result: The work in which to put the result in, where 0 is no and 1 is yes.
+bool CheckTutorMove(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Opens a Move Tutor UI of the given table using the same UI as the move relearner.
+// Arguments:
+//   [Work] result: The work in which to put the ID of the move that was learned in.
+//   [Work, Number] index: The index that points to the given Pokémon.
+//   [Work, Number] trayIndex: The tray index in which to look for the given Pokémon.
+//   [Work, Number] table: The Move Tutor table to use.
+bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/move_tutor_ui.cpp
+++ b/src/mod/features/commands/move_tutor_ui.cpp
@@ -1,0 +1,24 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/ZukanWork.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+#include "romdata/romdata.h"
+
+bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_MOVE_TUTOR_UI\n");
+
+    system_load_typeinfo(0x43ef);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    int32_t index = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t trayIndex = GetWorkOrIntValue(args->m_Items[3]);
+    int32_t table = GetWorkOrIntValue(args->m_Items[4]);
+
+    auto pokeParam = manager->GetPokemonParam(trayIndex, index);
+
+    // Callback sets arg1 to the learned move
+    auto callback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(manager, *Dpr::EvScript::EvDataManager::Method$$EvDataManager_EvCmdCallWazaOmoidashiUi);
+    return manager->CallWazaUICommon(3, pokeParam, callback, table);
+}

--- a/src/mod/features/commands/move_tutor_ui.cpp
+++ b/src/mod/features/commands/move_tutor_ui.cpp
@@ -27,34 +27,35 @@ void MoveTutorUI_Callback(Dpr::EvScript::EvDataManager::Object *__this, int32_t 
     Logger::log("MoveTutorUI_Callback\n");
 
     system_load_typeinfo(0x31aa);
+    system_load_typeinfo(0x43f0);
 
     tutorSequence = 1;
 
     // unlearnWazaNo is always zero, because we're just selecting the move to tutor
     // learnWazaNo is zero if we canceled
     if (learnWazaNo == 0)
+    {
+        tutorSequence = 2;
         return;
-
-    Logger::log("[MoveTutorUI_Callback] Let's find the mon\n");
+    }
 
     EvData::Aregment::Array* args = __this->fields._evArg;
     int32_t index = GetWorkOrIntValue(args->m_Items[2]);
     int32_t trayIndex = GetWorkOrIntValue(args->m_Items[3]);
     auto pokeParam = __this->GetPokemonParam(trayIndex, index);
 
-    Logger::log("[MoveTutorUI_Callback] pokeParam = %08X\n", pokeParam);
-
     // Already learned the move because you had less than 4 moves
     if (pokeParam->cast<Pml::PokePara::CoreParam>()->AddWazaIfEmptyExist(learnWazaNo) == 0)
+    {
+        tutorSequence = 2;
         return;
+    }
 
     auto evDataManagerDispClass = Dpr::EvScript::EvDataManager::DisplayClass1544_0::newInstance();
     evDataManagerDispClass->fields.__4__this = __this;
     evDataManagerDispClass->fields.param = pokeParam;
     evDataManagerDispClass->fields.tray = 0;
     evDataManagerDispClass->fields.idx = 0;
-
-    Logger::log("[MoveTutorUI_Callback] evDataManagerDispClass = %08X\n", evDataManagerDispClass);
 
     MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdCallWazaOshieUiTutor((Il2CppMethodPointer)&LearnMoveAfterMoveTutor_Callback);
     System::Action::Object* resultCallback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(evDataManagerDispClass, mi);

--- a/src/mod/features/commands/move_tutor_ui.cpp
+++ b/src/mod/features/commands/move_tutor_ui.cpp
@@ -1,9 +1,78 @@
 #include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/Dpr/UI/UIWazaManage.h"
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
 #include "externals/ZukanWork.h"
 
 #include "features/commands/utils/utils.h"
 #include "logger/logger.h"
-#include "romdata/romdata.h"
+
+int32_t tutorSequence = 0;
+
+void LearnMoveAfterMoveTutor_Callback(Dpr::EvScript::EvDataManager::DisplayClass1544_0::Object* __this, int32_t learnWazaNo, int32_t unlearnWazaNo)
+{
+    Logger::log("LearnMoveAfterMoveTutor_Callback\n");
+    tutorSequence = 2;
+
+    // User decided to not learn the move
+    if (learnWazaNo == 0 || unlearnWazaNo == 0)
+        return;
+
+    __this->fields.__4__this->LearnWaza(__this->fields.param, learnWazaNo, unlearnWazaNo);
+    SetWorkToValue(__this->fields.__4__this->fields._evArg->m_Items[1], learnWazaNo);
+}
+
+void MoveTutorUI_Callback(Dpr::EvScript::EvDataManager::Object *__this, int32_t learnWazaNo, int32_t unlearnWazaNo)
+{
+    Logger::log("MoveTutorUI_Callback\n");
+
+    system_load_typeinfo(0x31aa);
+
+    tutorSequence = 1;
+
+    // unlearnWazaNo is always zero, because we're just selecting the move to tutor
+    // learnWazaNo is zero if we canceled
+    if (learnWazaNo == 0)
+        return;
+
+    Logger::log("[MoveTutorUI_Callback] Let's find the mon\n");
+
+    EvData::Aregment::Array* args = __this->fields._evArg;
+    int32_t index = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t trayIndex = GetWorkOrIntValue(args->m_Items[3]);
+    auto pokeParam = __this->GetPokemonParam(trayIndex, index);
+
+    Logger::log("[MoveTutorUI_Callback] pokeParam = %08X\n", pokeParam);
+
+    // Already learned the move because you had less than 4 moves
+    if (pokeParam->cast<Pml::PokePara::CoreParam>()->AddWazaIfEmptyExist(learnWazaNo) == 0)
+        return;
+
+    auto evDataManagerDispClass = Dpr::EvScript::EvDataManager::DisplayClass1544_0::newInstance();
+    evDataManagerDispClass->fields.__4__this = __this;
+    evDataManagerDispClass->fields.param = pokeParam;
+    evDataManagerDispClass->fields.tray = 0;
+    evDataManagerDispClass->fields.idx = 0;
+
+    Logger::log("[MoveTutorUI_Callback] evDataManagerDispClass = %08X\n", evDataManagerDispClass);
+
+    MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdCallWazaOshieUiTutor((Il2CppMethodPointer)&LearnMoveAfterMoveTutor_Callback);
+    System::Action::Object* resultCallback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(evDataManagerDispClass, mi);
+    auto param = (Dpr::UI::UIWazaManage::Param::Object) {
+        .fields = {
+            .BootType = 2,
+            .IsOpenFromFieldScript = true,
+            .PokemonParam = pokeParam,
+            .LearnWazaNo = learnWazaNo,
+            .ResultCallback = resultCallback,
+        }
+    };
+
+    SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
+    auto uiManager = Dpr::UI::UIManager::get_Instance();
+    auto uiWazaManage = (Dpr::UI::UIWazaManage::Object *) uiManager->CreateUIWindow(UIWindowID::WAZA_MANAGE, Dpr::UI::UIManager::Method$$CreateUIWindow_UIWazaManage_);
+    uiWazaManage->Open(param, nullptr);
+}
 
 bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager)
 {
@@ -18,7 +87,24 @@ bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager)
 
     auto pokeParam = manager->GetPokemonParam(trayIndex, index);
 
-    // Callback sets arg1 to the learned move
-    auto callback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(manager, *Dpr::EvScript::EvDataManager::Method$$EvDataManager_EvCmdCallWazaOmoidashiUi);
-    return manager->CallWazaUICommon(3, pokeParam, callback, table);
+    switch (tutorSequence)
+    {
+        case 0:
+        {
+            MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdCallWazaOmoidashiUiTutor((Il2CppMethodPointer)&MoveTutorUI_Callback);
+            System::Action::Object* callback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(manager, mi);
+            manager->CallWazaUICommon(3, pokeParam, callback, table);
+            return false;
+        }
+
+        case 1:
+            return false;
+
+        case 2:
+            tutorSequence = 0;
+            return true;
+
+        default:
+            return true;
+    }
 }

--- a/src/mod/features/commands/move_tutor_ui.cpp
+++ b/src/mod/features/commands/move_tutor_ui.cpp
@@ -16,7 +16,10 @@ void LearnMoveAfterMoveTutor_Callback(Dpr::EvScript::EvDataManager::DisplayClass
 
     // User decided to not learn the move
     if (learnWazaNo == 0 || unlearnWazaNo == 0)
+    {
+        SetWorkToValue(__this->fields.__4__this->fields._evArg->m_Items[1], 0);
         return;
+    }
 
     __this->fields.__4__this->LearnWaza(__this->fields.param, learnWazaNo, unlearnWazaNo);
     SetWorkToValue(__this->fields.__4__this->fields._evArg->m_Items[1], learnWazaNo);
@@ -36,6 +39,7 @@ void MoveTutorUI_Callback(Dpr::EvScript::EvDataManager::Object *__this, int32_t 
     if (learnWazaNo == 0)
     {
         tutorSequence = 2;
+        SetWorkToValue(__this->fields._evArg->m_Items[1], 0);
         return;
     }
 
@@ -48,6 +52,7 @@ void MoveTutorUI_Callback(Dpr::EvScript::EvDataManager::Object *__this, int32_t 
     if (pokeParam->cast<Pml::PokePara::CoreParam>()->AddWazaIfEmptyExist(learnWazaNo) == 0)
     {
         tutorSequence = 2;
+        SetWorkToValue(args->m_Items[1], learnWazaNo);
         return;
     }
 

--- a/src/mod/features/commands/move_tutor_ui.cpp
+++ b/src/mod/features/commands/move_tutor_ui.cpp
@@ -7,7 +7,7 @@
 
 bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager)
 {
-    Logger::log("_MOVE_TUTOR_UI\n");
+    //Logger::log("_MOVE_TUTOR_UI\n");
 
     system_load_typeinfo(0x43ef);
     EvData::Aregment::Array* args = manager->fields._evArg;

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -95,8 +95,14 @@ void exl_hidden_power_ui_main();
 // Allows configuring the available languages on the language select screen.
 void exl_language_select_main();
 
+// Fixes bugs with specific UI elements not matching the player's language.
+void exl_language_ui_fixes_main();
+
 // Adds the Level Cap functionality.
 void exl_level_cap_main();
+
+// Uniformizes local trades across languages and allows extending the table in RomFS.
+void exl_local_trades_main();
 
 //
 void exl_madrid_ui_main();
@@ -104,11 +110,8 @@ void exl_madrid_ui_main();
 //
 void exl_mega_evolution_main();
 
-// Fixes bugs with specific UI elements not matching the player's language.
-void exl_language_ui_fixes_main();
-
-// Uniformizes local trades across languages and allows extending the table in RomFS.
-void exl_local_trades_main();
+// Adds an extra type of move relearner UI that loads a specific tutor table.
+void exl_move_tutor_relearner_main();
 
 // Adds audio feedback when "bonking" into NPCs.
 void exl_npc_collision_audio_main();

--- a/src/mod/features/gender_neutral_boutique.cpp
+++ b/src/mod/features/gender_neutral_boutique.cpp
@@ -48,7 +48,8 @@ void exl_gender_neutral_boutique_main() {
     exl::patch::CodePatcher p(0);
     auto inst = nn::vector<exl::patch::Instruction> {
         { 0x0202f120, Movz(X0, 0) }, // Remove bike outfit override for battles on cycling road
-        { 0x02cf3d38, Movz(W21, 1) }, // Reindex Dawn default outfit for intro
+        { 0x02cf3cf4, Movz(W21, array_index(OUTFITS, "Platinum Style Masculine")) }, // Change Lucas default outfit in intro to platinum outfit
+        { 0x02cf3d38, Movz(W21, array_index(OUTFITS, "Platinum Style Feminine")) },  // Change Dawn default outfit in intro to platinum outfit
     };
     p.WriteInst(inst);
 };

--- a/src/mod/features/items/repel_fix.cpp
+++ b/src/mod/features/items/repel_fix.cpp
@@ -10,7 +10,7 @@ HOOK_DEFINE_INLINE(RepelInventoryOverride){
     static void Callback(exl::hook::nx64::InlineCtx* ctx)
     {
         auto evDataManager = (Dpr::EvScript::EvDataManager::Object*)ctx->X[0];
-        if (evDataManager->fields._eventListIndex == 0xFFFFFFFF)
+        if (evDataManager->fields._eventListIndex == -1)
         {
             auto label = (System::String::Object*)ctx->X[1];
             auto callback = (Dpr::EvScript::EvDataManager::EventEndDelegate::Object*)ctx->X[2];

--- a/src/mod/features/local_trades_extension.cpp
+++ b/src/mod/features/local_trades_extension.cpp
@@ -86,7 +86,7 @@ Pml::PokePara::PokemonParam::Object* CreateTradePokeParam(int32_t npcindex, Dpr:
             coreParam->SetCondition(Pml::PokePara::Condition::FUR, extraData.evs[5]);
     }
 
-    for (int32_t i=0; i<data->fields.waza->max_length && i<4; i++)
+    for (uint64_t i=0; i<data->fields.waza->max_length && i<4; i++)
         coreParam->SetWaza(i, data->fields.waza->m_Items[i]);
 
     poketool::poke_memo::poketool_poke_memo::ClearPlaceTime(coreParam, poketool::poke_memo::DATA_TYPE_EGG_TAKEN);

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -112,6 +112,8 @@ void CallFeatureHooks()
         exl_text_color_main();
     if (IsActivatedFeature(array_index(FEATURES, "Language UI Fixes")))
         exl_language_ui_fixes_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Move Tutor Relearner")))
+        exl_move_tutor_relearner_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/more_evolution_methods.cpp
+++ b/src/mod/features/more_evolution_methods.cpp
@@ -141,11 +141,13 @@ AlcremieCream GetAlcremieCream(Pml::PokePara::CoreParam::Object* poke)
     {
         if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::RUBY_CREAM;
         else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::SALTED_CREAM;
+        else return AlcremieCream::RUBY_CREAM;
     }
     else if (poke->fields.m_accessor->GetBeautiful() >= 170)
     {
         if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::RUBY_SWIRL;
         else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::MINT_CREAM;
+        else return AlcremieCream::RUBY_SWIRL;
     }
     else if (poke->fields.m_accessor->GetCute() >= 170)
     {
@@ -155,11 +157,13 @@ AlcremieCream GetAlcremieCream(Pml::PokePara::CoreParam::Object* poke)
     {
         if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::VANILLA_CREAM;
         else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::MATCHA_CREAM;
+        else return AlcremieCream::VANILLA_CREAM;
     }
     else if (poke->fields.m_accessor->GetStrong() >= 170)
     {
         if (extraEvoData.currentEvolutionSituation.isMorningOrNoon) return AlcremieCream::CARAMEL_SWIRL;
         else if (extraEvoData.currentEvolutionSituation.isNight) return AlcremieCream::LEMON_CREAM;
+        else return AlcremieCream::CARAMEL_SWIRL;
     }
     else return AlcremieCream::VANILLA_CREAM;
 }

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -89,7 +89,8 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
 
                 for (uint64_t i=0; i<moves.size(); i++)
                 {
-                    if (IsMoveLearnableByTutor(monsno, formno, moves[i]))
+                    if (IsMoveLearnableByTutor(monsno, formno, moves[i]) &&
+                        !__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->HaveWaza(moves[i]))
                         list->Add(moves[i]);
                 }
             }

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -10,8 +10,6 @@
 
 HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
     static void Callback(Dpr::UI::UIWazaManage::Object* __this) {
-        Logger::log("[UIWazaManage$$SetupPokemonInfo] START\n");
-
         system_load_typeinfo(0x9e21);
 
         Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
@@ -83,7 +81,6 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
 
             case 3:
             {
-                Logger::log("[UIWazaManage$$SetupPokemonInfo] Setting up moves!\n");
                 selectIndex = -1;
                 list->Clear();
 
@@ -112,15 +109,11 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
         }
 
         __this->fields.statusPanelCondition->Setup(__this->fields.param.fields.PokemonParam);
-
-        Logger::log("[UIWazaManage$$SetupPokemonInfo] END\n");
     }
 };
 
 HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
     static void Callback(Dpr::UI::UIWazaManage::Object* __this, float deltaTime) {
-        //Logger::log("UIWazaManage$$OnUpdate\n");
-
         system_load_typeinfo(0x9e1b);
         system_load_typeinfo(0x9752);
         system_load_typeinfo(0x9753);
@@ -141,20 +134,11 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
 
         if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonA, false))
         {
-            Logger::log("[UIWazaManage$$OnUpdate] Pressed A!\n");
-            Logger::log("[UIWazaManage$$OnUpdate] currWindow = %08X\n", currWindow);
-            Logger::log("[UIWazaManage$$OnUpdate] __this = %08X\n", __this);
-            Logger::log("[UIWazaManage$$OnUpdate] __this.msgWindowController = %08X\n", __this->fields.msgWindowController);
-
             auto disp = Dpr::UI::UIWazaManage::__c__DisplayClass39_0::newInstance();
             disp->fields.__4__this = __this;
             disp->fields.learnWazaNo = 0;
             disp->fields.unlearnWazaNo = 0;
             disp->fields.selectWazaNo = __this->fields.wazaStatusPanels->m_Items[__this->fields.selectTabIndex]->GetSelectedWazaNo();
-
-            Logger::log("[UIWazaManage$$OnUpdate] disp = %08X\n", disp);
-            Logger::log("[UIWazaManage$$OnUpdate] selected wazaStatusPanels = %08X\n", __this->fields.wazaStatusPanels->m_Items[__this->fields.selectTabIndex]);
-            Logger::log("[UIWazaManage$$OnUpdate] selectWazaNo = %d\n", disp->fields.selectWazaNo);
 
             System::String::Object* labelName = nullptr;
             switch (__this->fields.param.fields.BootType)
@@ -219,15 +203,11 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
                     return; // End here
             }
 
-            Logger::log("[UIWazaManage$$OnUpdate] labelName = %08X (%s)\n", labelName, labelName->asCString().c_str());
-
             auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(disp, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__2);
             __this->fields.msgWindowController->OpenMsgWindow(3, labelName, true, false, onFinished, nullptr);
 
             Audio::AudioManager::getClass()->initIfNeeded();
             Audio::AudioManager::instance()->PlaySe(0x5d95f820, nullptr);
-
-            Logger::log("[UIWazaManage$$OnUpdate] Method$$OnUpdate$$b__2 = %08X\n", *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__2);
         }
         else if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonB, false))
         {
@@ -272,37 +252,10 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
             Audio::AudioManager::getClass()->initIfNeeded();
             Audio::AudioManager::instance()->PlaySe(0xa4eb827e, nullptr);
         }
-
-        //Logger::log("UIWazaManage$$OnUpdate END\n");
-    }
-};
-
-HOOK_DEFINE_TRAMPOLINE(UIWazaManage$$OnUpdate_b2) {
-    static void Callback(Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object* __this) {
-        Logger::log("[UIWazaManage$$OnUpdate_b2] START\n");
-
-        Logger::log("[UIWazaManage$$OnUpdate_b2] __this = %08X\n", __this);
-        Orig(__this);
-
-        Logger::log("[UIWazaManage$$OnUpdate_b2] END\n");
-    }
-};
-
-HOOK_DEFINE_TRAMPOLINE(UIWazaManage$$OnUpdate_b3) {
-    static void Callback(Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object* __this, int32_t index) {
-        Logger::log("[UIWazaManage$$OnUpdate_b3] START\n");
-
-        Logger::log("[UIWazaManage$$OnUpdate_b3] __this = %08X\n", __this);
-        Logger::log("[UIWazaManage$$OnUpdate_b3] index = %d\n", index);
-        Orig(__this, index);
-
-        Logger::log("[UIWazaManage$$OnUpdate_b3] END\n");
     }
 };
 
 void exl_move_tutor_relearner_main() {
     UIWazaManage$$SetupPokemonInfo::InstallAtOffset(0x01dd40e0);
     UIWazaManage$$OnUpdate::InstallAtOffset(0x01dd4ae0);
-    UIWazaManage$$OnUpdate_b2::InstallAtOffset(0x01a34590);
-    UIWazaManage$$OnUpdate_b3::InstallAtOffset(0x01a34650);
 }

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -10,7 +10,7 @@
 
 HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
     static void Callback(Dpr::UI::UIWazaManage::Object* __this) {
-        Logger::log("UIWazaManage$$SetupPokemonInfo\n");
+        Logger::log("[UIWazaManage$$SetupPokemonInfo] START\n");
 
         system_load_typeinfo(0x9e21);
 
@@ -83,14 +83,14 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
 
             case 3:
             {
-                Logger::log("UIWazaManage$$SetupPokemonInfo Setting up moves!\n");
+                Logger::log("[UIWazaManage$$SetupPokemonInfo] Setting up moves!\n");
                 selectIndex = -1;
                 list->Clear();
 
                 int32_t table = __this->fields.param.fields.LearnWazaNo;
                 auto moves = GetMoveTutorTable(table);
 
-                for (int32_t i=0; i<moves.size(); i++)
+                for (uint64_t i=0; i<moves.size(); i++)
                 {
                     if (IsMoveLearnableByTutor(monsno, formno, moves[i]))
                         list->Add(moves[i]);
@@ -113,7 +113,7 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
 
         __this->fields.statusPanelCondition->Setup(__this->fields.param.fields.PokemonParam);
 
-        Logger::log("UIWazaManage$$SetupPokemonInfo END\n");
+        Logger::log("[UIWazaManage$$SetupPokemonInfo] END\n");
     }
 };
 
@@ -122,6 +122,7 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
         //Logger::log("UIWazaManage$$OnUpdate\n");
 
         system_load_typeinfo(0x9e1b);
+        system_load_typeinfo(0x9752);
         system_load_typeinfo(0x9753);
 
         Dpr::UI::UIManager::getClass()->initIfNeeded();
@@ -140,10 +141,20 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
 
         if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonA, false))
         {
+            Logger::log("[UIWazaManage$$OnUpdate] Pressed A!\n");
+            Logger::log("[UIWazaManage$$OnUpdate] currWindow = %08X\n", currWindow);
+            Logger::log("[UIWazaManage$$OnUpdate] __this = %08X\n", __this);
+            Logger::log("[UIWazaManage$$OnUpdate] __this.msgWindowController = %08X\n", __this->fields.msgWindowController);
+
             auto disp = Dpr::UI::UIWazaManage::__c__DisplayClass39_0::newInstance();
+            disp->fields.__4__this = __this;
             disp->fields.learnWazaNo = 0;
             disp->fields.unlearnWazaNo = 0;
             disp->fields.selectWazaNo = __this->fields.wazaStatusPanels->m_Items[__this->fields.selectTabIndex]->GetSelectedWazaNo();
+
+            Logger::log("[UIWazaManage$$OnUpdate] disp = %08X\n", disp);
+            Logger::log("[UIWazaManage$$OnUpdate] selected wazaStatusPanels = %08X\n", __this->fields.wazaStatusPanels->m_Items[__this->fields.selectTabIndex]);
+            Logger::log("[UIWazaManage$$OnUpdate] selectWazaNo = %d\n", disp->fields.selectWazaNo);
 
             System::String::Object* labelName = nullptr;
             switch (__this->fields.param.fields.BootType)
@@ -151,7 +162,6 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
                 case 0:
                 case 3:
                 {
-                    Logger::log("UIWazaManage$$OnUpdate Pressed A!\n");
                     disp->fields.learnWazaNo = disp->fields.selectWazaNo;
 
                     Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
@@ -209,20 +219,25 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
                     return; // End here
             }
 
+            Logger::log("[UIWazaManage$$OnUpdate] labelName = %08X (%s)\n", labelName, labelName->asCString().c_str());
+
             auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(disp, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__2);
             __this->fields.msgWindowController->OpenMsgWindow(3, labelName, true, false, onFinished, nullptr);
 
             Audio::AudioManager::getClass()->initIfNeeded();
             Audio::AudioManager::instance()->PlaySe(0x5d95f820, nullptr);
+
+            Logger::log("[UIWazaManage$$OnUpdate] Method$$OnUpdate$$b__2 = %08X\n", *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__2);
         }
         else if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonB, false))
         {
+            Logger::log("[UIWazaManage$$OnUpdate] Pressed B!\n");
+
             switch (__this->fields.param.fields.BootType)
             {
                 case 0:
                 case 3:
                 {
-                    Logger::log("UIWazaManage$$OnUpdate Pressed B!\n");
                     Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
                     Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
 
@@ -262,7 +277,32 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
     }
 };
 
+HOOK_DEFINE_TRAMPOLINE(UIWazaManage$$OnUpdate_b2) {
+    static void Callback(Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object* __this) {
+        Logger::log("[UIWazaManage$$OnUpdate_b2] START\n");
+
+        Logger::log("[UIWazaManage$$OnUpdate_b2] __this = %08X\n", __this);
+        Orig(__this);
+
+        Logger::log("[UIWazaManage$$OnUpdate_b2] END\n");
+    }
+};
+
+HOOK_DEFINE_TRAMPOLINE(UIWazaManage$$OnUpdate_b3) {
+    static void Callback(Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object* __this, int32_t index) {
+        Logger::log("[UIWazaManage$$OnUpdate_b3] START\n");
+
+        Logger::log("[UIWazaManage$$OnUpdate_b3] __this = %08X\n", __this);
+        Logger::log("[UIWazaManage$$OnUpdate_b3] index = %d\n", index);
+        Orig(__this, index);
+
+        Logger::log("[UIWazaManage$$OnUpdate_b3] END\n");
+    }
+};
+
 void exl_move_tutor_relearner_main() {
     UIWazaManage$$SetupPokemonInfo::InstallAtOffset(0x01dd40e0);
     UIWazaManage$$OnUpdate::InstallAtOffset(0x01dd4ae0);
+    UIWazaManage$$OnUpdate_b2::InstallAtOffset(0x01a34590);
+    UIWazaManage$$OnUpdate_b3::InstallAtOffset(0x01a34650);
 }

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -1,0 +1,120 @@
+#include "exlaunch.hpp"
+
+#include "externals/Audio/AudioManager.h"
+#include "externals/Dpr/Message/MessageWordSetHelper.h"
+#include "externals/Dpr/UI/UIWazaManage.h"
+
+#include "logger/logger.h"
+#include "romdata/romdata.h"
+
+HOOK_DEFINE_INLINE(UIWazaManage$$SetupPokemonInfo$$BootType_Setups) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_Setups\n");
+        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[0];
+
+        bool validType = window->fields.param.fields.BootType == 0 || window->fields.param.fields.BootType == 3;
+        ctx->W[22] = (uint32_t)validType;
+        ctx->W[21] = (uint32_t)!validType;
+
+        // Set up the first one
+        ctx->W[2] = ctx->W[22];
+        ctx->X[3] = (uint64_t)nullptr;
+        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_Setups END\n");
+    }
+};
+
+HOOK_DEFINE_INLINE(UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves\n");
+        system_load_typeinfo(0x4ced);
+        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
+
+        int32_t type = (int32_t)ctx->W[8];
+        auto list = (System::Collections::Generic::List$$int32_t::Object*)ctx->X[21];
+        if (type == 3)
+        {
+            Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves TYPE 3\n");
+            list->Clear();
+
+            int32_t table = window->fields.param.fields.LearnWazaNo;
+            auto moves = GetMoveTutorTable(table);
+
+            for (int32_t i=0; i<moves.size(); i++)
+                list->Add(moves[i]);
+        }
+
+        ctx->W[22] = 0xffffffff;
+        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves END\n");
+    }
+};
+
+HOOK_DEFINE_INLINE(UIWazaManage$$OnUpdate$$BootType_Learn) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn\n");
+        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
+        auto disp = (Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object*)ctx->X[20];
+        auto selectedMove = (int32_t)ctx->W[0];
+
+        disp->fields.selectWazaNo = selectedMove;
+
+        auto type = (int32_t)window->fields.param.fields.BootType;
+        ctx->W[8] = type;
+
+        if (type == 3)
+        {
+            Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn TYPE 3\n");
+            disp->fields.learnWazaNo = selectedMove;
+
+            Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+            Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.learnWazaNo);
+
+            auto labelName = System::String::Create("SS_waza_remember_023");
+            ctx->X[8] = (uint64_t)&labelName;
+        }
+
+        ctx->W[21] = ctx->W[0];
+        Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn END\n");
+    }
+};
+
+HOOK_DEFINE_INLINE(UIWazaManage$$OnUpdate$$BootType_Closing) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing\n");
+        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
+
+        auto type = (int32_t)window->fields.param.fields.BootType;
+        ctx->W[8] = type;
+
+        if (type == 3)
+        {
+            Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing TYPE 3\n");
+            Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+            Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, window->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
+            auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(window, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__39_0);
+            window->fields.msgWindowController->OpenMsgWindow(3, System::String::Create("SS_waza_remember_026"), true, false, onFinished, nullptr);
+
+            Audio::AudioManager::getClass()->initIfNeeded();
+            Audio::AudioManager::instance()->PlaySe(0xa4eb827e, nullptr);
+        }
+        Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing END\n");
+    }
+};
+
+void exl_move_tutor_relearner_main() {
+    UIWazaManage$$SetupPokemonInfo$$BootType_Setups::InstallAtOffset(0x01dd4410);
+    UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves::InstallAtOffset(0x01dd452c);
+    UIWazaManage$$OnUpdate$$BootType_Learn::InstallAtOffset(0x01dd4cb0);
+    UIWazaManage$$OnUpdate$$BootType_Closing::InstallAtOffset(0x01dd4d48);
+
+    using namespace exl::armv8::inst;
+    using namespace exl::armv8::reg;
+    exl::patch::CodePatcher p(0x01dd4414);
+    p.WriteInst(Nop()); // Nop out the values of w22 and w21
+    p.WriteInst(Nop());
+    p.WriteInst(Nop());
+
+    // Jump to after the switch if boot type is 3
+    p.Seek(0x01dd4cb4);
+    p.WriteInst(0x71000d1f); // cmp w8, #3
+    p.WriteInst(0x54001a20); // b.eq #0x344
+}

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -8,106 +8,13 @@
 #include "logger/logger.h"
 #include "romdata/romdata.h"
 
-HOOK_DEFINE_INLINE(UIWazaManage$$SetupPokemonInfo$$BootType_Setups) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_Setups\n");
-        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[0];
-
-        bool validType = window->fields.param.fields.BootType == 0 || window->fields.param.fields.BootType == 3;
-        ctx->W[22] = (uint32_t)validType;
-        ctx->W[21] = (uint32_t)!validType;
-
-        // Set up the first one
-        ctx->W[2] = ctx->W[22];
-        ctx->X[3] = (uint64_t)nullptr;
-        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_Setups END\n");
-    }
-};
-
-HOOK_DEFINE_INLINE(UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves\n");
-        system_load_typeinfo(0x4ced);
-        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
-
-        int32_t type = (int32_t)ctx->W[8];
-        auto list = (System::Collections::Generic::List$$int32_t::Object*)ctx->X[21];
-        if (type == 3)
-        {
-            Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves TYPE 3\n");
-            list->Clear();
-
-            int32_t table = window->fields.param.fields.LearnWazaNo;
-            auto moves = GetMoveTutorTable(table);
-
-            for (int32_t i=0; i<moves.size(); i++)
-                list->Add(moves[i]);
-        }
-
-        ctx->W[22] = 0xffffffff;
-        Logger::log("UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves END\n");
-    }
-};
-
-HOOK_DEFINE_INLINE(UIWazaManage$$OnUpdate$$BootType_Learn) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn\n");
-        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
-        auto disp = (Dpr::UI::UIWazaManage::__c__DisplayClass39_0::Object*)ctx->X[20];
-        auto selectedMove = (int32_t)ctx->W[0];
-
-        disp->fields.selectWazaNo = selectedMove;
-
-        auto type = (int32_t)window->fields.param.fields.BootType;
-        ctx->W[8] = type;
-
-        if (type == 3)
-        {
-            Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn TYPE 3\n");
-            disp->fields.learnWazaNo = selectedMove;
-
-            Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
-            Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.learnWazaNo);
-
-            auto labelName = System::String::Create("SS_waza_remember_023");
-            ctx->X[8] = (uint64_t)&labelName;
-        }
-
-        ctx->W[21] = ctx->W[0];
-        Logger::log("UIWazaManage$$OnUpdate$$BootType_Learn END\n");
-    }
-};
-
-HOOK_DEFINE_INLINE(UIWazaManage$$OnUpdate$$BootType_Closing) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing\n");
-        auto window = (Dpr::UI::UIWazaManage::Object*)ctx->X[19];
-
-        auto type = (int32_t)window->fields.param.fields.BootType;
-        ctx->W[8] = type;
-
-        if (type == 3)
-        {
-            Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing TYPE 3\n");
-            Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
-            Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, window->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
-            auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(window, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__39_0);
-            window->fields.msgWindowController->OpenMsgWindow(3, System::String::Create("SS_waza_remember_026"), true, false, onFinished, nullptr);
-
-            Audio::AudioManager::getClass()->initIfNeeded();
-            Audio::AudioManager::instance()->PlaySe(0xa4eb827e, nullptr);
-        }
-        Logger::log("UIWazaManage$$OnUpdate$$BootType_Closing END\n");
-    }
-};
-
-
 HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
     static void Callback(Dpr::UI::UIWazaManage::Object* __this) {
         Logger::log("UIWazaManage$$SetupPokemonInfo\n");
 
         system_load_typeinfo(0x9e21);
 
+        Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
         Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
         __this->fields.pokemonInfoName->fields._useMessage = true;
         __this->fields.pokemonInfoName->fields._isManual = true;
@@ -215,6 +122,7 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
         //Logger::log("UIWazaManage$$OnUpdate\n");
 
         system_load_typeinfo(0x9e1b);
+        system_load_typeinfo(0x9753);
 
         Dpr::UI::UIManager::getClass()->initIfNeeded();
         auto currWindow = Dpr::UI::UIManager::get_Instance()->GetCurrentUIWindow(Dpr::UI::UIManager::Method$$GetCurrentUIWindow_UIWindow_);
@@ -355,23 +263,6 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
 };
 
 void exl_move_tutor_relearner_main() {
-    /*UIWazaManage$$SetupPokemonInfo$$BootType_Setups::InstallAtOffset(0x01dd4410);
-    UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves::InstallAtOffset(0x01dd452c);
-    UIWazaManage$$OnUpdate$$BootType_Learn::InstallAtOffset(0x01dd4cb0);
-    UIWazaManage$$OnUpdate$$BootType_Closing::InstallAtOffset(0x01dd4d48);*/
-
     UIWazaManage$$SetupPokemonInfo::InstallAtOffset(0x01dd40e0);
     UIWazaManage$$OnUpdate::InstallAtOffset(0x01dd4ae0);
-
-    /*using namespace exl::armv8::inst;
-    using namespace exl::armv8::reg;
-    exl::patch::CodePatcher p(0x01dd4414);
-    p.WriteInst(Nop()); // Nop out the values of w22 and w21
-    p.WriteInst(Nop());
-    p.WriteInst(Nop());
-
-    // Jump to after the switch if boot type is 3
-    p.Seek(0x01dd4cb4);
-    p.WriteInst(0x71000d1f); // cmp w8, #3
-    p.WriteInst(0x54001a20); // b.eq #0x344*/
 }

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -2,6 +2,7 @@
 
 #include "externals/Audio/AudioManager.h"
 #include "externals/Dpr/Message/MessageWordSetHelper.h"
+#include "externals/Dpr/UI/UIManager.h"
 #include "externals/Dpr/UI/UIWazaManage.h"
 
 #include "logger/logger.h"
@@ -100,13 +101,269 @@ HOOK_DEFINE_INLINE(UIWazaManage$$OnUpdate$$BootType_Closing) {
     }
 };
 
+
+HOOK_DEFINE_REPLACE(UIWazaManage$$SetupPokemonInfo) {
+    static void Callback(Dpr::UI::UIWazaManage::Object* __this) {
+        Logger::log("UIWazaManage$$SetupPokemonInfo\n");
+
+        system_load_typeinfo(0x9e21);
+
+        Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
+        __this->fields.pokemonInfoName->fields._useMessage = true;
+        __this->fields.pokemonInfoName->fields._isManual = true;
+        __this->fields.pokemonInfoName->UpdateMessage(true, Dpr::Message::MessageEnumData::MsgLangId::Num);
+
+        Dpr::Message::MessageWordSetHelper::SetDigitWord(0, __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetLevel());
+        __this->fields.pokemonInfoLevel->fields._useMessage = true;
+        __this->fields.pokemonInfoLevel->fields._isManual = true;
+        __this->fields.pokemonInfoLevel->UpdateMessage(true, Dpr::Message::MessageEnumData::MsgLangId::Num);
+
+        Dpr::UI::UIManager::getClass()->initIfNeeded();
+        __this->fields.pokemonInfoSex->set_sprite(Dpr::UI::UIManager::get_Instance()->GetSpritePokemonSex(__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetSex()));
+        __this->fields.pokemonInfoSex->cast<UnityEngine::Behaviour>()->set_enabled(UnityEngine::_Object::op_Inequality(__this->fields.pokemonInfoSex->fields.m_Sprite->cast<UnityEngine::_Object>(), nullptr));
+
+        auto btlParam = Dpr::UI::UIManager::ToBattlePokemonParam(__this->fields.param.fields.PokemonParam);
+        if (btlParam == nullptr)
+            __this->fields.pokemonInfoSick->Setup(__this->fields.param.fields.PokemonParam);
+        else
+            __this->fields.pokemonInfoSick->Setup(btlParam);
+
+        auto pokeLang = __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetLangId();
+        if ((uint32_t)Dpr::UI::UIManager::GetCurrentLangId() == pokeLang)
+        {
+            __this->fields.pokemonInfoLanguage->cast<UnityEngine::Component>()->get_gameObject()->SetActive(false);
+        }
+        else
+        {
+            __this->fields.pokemonInfoLanguage->cast<UnityEngine::Component>()->get_gameObject()->SetActive(true);
+            __this->fields.pokemonInfoLanguage->set_sprite(Dpr::UI::UIManager::get_Instance()->GetSpritePokemonLanguage((Dpr::Message::MessageEnumData::MsgLangId)pokeLang));
+        }
+
+        __this->fields.pokemonInfoMonsterBallImage->set_sprite(Dpr::UI::UIManager::get_Instance()->GetSpriteMonsterBall(__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetGetBall()));
+
+        bool isWazaActive = __this->fields.param.fields.BootType == 0 || __this->fields.param.fields.BootType == 3; // 3 is our custom tutor BootType
+        __this->fields.battlePokemonStatusPanel->Setup(__this->fields.param.fields.PokemonParam, isWazaActive);
+        __this->fields.contestPokemonStatusPanel->Setup(__this->fields.param.fields.PokemonParam, isWazaActive);
+        __this->fields.bgObject->SetActive(!isWazaActive);
+        __this->fields.withWazaBgObject->SetActive(isWazaActive);
+
+        auto list = System::Collections::Generic::List$$WazaNo::newInstance();
+
+        auto count = __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetWazaCount();
+        for (uint8_t i=0; i<count; i++)
+            list->Add(__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetWazaNo(i));
+
+        auto monsno = __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetMonsNo();
+        auto formno = __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->GetFormNo();
+
+        int32_t selectIndex;
+        switch (__this->fields.param.fields.BootType)
+        {
+            case 0:
+            {
+                list->Clear();
+                list->AddRange(__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->CollectRemindableWaza());
+                selectIndex = -1;
+            }
+            break;
+
+            case 2:
+            {
+                selectIndex = list->fields._size;
+                list->Add(__this->fields.param.fields.LearnWazaNo);
+            }
+            break;
+
+            case 3:
+            {
+                Logger::log("UIWazaManage$$SetupPokemonInfo Setting up moves!\n");
+                selectIndex = -1;
+                list->Clear();
+
+                int32_t table = __this->fields.param.fields.LearnWazaNo;
+                auto moves = GetMoveTutorTable(table);
+
+                for (int32_t i=0; i<moves.size(); i++)
+                {
+                    if (IsMoveLearnableByTutor(monsno, formno, moves[i]))
+                        list->Add(moves[i]);
+                }
+            }
+            break;
+
+            default:
+            {
+                selectIndex = -1;
+            }
+            break;
+        }
+
+        for (uint64_t i=0; i<__this->fields.wazaStatusPanels->max_length; i++)
+        {
+            __this->fields.wazaStatusPanels->m_Items[i]->Initialize();
+            __this->fields.wazaStatusPanels->m_Items[i]->Setup(__this->fields.param.fields.PokemonParam, (Pml::WazaNo_array*)list->ToArray(), selectIndex);
+        }
+
+        __this->fields.statusPanelCondition->Setup(__this->fields.param.fields.PokemonParam);
+
+        Logger::log("UIWazaManage$$SetupPokemonInfo END\n");
+    }
+};
+
+HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
+    static void Callback(Dpr::UI::UIWazaManage::Object* __this, float deltaTime) {
+        //Logger::log("UIWazaManage$$OnUpdate\n");
+
+        system_load_typeinfo(0x9e1b);
+
+        Dpr::UI::UIManager::getClass()->initIfNeeded();
+        auto currWindow = Dpr::UI::UIManager::get_Instance()->GetCurrentUIWindow(Dpr::UI::UIManager::Method$$GetCurrentUIWindow_UIWindow_);
+
+        if (UnityEngine::_Object::op_Inequality(currWindow->cast<UnityEngine::_Object>(), __this->cast<UnityEngine::_Object>()))
+            return;
+
+        if (__this->fields.msgWindowController->OnUpdate(deltaTime))
+            return;
+
+        for (uint64_t i=0; i<__this->fields.wazaStatusPanels->max_length; i++)
+            __this->fields.wazaStatusPanels->m_Items[i]->UpdateSelect(deltaTime, (int32_t)i == __this->fields.selectTabIndex);
+
+        __this->UpdateSelectTab(deltaTime);
+
+        if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonA, false))
+        {
+            auto disp = Dpr::UI::UIWazaManage::__c__DisplayClass39_0::newInstance();
+            disp->fields.learnWazaNo = 0;
+            disp->fields.unlearnWazaNo = 0;
+            disp->fields.selectWazaNo = __this->fields.wazaStatusPanels->m_Items[__this->fields.selectTabIndex]->GetSelectedWazaNo();
+
+            System::String::Object* labelName = nullptr;
+            switch (__this->fields.param.fields.BootType)
+            {
+                case 0:
+                case 3:
+                {
+                    Logger::log("UIWazaManage$$OnUpdate Pressed A!\n");
+                    disp->fields.learnWazaNo = disp->fields.selectWazaNo;
+
+                    Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                    Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.selectWazaNo);
+                    labelName = System::String::Create("SS_waza_remember_023");
+                }
+                break;
+
+                case 1:
+                {
+                    disp->fields.unlearnWazaNo = disp->fields.selectWazaNo;
+
+                    if (__this->fields.param.fields.IsOpenFromFieldScript)
+                    {
+                        if (__this->fields.param.fields.ResultCallback != nullptr)
+                            __this->fields.param.fields.ResultCallback->Invoke(disp->fields.learnWazaNo, disp->fields.selectWazaNo);
+
+                        __this->Close(__this->fields.onClosed);
+                        return;
+                    }
+                    else
+                    {
+                        Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                        Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.selectWazaNo);
+                        labelName = System::String::Create("SS_waza_remember_037");
+                    }
+                }
+                break;
+
+                case 2:
+                {
+                    if (__this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>()->HaveWaza(disp->fields.selectWazaNo))
+                    {
+                        disp->fields.learnWazaNo = __this->fields.param.fields.LearnWazaNo;
+                        disp->fields.unlearnWazaNo = disp->fields.selectWazaNo;
+
+                        Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                        Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.unlearnWazaNo);
+                        Dpr::Message::MessageWordSetHelper::SetWazaNameWord(1, disp->fields.learnWazaNo);
+                        labelName = System::String::Create("SS_waza_remember_045");
+                    }
+                    else
+                    {
+                        disp->fields.learnWazaNo = __this->fields.param.fields.LearnWazaNo;
+                        disp->fields.unlearnWazaNo = disp->fields.selectWazaNo;
+
+                        Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                        Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.selectWazaNo);
+                        labelName = System::String::Create("SS_waza_remember_043");
+                    }
+                }
+                break;
+
+                default:
+                    return; // End here
+            }
+
+            auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(disp, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__2);
+            __this->fields.msgWindowController->OpenMsgWindow(3, labelName, true, false, onFinished, nullptr);
+
+            Audio::AudioManager::getClass()->initIfNeeded();
+            Audio::AudioManager::instance()->PlaySe(0x5d95f820, nullptr);
+        }
+        else if (__this->cast<Dpr::UI::UIWindow>()->IsPushButton(Dpr::UI::UIManager::getClass()->static_fields->ButtonB, false))
+        {
+            switch (__this->fields.param.fields.BootType)
+            {
+                case 0:
+                case 3:
+                {
+                    Logger::log("UIWazaManage$$OnUpdate Pressed B!\n");
+                    Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                    Dpr::Message::MessageWordSetHelper::SetPokemonNickNameWord(0, __this->fields.param.fields.PokemonParam->cast<Pml::PokePara::CoreParam>(), true);
+
+                    auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(__this, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__39_0);
+                    __this->fields.msgWindowController->OpenMsgWindow(3, System::String::Create("SS_waza_remember_026"), true, false, onFinished, nullptr);
+                }
+                break;
+
+                case 1:
+                {
+                    if (__this->fields.param.fields.ResultCallback != nullptr)
+                        __this->fields.param.fields.ResultCallback->Invoke(0, 0);
+
+                    __this->Close(__this->fields.onClosed);
+                }
+                break;
+
+                case 2:
+                {
+                    Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
+                    Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, __this->fields.param.fields.LearnWazaNo);
+
+                    auto onFinished = System::Action::getClass(System::Action::void_TypeInfo)->newInstance(__this, *Dpr::UI::UIWazaManage::Method$$OnUpdate$$b__39_1);
+                    __this->fields.msgWindowController->OpenMsgWindow(3, System::String::Create("SS_waza_remember_043"), true, false, onFinished, nullptr);
+                }
+                break;
+
+                default:
+                    return; // End here
+            }
+
+            Audio::AudioManager::getClass()->initIfNeeded();
+            Audio::AudioManager::instance()->PlaySe(0xa4eb827e, nullptr);
+        }
+
+        //Logger::log("UIWazaManage$$OnUpdate END\n");
+    }
+};
+
 void exl_move_tutor_relearner_main() {
-    UIWazaManage$$SetupPokemonInfo$$BootType_Setups::InstallAtOffset(0x01dd4410);
+    /*UIWazaManage$$SetupPokemonInfo$$BootType_Setups::InstallAtOffset(0x01dd4410);
     UIWazaManage$$SetupPokemonInfo$$BootType_CollectMoves::InstallAtOffset(0x01dd452c);
     UIWazaManage$$OnUpdate$$BootType_Learn::InstallAtOffset(0x01dd4cb0);
-    UIWazaManage$$OnUpdate$$BootType_Closing::InstallAtOffset(0x01dd4d48);
+    UIWazaManage$$OnUpdate$$BootType_Closing::InstallAtOffset(0x01dd4d48);*/
 
-    using namespace exl::armv8::inst;
+    UIWazaManage$$SetupPokemonInfo::InstallAtOffset(0x01dd40e0);
+    UIWazaManage$$OnUpdate::InstallAtOffset(0x01dd4ae0);
+
+    /*using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;
     exl::patch::CodePatcher p(0x01dd4414);
     p.WriteInst(Nop()); // Nop out the values of w22 and w21
@@ -116,5 +373,5 @@ void exl_move_tutor_relearner_main() {
     // Jump to after the switch if boot type is 3
     p.Seek(0x01dd4cb4);
     p.WriteInst(0x71000d1f); // cmp w8, #3
-    p.WriteInst(0x54001a20); // b.eq #0x344
+    p.WriteInst(0x54001a20); // b.eq #0x344*/
 }

--- a/src/mod/features/pla_context_menu.cpp
+++ b/src/mod/features/pla_context_menu.cpp
@@ -53,9 +53,9 @@ void EvDataManager_EvCmdCallWazaOshieUi_b__0(Dpr::EvScript::EvDataManager::Displ
     __this->fields.__4__this->LearnWaza(__this->fields.param, learnWazaNo, unlearnWazaNo);
 }
 
-void EvDataManager_EvCmdCallWazaOmoidashiUi_b__1539_0(Dpr::EvScript::EvDataManager::Object *__this, int32_t learnWazaNo, int32_t unlearnWazaNo)
+void EvDataManager_EvCmdCallWazaOmoidashiUi_b__1542_0(Dpr::EvScript::EvDataManager::Object *__this, int32_t learnWazaNo, int32_t unlearnWazaNo)
 {
-    Logger::log("EvDataManager_EvCmdCallWazaOmoidashiUi_b__1539_0\n");
+    Logger::log("EvDataManager_EvCmdCallWazaOmoidashiUi_b__1542_0\n");
 
     // unlearnWazaNo is always zero, because this is just selecting the move to learn.
     if (learnWazaNo == 0)
@@ -107,7 +107,7 @@ void createMoveRelearnerWindow(Dpr::UI::PokemonWindow::DisplayClass25_0::Object 
 
     Dpr::EvScript::EvDataManager::Object * evDataManager = Dpr::EvScript::EvDataManager::get_Instanse();
 
-    MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdCallWazaOmoidashiUiParty((Il2CppMethodPointer)&EvDataManager_EvCmdCallWazaOmoidashiUi_b__1539_0);
+    MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdCallWazaOmoidashiUiParty((Il2CppMethodPointer)&EvDataManager_EvCmdCallWazaOmoidashiUi_b__1542_0);
     System::Action::Object* resultCallback = System::Action::getClass(System::Action::WazaNo_WazaNo_TypeInfo)->newInstance(evDataManager, mi);
 
     sPokemonParam = dispClass->fields.pokemonParam;

--- a/src/mod/features/spinda_hijacking.cpp
+++ b/src/mod/features/spinda_hijacking.cpp
@@ -46,7 +46,7 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                         for (uint64_t i=0; i<renderers->max_length; i++)
                         {
                             renderer = (UnityEngine::Renderer::Object*)renderers->m_Items[i];
-                            if (((UnityEngine::_Object::Object*)renderer)->GetName()->asCString().find("Patcheel") != -1)
+                            if (((UnityEngine::_Object::Object*)renderer)->GetName()->asCString().find("Patcheel") != nn::string::npos)
                                 break;
                         }
                     }
@@ -70,8 +70,8 @@ HOOK_DEFINE_TRAMPOLINE(PatcheelPattern$$SetPattern) {
                     uint32_t id = ((Pml::PokePara::CoreParam::Object*)param)->GetMultiPurposeWork();
                     Logger::log("[PatcheelPattern$$SetPattern] Using id %d\n", id);
 
-                    for (int i=0; i<__this->fields.UVDatas->max_length; i++)
-                        ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->fields.renderer)->set_enabled(i == id);
+                    for (uint64_t i=0; i<__this->fields.UVDatas->max_length; i++)
+                        ((UnityEngine::Renderer::Object*)__this->fields.UVDatas->m_Items[i]->fields.renderer)->set_enabled(i == (uint64_t)id);
                 }
                 break;
             }

--- a/src/mod/romdata/data/MoveTutor.h
+++ b/src/mod/romdata/data/MoveTutor.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+#include "memory/json.h"
+#include "memory/vector.h"
+
+namespace RomData
+{
+    struct MoveTutor
+    {
+        nn::vector<int32_t> moves;
+    };
+
+    JSON_TEMPLATE
+    void to_json(GENERIC_JSON& j, const MoveTutor& t) {
+        j = nn::json {
+            {"moves", t.moves},
+        };
+    }
+
+    JSON_TEMPLATE
+    void from_json(const GENERIC_JSON& j, MoveTutor& t) {
+        j.at("moves").get_to(t.moves);
+    }
+}

--- a/src/mod/romdata/local_trades.cpp
+++ b/src/mod/romdata/local_trades.cpp
@@ -15,17 +15,17 @@ void LogLocalTradeData(const RomData::LocalTrade& t)
     Logger::log("CURRENT LOCAL TRADE\n");
 
     Logger::log("IVs: ");
-    for (int i=0; i<t.ivs.size(); i++)
+    for (uint64_t i=0; i<t.ivs.size(); i++)
         Logger::log("%d ", t.ivs[i]);
     Logger::log("\n");
 
     Logger::log("EVs: ");
-    for (int i=0; i<t.evs.size(); i++)
+    for (uint64_t i=0; i<t.evs.size(); i++)
         Logger::log("%d ", t.evs[i]);
     Logger::log("\n");
 
     Logger::log("Contest Stats: ");
-    for (int i=0; i<t.contestStats.size(); i++)
+    for (uint64_t i=0; i<t.contestStats.size(); i++)
         Logger::log("%d ", t.contestStats[i]);
     Logger::log("\n");
 

--- a/src/mod/romdata/move_tutors.cpp
+++ b/src/mod/romdata/move_tutors.cpp
@@ -1,0 +1,88 @@
+#include "exlaunch.hpp"
+
+#include "data/moves.h"
+#include "helpers.h"
+#include "memory/json.h"
+#include "memory/string.h"
+#include "romdata/data/MoveTutor.h"
+
+#include "logger/logger.h"
+
+const char* moveTutorLearnsetFolderPath = "rom:/Data/ExtraData/MonData/MoveTutorLearnset/";
+const char* moveTutorFolderPath = "rom:/Data/ExtraData/MoveTutor/";
+
+void LogMoveTutorData(const RomData::MoveTutor& t, int32_t monsno, int32_t formno)
+{
+    Logger::log("Monsno %d of formno %d learns these moves from a Move Tutor:\n", monsno, formno);
+    for (auto &m: t.moves)
+    {
+        Logger::log("%s, ", MOVES[m]);
+    }
+    Logger::log("\n");
+}
+
+void LogMoveTutorData(const RomData::MoveTutor& t, int32_t id)
+{
+    Logger::log("Move Tutor table %d teaches these moves:\n", id);
+    for (auto &m: t.moves)
+    {
+        Logger::log("%s, ", MOVES[m]);
+    }
+    Logger::log("\n");
+}
+
+nn::vector<int32_t> GetMoveTutorLearnset(int32_t monsno, int32_t formno)
+{
+    nn::string filePath(moveTutorLearnsetFolderPath);
+    filePath.append("monsno_" + nn::to_string(monsno) + "_formno_" + nn::to_string(formno) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::MoveTutor moveTutor = {};
+        moveTutor = j.get<RomData::MoveTutor>();
+        LogMoveTutorData(moveTutor, monsno, formno);
+        return moveTutor.moves;
+    }
+    else
+    {
+        Logger::log("Error when parsing Move Tutor data for monsno %d and formno %d!\n", monsno, formno);
+    }
+
+    // Default, empty
+    return {};
+}
+
+bool IsMoveLearnableByTutor(int32_t monsno, int32_t formno, int32_t move)
+{
+    auto tutorMoves = GetMoveTutorLearnset(monsno, formno);
+
+    for (int32_t tutorMove : tutorMoves)
+    {
+        if (move == tutorMove) return true;
+    }
+
+    return false;
+}
+
+nn::vector<int32_t> GetMoveTutorTable(int32_t id)
+{
+    nn::string filePath(moveTutorFolderPath);
+    filePath.append("tutor_" + nn::to_string(id) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::MoveTutor moveTutor = {};
+        moveTutor = j.get<RomData::MoveTutor>();
+        LogMoveTutorData(moveTutor, id);
+        return moveTutor.moves;
+    }
+    else
+    {
+        Logger::log("Error when parsing Move Tutor data for table %d!\n", id);
+    }
+
+    // Default, empty
+    return {};
+}

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -75,4 +75,13 @@ nn::vector<uint32_t> GetVariantRates(int32_t monsno, int32_t formno, int32_t zon
 // Rolls for a variant based on the form rates for the given Pokémon at the given zoneID.
 int32_t RollForVariant(int32_t monsno, int32_t formno, int32_t zoneID);
 
+// Returns the full Move Tutor move list of the given Pokémon.
+nn::vector<int32_t> GetMoveTutorLearnset(int32_t monsno, int32_t formno);
+
+// Checks if a given move is available to be learned by Move Tutor for the given Pokémon.
+bool IsMoveLearnableByTutor(int32_t monsno, int32_t formno, int32_t move);
+
+// Returns the full move list of the given tutor.
+nn::vector<int32_t> GetMoveTutorTable(int32_t id);
+
 void LoadFeaturesFromJSON(nn::json j);


### PR DESCRIPTION
Closes #92, and contributes to #160.

- Adds the new feature "Move Tutor Relearner".
  - Rewrites some of the code for the "move management" UI to allow for a version of it for Move Tutors.
- Reads Move Tutor data from JSON files.
  - ExtraData/MoveTutor contains JSONs which contain a list of moves that a specific tutor can teach.
  - ExtraData/MonData/MoveTutorLearnset contains JSONs which contain a list of moves that a specific species can learn from tutors, regardless of which tutor teaches them.
- New command: _CHECK_TUTOR_MOVE (1256).
  - Checks if a specific species can learn a specific move by tutor.
    - Monsno [Work, Float]: The natdex number of the species to check.
    - Formno [Work, Float]: The form ID of the species to check.
    - Move [Work, Float]: The move ID of the species to check.
    - Result [Work]: The work in which to put the result. (0 for no, 1 for yes)
- New command: _MOVE_TUTOR_UI (1257).
  - Opens a version of the "move management" UI that lists the moves a specific tutor can teach.
    - Learned [Work]: The work in which to put the move that was learned. (0 for no move)
    - Index [Work, Float]: The index that points to the given Pokémon.
    - TrayIndex [Work, Float]: The tray index in which to look for the given Pokémon.
    - Table [Work, Float]: The Move Tutor table to use.
- Fixed a few warnings when building.
- Fixed UIText and its parent classes' field alignment issues.
- Makes the player's outfit at the start of the game the platinum outfit.