### PR TITLE
Extra Intro Stuff

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -53,6 +53,7 @@ static constexpr const char* FEATURES[] = {
     "Dialog Text Color",
     "Language UI Fixes",
     "Move Tutor Relearner",
+    "Player Select",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -54,6 +54,7 @@ static constexpr const char* FEATURES[] = {
     "Language UI Fixes",
     "Move Tutor Relearner",
     "Player Select",
+    "Intro Professor Pokémon",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/Dpr/Demo/DemoBase.h
+++ b/src/mod/externals/Dpr/Demo/DemoBase.h
@@ -11,6 +11,21 @@
 
 namespace Dpr::Demo {
     struct DemoBase : ILClass<DemoBase> {
+        struct LoadPokeAsset_d__71 : ILClass<LoadPokeAsset_d__71> {
+            struct Fields {
+                int32_t __1__state;
+                Il2CppObject* __2__current;
+                Dpr::Demo::DemoBase::Object* __4__this;
+                bool useAssetUnloader;
+                int32_t monsNo;
+                uint16_t formNo;
+                uint8_t sex;
+                bool isRare;
+                bool isEgg;
+                bool isBattleModel;
+            };
+        };
+
         struct Fields {
             void* cameraController; // Dpr_Demo_DemoCamera_o*
             void* manager; // Dpr_Demo_DemoSceneManager_o*

--- a/src/mod/externals/Dpr/UI/SelectPlayerVisualItem.h
+++ b/src/mod/externals/Dpr/UI/SelectPlayerVisualItem.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/SelectOpeningItem.h"
+
+namespace Dpr::UI {
+    struct SelectPlayerVisualItem : ILClass<SelectPlayerVisualItem> {
+        struct Fields : Dpr::UI::SelectOpeningItem::Fields {
+            bool sex;
+            int32_t colorId;
+        };
+    };
+}
+
+namespace System::Collections::Generic {
+    struct List$$SelectPlayerVisualItem : List<List$$SelectPlayerVisualItem, Dpr::UI::SelectPlayerVisualItem> {
+        static inline StaticILMethod<0x04c898f0> Method$$Add {};
+    };
+}

--- a/src/mod/externals/Dpr/UI/SelectPlayerVisualWindow.h
+++ b/src/mod/externals/Dpr/UI/SelectPlayerVisualWindow.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/Cursor.h"
+#include "externals/Dpr/UI/SelectPlayerVisualItem.h"
+#include "externals/Dpr/UI/SelectOpeningBase.h"
+#include "externals/UnityEngine/Events/UnityAction.h"
+#include "externals/UnityEngine/RectTransform.h"
+
+namespace Dpr::UI {
+    struct SelectPlayerVisualWindow : ILClass<SelectPlayerVisualWindow> {
+        struct Fields : Dpr::UI::SelectOpeningBase::Fields {
+            UnityEngine::RectTransform::Object* _content;
+            Dpr::UI::Cursor::Object* _cursor;
+            System::Collections::Generic::List$$SelectPlayerVisualItem::Object* _items;
+            int32_t _selectIndex;
+        };
+
+        inline bool SetSelectIndex(int32_t index, bool isInitialized) {
+            return external<bool>(0x01d3e050, this, index, isInitialized);
+        }
+    };
+}

--- a/src/mod/externals/OpeningController.h
+++ b/src/mod/externals/OpeningController.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/SelectPlayerVisualItem.h"
+#include "externals/UnityEngine/MonoBehaviour.h"
+
+struct OpeningController : ILClass<OpeningController> {
+    struct Fields : UnityEngine::MonoBehaviour::Fields {
+        struct Dpr::UI::SelectPlayerVisualItem::Object* _selectPlayerVisualItem;
+        void* OnFinishedCallBack;
+        void* demoRequestOperation;
+        void* demoInstance;
+        void* demoSceneManager;
+        void* demoModel;
+    };
+};

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -119,6 +119,9 @@ void exl_npc_collision_audio_main();
 // Adds nicknaming and move relearning to the party menu.
 void exl_pla_context_menu_main();
 
+// Allows configuring the controls on the player select screen.
+void exl_player_select_main();
+
 // Fixes Poké Radar bugs and improves chain rates.
 void exl_poke_radar_fixes_main();
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -92,6 +92,9 @@ void exl_gender_neutral_boutique_main();
 // Replaces every instance of Hidden Power being shown as "Normal" type with its actual type for the Pokémon.
 void exl_hidden_power_ui_main();
 
+// Allows configuring Rowan's Pokémon in the intro.
+void exl_intro_professor_pokemon_main();
+
 // Allows configuring the available languages on the language select screen.
 void exl_language_select_main();
 

--- a/src/mod/features/gender_neutral_boutique.cpp
+++ b/src/mod/features/gender_neutral_boutique.cpp
@@ -48,8 +48,6 @@ void exl_gender_neutral_boutique_main() {
     exl::patch::CodePatcher p(0);
     auto inst = nn::vector<exl::patch::Instruction> {
         { 0x0202f120, Movz(X0, 0) }, // Remove bike outfit override for battles on cycling road
-        { 0x02cf3cf4, Movz(W21, array_index(OUTFITS, "Platinum Style Masculine")) }, // Change Lucas default outfit in intro to platinum outfit
-        { 0x02cf3d38, Movz(W21, array_index(OUTFITS, "Platinum Style Feminine")) },  // Change Dawn default outfit in intro to platinum outfit
     };
     p.WriteInst(inst);
 };

--- a/src/mod/features/intro_professor_pokemon.cpp
+++ b/src/mod/features/intro_professor_pokemon.cpp
@@ -6,7 +6,7 @@
 
 #include "utils/utils.h"
 
-HOOK_DEFINE_INLINE(Demo_Hakase_PreloadAssetBundles) {
+HOOK_DEFINE_INLINE(Mon_Demo_Hakase_PreloadAssetBundles) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto profMon = GetProfessorMon();
         ctx->W[0] = profMon.monsno;
@@ -16,7 +16,7 @@ HOOK_DEFINE_INLINE(Demo_Hakase_PreloadAssetBundles) {
     }
 };
 
-HOOK_DEFINE_INLINE(Demo_Hakase_ReleasePreloadedAssetBundles) {
+HOOK_DEFINE_INLINE(Mon_Demo_Hakase_ReleasePreloadedAssetBundles) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto profMon = GetProfessorMon();
         ctx->W[0] = profMon.monsno;
@@ -26,7 +26,7 @@ HOOK_DEFINE_INLINE(Demo_Hakase_ReleasePreloadedAssetBundles) {
     }
 };
 
-HOOK_DEFINE_INLINE(Demo_Hakase_Enter_d__15_MoveNext) {
+HOOK_DEFINE_INLINE(Mon_Demo_Hakase_Enter_d__15_MoveNext) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto disp = (Dpr::Demo::DemoBase::LoadPokeAsset_d__71::Object*)ctx->X[22];
         auto profMon = GetProfessorMon();
@@ -38,7 +38,7 @@ HOOK_DEFINE_INLINE(Demo_Hakase_Enter_d__15_MoveNext) {
     }
 };
 
-HOOK_DEFINE_INLINE(Demo_Hakase_Main_b__16_7) {
+HOOK_DEFINE_INLINE(Mon_Demo_Hakase_Main_b__16_7) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto profMon = GetProfessorMon();
         ctx->W[0] = profMon.monsno;
@@ -46,9 +46,38 @@ HOOK_DEFINE_INLINE(Demo_Hakase_Main_b__16_7) {
     }
 };
 
+HOOK_DEFINE_INLINE(Prof_Demo_Hakase_PreloadAssetBundles) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        ctx->X[0] = (uint64_t)System::String::Create("persons/battle/tr2003_00");
+    }
+};
+
+HOOK_DEFINE_INLINE(Prof_Demo_Hakase_ReleasePreloadedAssetBundles) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        ctx->X[0] = (uint64_t)System::String::Create("persons/battle/tr2003_00");
+    }
+};
+
+HOOK_DEFINE_INLINE(Prof_Demo_Hakase_Enter_d__15_MoveNext) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        ctx->X[0] = (uint64_t)System::String::Create("persons/battle/tr2003_00");
+    }
+};
+
+HOOK_DEFINE_INLINE(Prof_Demo_Hakase_Enter_b__15_1) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        ctx->X[1] = (uint64_t)System::String::Create("tr2003_00");
+    }
+};
+
 void exl_intro_professor_pokemon_main() {
-    Demo_Hakase_PreloadAssetBundles::InstallAtOffset(0x01ad2138);
-    Demo_Hakase_ReleasePreloadedAssetBundles::InstallAtOffset(0x01ad2350);
-    Demo_Hakase_Enter_d__15_MoveNext::InstallAtOffset(0x01ad4108);
-    Demo_Hakase_Main_b__16_7::InstallAtOffset(0x01ad3308);
+    Mon_Demo_Hakase_PreloadAssetBundles::InstallAtOffset(0x01ad2138);
+    Mon_Demo_Hakase_ReleasePreloadedAssetBundles::InstallAtOffset(0x01ad2350);
+    Mon_Demo_Hakase_Enter_d__15_MoveNext::InstallAtOffset(0x01ad4108);
+    Mon_Demo_Hakase_Main_b__16_7::InstallAtOffset(0x01ad3308);
+
+    Prof_Demo_Hakase_PreloadAssetBundles::InstallAtOffset(0x01ad2038);
+    Prof_Demo_Hakase_ReleasePreloadedAssetBundles::InstallAtOffset(0x01ad2280);
+    Prof_Demo_Hakase_Enter_d__15_MoveNext::InstallAtOffset(0x01ad3fb4);
+    Prof_Demo_Hakase_Enter_b__15_1::InstallAtOffset(0x01ad2d04);
 }

