### PR TITLE
Command: _GET_HIGHEST_RADAR_STREAK

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1265,6 +1265,7 @@ namespace Dpr::EvScript {
             _GET_CAUGHT_LOCATION = 1255,
             _CHECK_TUTOR_MOVE = 1256,
             _MOVE_TUTOR_UI = 1257,
+            _GET_HIGHEST_RADAR_STREAK = 1258,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/PlayerWork.h
+++ b/src/mod/externals/PlayerWork.h
@@ -347,4 +347,8 @@ struct PlayerWork : ILClass<PlayerWork, 0x04c59b58> {
     static inline void set_zukan(DPData::ZUKAN_WORK::Object* value) {
         external<void>(0x02cf0fd0, value);
     }
+
+    static inline DPData::POKETCH_POKETORE_COUNT_ARRAY::Object get_poketoreCountArray() {
+        return external<DPData::POKETCH_POKETORE_COUNT_ARRAY::Object>(0x02ce9ef0);
+    }
 };

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -86,6 +86,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(CheckTutorMove(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI:
                     return HandleCmdStepper(MoveTutorUI(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GET_HIGHEST_RADAR_STREAK:
+                    return HandleCmdStepper(GetHighestRadarStreak(__this));
                 default:
                     break;
             }
@@ -130,4 +132,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_CAUGHT_LOCATION);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHECK_TUTOR_MOVE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_HIGHEST_RADAR_STREAK);
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -165,3 +165,8 @@ bool CheckTutorMove(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] trayIndex: The tray index in which to look for the given Pokémon.
 //   [Work, Number] table: The Move Tutor table to use.
 bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Retrieves the value of the highest PokeRadar streak and sets it into a work.
+// Arguments:
+//   [Work] result: The work in which to put the value of the highest radar streak.
+bool GetHighestRadarStreak(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/get_highest_radar_streak.cpp
+++ b/src/mod/features/commands/get_highest_radar_streak.cpp
@@ -1,0 +1,22 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/PlayerWork.h"
+#include "externals/FlagWork.h"
+#include "externals/FlagWork_Enums.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+
+bool GetHighestRadarStreak(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_GET_HIGHEST_RADAR_STREAK\n");
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    if (args->max_length >= 2) {
+        auto radarRanks = PlayerWork::get_poketoreCountArray();
+
+        // It will always be a length of 3, but accounting for manual json modification
+        auto streak = (radarRanks.fields.data->max_length >= 1) ? radarRanks.fields.data->m_Items[0].fields.count : 0;
+        FlagWork::SetWork(GetWorkOrIntValue(args->m_Items[1]), streak);
+    }
+
+    return true;
+}


### PR DESCRIPTION
Command: _GET_HIGHEST_RADAR_STREAK
-
- Implements _GET_HIGHEST_RADAR_STREAK which will find the player's highest poke radar streak and place the result in the provided work.
- Closes #154 