--- a/src/mod/features/intro_professor_pokemon.cpp
+++ b/src/mod/features/intro_professor_pokemon.cpp
@@ -1,0 +1,54 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Demo/DemoBase.h"
+
+#include "romdata/romdata.h"
+
+#include "utils/utils.h"
+
+HOOK_DEFINE_INLINE(Demo_Hakase_PreloadAssetBundles) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto profMon = GetProfessorMon();
+        ctx->W[0] = profMon.monsno;
+        ctx->W[1] = profMon.formno;
+        ctx->W[2] = profMon.sex;
+        ctx->W[3] = profMon.shiny;
+    }
+};
+
+HOOK_DEFINE_INLINE(Demo_Hakase_ReleasePreloadedAssetBundles) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto profMon = GetProfessorMon();
+        ctx->W[0] = profMon.monsno;
+        ctx->W[1] = profMon.formno;
+        ctx->W[2] = profMon.sex;
+        ctx->W[3] = profMon.shiny;
+    }
+};
+
+HOOK_DEFINE_INLINE(Demo_Hakase_Enter_d__15_MoveNext) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto disp = (Dpr::Demo::DemoBase::LoadPokeAsset_d__71::Object*)ctx->X[22];
+        auto profMon = GetProfessorMon();
+
+        disp->fields.monsNo = profMon.monsno;
+        disp->fields.formNo = profMon.formno;
+        disp->fields.sex = profMon.sex;
+        disp->fields.isRare = profMon.shiny;
+    }
+};
+
+HOOK_DEFINE_INLINE(Demo_Hakase_Main_b__16_7) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto profMon = GetProfessorMon();
+        ctx->W[0] = profMon.monsno;
+        ctx->W[1] = profMon.formno;
+    }
+};
+
+void exl_intro_professor_pokemon_main() {
+    Demo_Hakase_PreloadAssetBundles::InstallAtOffset(0x01ad2138);
+    Demo_Hakase_ReleasePreloadedAssetBundles::InstallAtOffset(0x01ad2350);
+    Demo_Hakase_Enter_d__15_MoveNext::InstallAtOffset(0x01ad4108);
+    Demo_Hakase_Main_b__16_7::InstallAtOffset(0x01ad3308);
+}

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -114,6 +114,8 @@ void CallFeatureHooks()
         exl_language_ui_fixes_main();
     if (IsActivatedFeature(array_index(FEATURES, "Move Tutor Relearner")))
         exl_move_tutor_relearner_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Player Select")))
+        exl_player_select_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -116,6 +116,8 @@ void CallFeatureHooks()
         exl_move_tutor_relearner_main();
     if (IsActivatedFeature(array_index(FEATURES, "Player Select")))
         exl_player_select_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Intro Professor Pokémon")))
+        exl_intro_professor_pokemon_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/romdata/data/IntroData.h
+++ b/src/mod/romdata/data/IntroData.h
@@ -6,23 +6,49 @@
 
 namespace RomData
 {
+    struct ProfessorMon
+    {
+        int32_t monsno;
+        uint16_t formno;
+        uint8_t sex;
+        bool shiny;
+    };
+
     struct IntroData
     {
         nn::vector<int32_t> languages;
-        nn::vector<int32_t> colorVariations;
+        ProfessorMon professorMon;
     };
+
+    JSON_TEMPLATE
+    void to_json(GENERIC_JSON& j, const ProfessorMon& m) {
+        j = nn::json {
+            {"monsno", m.monsno},
+            {"formno", m.formno},
+            {"sex", m.sex},
+            {"shiny", m.shiny},
+        };
+    }
+
+    JSON_TEMPLATE
+    void from_json(const GENERIC_JSON& j, ProfessorMon& m) {
+        j.at("monsno").get_to(m.monsno);
+        j.at("formno").get_to(m.formno);
+        j.at("sex").get_to(m.sex);
+        j.at("shiny").get_to(m.shiny);
+    }
 
     JSON_TEMPLATE
     void to_json(GENERIC_JSON& j, const IntroData& i) {
         j = nn::json {
             {"languages", i.languages},
-            {"colorVariations", i.colorVariations},
+            {"professorMon", i.professorMon},
         };
     }
 
     JSON_TEMPLATE
     void from_json(const GENERIC_JSON& j, IntroData& i) {
         j.at("languages").get_to(i.languages);
-        j.at("colorVariations").get_to(i.colorVariations);
+        j.at("professorMon").get_to(i.professorMon);
     }
 }

--- a/src/mod/romdata/intro_data.cpp
+++ b/src/mod/romdata/intro_data.cpp
@@ -1,5 +1,8 @@
 #include "exlaunch.hpp"
 
+#include "data/species.h"
+#include "data/utils.h"
+
 #include "helpers.h"
 #include "memory/json.h"
 #include "memory/string.h"
@@ -44,7 +47,7 @@ bool IsLanguageActivated(int32_t langID)
     return false;
 }
 
-nn::vector<int32_t> GetIntroColorVariationPresets()
+RomData::ProfessorMon GetProfessorMon()
 {
     nn::string filePath(introFolderPath);
     filePath.append("intro.json");
@@ -55,13 +58,18 @@ nn::vector<int32_t> GetIntroColorVariationPresets()
         RomData::IntroData introData = {};
         introData = j.get<RomData::IntroData>();
 
-        return introData.colorVariations;
+        return introData.professorMon;
     }
     else
     {
         Logger::log("Error when parsing Intro data!\n");
     }
 
-    // Default - Vanilla variations
-    return { 0, 1, 2, 3 };
+    // Default - Vanilla Munchlax
+    return {
+        .monsno = array_index(SPECIES, "Munchlax"),
+        .formno = 0,
+        .sex = 0,
+        .shiny = false,
+    };
 }

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -54,8 +54,8 @@ nn::vector<int32_t> GetActivatedLanguages();
 // Checks if a given language is available on the language select screen.
 bool IsLanguageActivated(int32_t langID);
 
-// Returns the available Color Variation presets in the intro.
-nn::vector<int32_t> GetIntroColorVariationPresets();
+// Returns the data about the professor's Pokémon in the intro.
+RomData::ProfessorMon GetProfessorMon();
 
 // Returns the extra arena data.
 RomData::Arena GetExtraArenaData(int32_t arena);

--- a/src/mod/save/migration/migration.cpp
+++ b/src/mod/save/migration/migration.cpp
@@ -7,6 +7,7 @@
 
 void migrate(PlayerWork::Object* playerWork)
 {
+    bool firstSave = false;
     bool changed = false;
     while (getCustomSaveData()->main.version < CURRENT_VERSION) {
         Logger::log("Custom save data version mismatch! Expected %d, got %d; performing migration.\n", CURRENT_VERSION, getCustomSaveData()->main.version);
@@ -16,6 +17,7 @@ void migrate(PlayerWork::Object* playerWork)
                 migrateToReLease(playerWork);
 
                 getCustomSaveData()->main.version = ModVersion::Re_Lease;
+                firstSave = true;
                 break;
             }
 
@@ -43,7 +45,7 @@ void migrate(PlayerWork::Object* playerWork)
         changed = true;
     }
 
-    if (changed) {
+    if (changed && !firstSave) {
         nn::err::ApplicationErrorArg err(0, "A mod update has been detected. Press Details to view the changelog.", CHANGELOG, nn::settings::LanguageCode::Make(nn::settings::Language::Language_English));
         nn::err::ShowApplicationError(err);
     }

--- a/src/mod/utils/grid_selection.cpp
+++ b/src/mod/utils/grid_selection.cpp
@@ -1,0 +1,60 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/UnityEngine/Mathf.h"
+
+int32_t HorizontalRepeat(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount)
+{
+    if (vSelection == vCount - 1)
+    {
+        // Last Row
+        return Dpr::UI::UIManager::Repeat(hSelection, 0, lasthCount - 1);
+    }
+    else
+    {
+        // Any other row
+        return Dpr::UI::UIManager::Repeat(hSelection, 0, hCount - 1);
+    }
+}
+
+int32_t HorizontalClamp(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount)
+{
+    if (vSelection == vCount - 1)
+    {
+        // Last Row
+        return UnityEngine::Mathf::Clamp(hSelection, 0, lasthCount - 1);
+    }
+    else
+    {
+        // Any other row
+        return UnityEngine::Mathf::Clamp(hSelection, 0, hCount - 1);
+    }
+}
+
+int32_t VerticalRepeat(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount)
+{
+    if (hSelection + 1 > lasthCount)
+    {
+        // Column with a missing item on last row
+        return Dpr::UI::UIManager::Repeat(vSelection, 0, vCount - 2);
+    }
+    else
+    {
+        // Any other column
+        return Dpr::UI::UIManager::Repeat(vSelection, 0, vCount - 1);
+    }
+}
+
+int32_t VerticalClamp(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount)
+{
+    if (hSelection + 1 > lasthCount)
+    {
+        // Column with a missing item on last row
+        return UnityEngine::Mathf::Clamp(vSelection, 0, vCount - 2);
+    }
+    else
+    {
+        // Any other column
+        return UnityEngine::Mathf::Clamp(vSelection, 0, vCount - 1);
+    }
+}

--- a/src/mod/utils/utils.h
+++ b/src/mod/utils/utils.h
@@ -5,3 +5,16 @@
 // Returns the "default" catalog for a monsno + formno combo.
 // "Default" here is male (female if female-only, genderless if genderless), non-shiny, non-egg.
 XLSXContent::PokemonInfo::SheetCatalog::Object* GetDefaultCatalog(int32_t monsno, int32_t formno);
+
+
+// Moves the selection horizontally, and loops when hitting the edge of the grid.
+int32_t HorizontalRepeat(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount);
+
+// Moves the selection horizontally, and stops when hitting the edge of the grid.
+int32_t HorizontalClamp(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount);
+
+// Moves the selection vertically, and loops when hitting the edge of the grid.
+int32_t VerticalRepeat(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount);
+
+// Moves the selection vertically, and stops when hitting the edge of the grid.
+int32_t VerticalClamp(int32_t hSelection, int32_t hCount, int32_t vSelection, int32_t vCount, int32_t lasthCount);


### PR DESCRIPTION
- Adds support for reading the professor's Pokémon in the intro from JSON.
- Changes the model used for the professor in the intro to the one where he's wearing a coat.
- Rewrites the controls for the player variation selection in the intro to support a bigger grid.
  - Re-uses some of the code from the rewritten language selection screen, and so moves some of that code to utils.
- Removes the changelog popup when there is no save.