### PR TITLE
Platinum Veilstone Gym

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -55,6 +55,7 @@ static constexpr const char* FEATURES[] = {
     "Move Tutor Relearner",
     "Player Select",
     "Intro Professor Pokémon",
+    "Pushable Entities",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/BaseEntity.h
+++ b/src/mod/externals/BaseEntity.h
@@ -51,6 +51,11 @@ struct BaseEntity : ILClass<BaseEntity> {
         return external<UnityEngine::Transform::Object*>(0x01d66e50, this);
     }
 
+    inline void SetPositionDirect(UnityEngine::Vector3::Object pos) {
+        UnityEngine::Vector3::Fields posProxy = { .x = pos.fields.x, .y = pos.fields.y, .z = pos.fields.z };
+        external<void>(0x01d67740, this, posProxy);
+    }
+
     static_assert(sizeof(VTable) == 0xe0);
     static_assert(offsetof(VTable, _4_get_entityType) == 0x40);
     static_assert(offsetof(VTable, _5_GetAnimationPlayer) == 0x50);

--- a/src/mod/externals/DIR.h
+++ b/src/mod/externals/DIR.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+enum class DIR : int32_t {
+    DIR_NOT = -1,
+    DIR_UP = 0,
+    DIR_DOWN = 1,
+    DIR_LEFT = 2,
+    DIR_RIGHT = 3,
+    DIR_LEFTUP = 4,
+    DIR_RIGHTUP = 5,
+    DIR_LEFTDOWN = 6,
+    DIR_RIGHTDOWN = 7,
+};

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1266,6 +1266,7 @@ namespace Dpr::EvScript {
             _CHECK_TUTOR_MOVE = 1256,
             _MOVE_TUTOR_UI = 1257,
             _GET_HIGHEST_RADAR_STREAK = 1258,
+            _GET_TILE_ATTRIBUTE = 1259,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1269,6 +1269,7 @@ namespace Dpr::EvScript {
             _GET_TILE_ATTRIBUTE = 1259,
             _EVENT_ENTITY_CLIP_PLAY_BY_INDEX = 1260,
             _EVENT_ENTITY_CLIP_WAIT_BY_INDEX = 1261,
+            _ENTITY_MOVE = 1262,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1267,6 +1267,8 @@ namespace Dpr::EvScript {
             _MOVE_TUTOR_UI = 1257,
             _GET_HIGHEST_RADAR_STREAK = 1258,
             _GET_TILE_ATTRIBUTE = 1259,
+            _EVENT_ENTITY_CLIP_PLAY_BY_INDEX = 1260,
+            _EVENT_ENTITY_CLIP_WAIT_BY_INDEX = 1261,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -19,6 +19,8 @@
 #include "externals/UnityEngine/Vector2Int.h"
 #include "externals/UnityEngine/Vector3.h"
 
+struct FieldObjectEntity;
+
 namespace System::Collections::Generic {
     struct List$$FieldObjectEntity;
 }
@@ -451,6 +453,10 @@ namespace Dpr::EvScript {
 
         inline bool CallWazaUICommon(int32_t bootType, Pml::PokePara::PokemonParam::Object* pokemonParam, System::Action::Object* resultCallback, int32_t oshieWazaNo) {
             return external<bool>(0x02c92530, this, bootType, pokemonParam, resultCallback, oshieWazaNo);
+        }
+
+        inline FieldObjectEntity* GetFieldObject(int32_t id) {
+            return external<FieldObjectEntity*>(0x02c491c0, this, id);
         }
 
         static inline Dpr::EvScript::EvDataManager::Object* get_Instanse() {

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -19,6 +19,10 @@
 #include "externals/UnityEngine/Vector2Int.h"
 #include "externals/UnityEngine/Vector3.h"
 
+namespace System::Collections::Generic {
+    struct List$$FieldObjectEntity;
+}
+
 namespace Dpr::EvScript {
     struct EvDataManager : ILClass<EvDataManager, 0x04c59c50> {
         struct WorpEventData : ILStruct<WorpEventData> {
@@ -337,7 +341,7 @@ namespace Dpr::EvScript {
             bool isSpBtlAruseus;
             void * Debug_01_DebugLabel;
             void * DebugSceneEventLabel;
-            void * _fieldObjectEntity;
+            System::Collections::Generic::List$$FieldObjectEntity* _fieldObjectEntity;
             void * _FieldKinomiGrowEntity;
             void * _AssetReqOpeList;
             void * _loadObjectList;

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -459,6 +459,10 @@ namespace Dpr::EvScript {
             return external<FieldObjectEntity*>(0x02c491c0, this, id);
         }
 
+        inline FieldObjectEntity* Find_fieldObjectEntity(System::String::Object* id) {
+            return external<FieldObjectEntity*>(0x02c48c00, this, id);
+        }
+
         static inline Dpr::EvScript::EvDataManager::Object* get_Instanse() {
             return external<Dpr::EvScript::EvDataManager::Object*>(0x02c3d4d0);
         }

--- a/src/mod/externals/Dpr/Field/WA_Kairiki.h
+++ b/src/mod/externals/Dpr/Field/WA_Kairiki.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/FieldPlayerEntity.h"
+#include "externals/UnityEngine/Vector2Int.h"
+
+namespace Dpr::Field {
+    struct WA_Kairiki : ILClass<WA_Kairiki> {
+        struct Fields {
+            bool isVoiceEnd;
+            int32_t seqNo;
+        };
+
+        static inline bool PushEntity(FieldPlayerEntity::Object* player, DIR dir, FieldObjectEntity::Object* target, UnityEngine::Vector2Int::Object* outgrid, bool* hit) {
+            return external<bool>(0x019bd590, player, dir, target, outgrid, hit);
+        }
+    };
+}

--- a/src/mod/externals/FieldEventEntity.h
+++ b/src/mod/externals/FieldEventEntity.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/FieldObjectEntity.h"
+
+struct FieldEventEntity : ILClass<FieldEventEntity> {
+    struct Fields : FieldObjectEntity::Fields {
+        // TODO
+    };
+
+    inline void Play(int32_t index) {
+        return external<void>(0x01793d70, this, index);
+    }
+
+    inline bool get_isCompleted() {
+        return external<bool>(0x01793be0, this);
+    }
+};

--- a/src/mod/externals/FieldManager.h
+++ b/src/mod/externals/FieldManager.h
@@ -2,18 +2,81 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Effect/EffectInstance.h"
+#include "externals/System/Action.h"
+#include "externals/UnityEngine/GameObject.h"
+#include "externals/UnityEngine/Material.h"
+#include "externals/UnityEngine/Transform.h"
+#include "externals/UnityEngine/Vector3.h"
+
 struct FieldManager : ILClass<FieldManager, 0x04c5a638> {
     struct Fields {
-        // TODO
+        System::Action::Object* OnZoneChangeEvent;
+        System::Action::Object* OnZoneChangeOnce;
+        System::Action::Object* OnSceneInitEvent;
+        int32_t _updateType;
+        int32_t _encountUpdateType;
+        float _encountWait;
+        int32_t _encountFadeType;
+        void* _attributeEntitySE; // System_Collections_Generic_Queue_FieldManager_AttributeEvent__o*
+        void* _attributeEntityEffect; // System_Collections_Generic_Queue_FieldManager_AttributeEvent__o*
+        int32_t NowMapType;
+        int32_t OldMapType;
+        int32_t _now_zoneID;
+        int32_t _Before_zoneID_k__BackingField;
+        void* _effectDataArray; // FieldManager_LoadEffectData_array*
+        Effect::EffectInstance::Object* _weatherEffectInstance;
+        int32_t _nowWeather;
+        void* _weather; // FieldWeather_o*
+        void* MistWork; // FieldMistWork_o*
+        void* FlashWork; // FieldFlashWork_o*
+        int32_t _btl_trainerID1;
+        int32_t _btl_trainerID2;
+        UnityEngine::GameObject::Object* _ug_hole;
+        bool _is_ugHoleLock;
+        UnityEngine::Vector3::Object _ugHolePos;
+        void* _ugMainProc; // UgMainProc_o*
+        UnityEngine::GameObject::Object* _fldCanvasObject;
+        void* _fldCanvasAssetReqOpe; // SmartPoint_AssetAssistant_AssetRequestOperation_o*
+        int32_t _oldEncountWalkCount;
+        void* _encFadeTextures; // EncountFadeTextures_o*
+        UnityEngine::Material::Object* _encFadeMaterial;
+        void* _encFadeTexturesReqOpe; // SmartPoint_AssetAssistant_AssetRequestOperation_o*
+        void* _encResult; // Dpr_Field_EncountResult_o*
+        void* _encEffctController; // EncEffectSequenceController_o*
+        int32_t _encEffectCount;
+        UnityEngine::GameObject::Array* _encEffectAsset;
+        bool _encountAttriLog;
+        void* _fishing; // Dpr_Field_FieldFishing_o*
+        int32_t _useRod;
+        void* _wazaAction; // FieldManager_FieldWazaAction_o*
+        bool _IsMenuOpen_k__BackingField;
+        bool _isMenuOpenRequest;
+        float _shortCutPushTime;
+        int32_t _shortCutPushHoldId;
+        bool _IsPoketchOpen_k__BackingField;
+        bool SND_W_ID_CTRL_BGM_FLAG;
+        void* _KinomiResources_k__BackingField; // KinomiResources_o*
+        int32_t _demoReturnType;
+        bool _demoReturnInput;
+        uint32_t _WalkEventName_Attribute;
+        bool _initFlag;
+        int32_t _autoSaveState;
+        UnityEngine::Vector3::Object eventTownMapPos;
+        void* unnnoonFormList; // System_Collections_Generic_List_int__o*
+        int32_t _shorCutSeq;
+        UnityEngine::Transform::Object* _akLisnerTransform;
     };
 
     struct StaticFields {
-        FieldManager* _Instance_k__BackingField;
+        FieldManager::Object* _Instance_k__BackingField;
         void* fwMng; // Dpr_Field_Walking_FieldWalkingManager_o*
         void* abUnloader; // Dpr_SubContents_Utils_AssetUnloader_o*
         bool _IsResume_k__BackingField;
         bool SealPrevFlag;
     };
+
+    static_assert(offsetof(Fields, _akLisnerTransform) == 0x158);
 
     inline uint16_t GetFormNo(int32_t mons, int32_t karana, int32_t anno) {
         return external<uint16_t>(0x0179f560, this, mons, karana, anno);

--- a/src/mod/externals/FieldManager.h
+++ b/src/mod/externals/FieldManager.h
@@ -85,4 +85,8 @@ struct FieldManager : ILClass<FieldManager, 0x04c5a638> {
     inline void EventWildBattle(int32_t mons, int32_t level, bool isCaptureDemo, bool isSymbol, bool isMitu, uint8_t talentVNum, bool isCantUseBall, int32_t formNo, bool tokusei3rd) {
         external<void>(0x0179f720, this, mons, level, isCaptureDemo, isSymbol, isMitu, talentVNum, isCantUseBall, formNo, tokusei3rd);
     }
+
+    inline int32_t get_areaID() {
+        return external<int32_t>(0x01797f90, this);
+    }
 };

--- a/src/mod/externals/FieldObjectEntity.h
+++ b/src/mod/externals/FieldObjectEntity.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/BaseEntity.h"
+#include "externals/DIR.h"
 #include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/UnityEngine/Vector2Int.h"
 #include "externals/UnityEngine/Vector3.h"
@@ -30,4 +31,18 @@ struct FieldObjectEntity : ILClass<FieldObjectEntity> {
     inline UnityEngine::Vector2Int::Object get_gridPosition() {
         return external<UnityEngine::Vector2Int::Object>(0x01d50aa0, this);
     }
+
+    inline float get_Height() {
+        return external<float>(0x01d549e0, this);
+    }
+
+    static inline DIR GetDir(float dir) {
+        return external<DIR>(0x01d55140, dir);
+    }
 };
+
+namespace System::Collections::Generic {
+    struct List$$FieldObjectEntity : List<List$$FieldObjectEntity, FieldObjectEntity> {
+
+    };
+}

--- a/src/mod/externals/FieldPlayerEntity.h
+++ b/src/mod/externals/FieldPlayerEntity.h
@@ -113,8 +113,12 @@ struct FieldPlayerEntity : ILClass<FieldPlayerEntity> {
         bool isSwampLoopEffect;
     };
 
-    inline void set_colorID(int32_t value) {
+    static inline void set_colorID(int32_t value) {
         external<void>(0x02cef870, value);
+    }
+
+    inline void GetInputVector(UnityEngine::Vector2::Object* stickL, float* stickPowerSq, float deltatime, bool* analogstick) {
+        external<void>(0x01dabb10, this, stickL, stickPowerSq, deltatime, analogstick);
     }
 
     static_assert(offsetof(Fields, _hatRenderers) == 0x198);

--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -3246,6 +3246,7 @@ enum class FlagWork_Work : int32_t {
     WK_PUNCHINGBAG_OBJ_ID = 502,
     WK_PUNCHINGBAG_OBJ_DIR = 503,
     WK_PUNCHINGBAG_OBJ_TILES = 504,
+    WK_PUNCHINGBAG_HIT_OBJ_ID = 505,
 
     // Debug works, can be replaced at any time
     WORK_4000 = 4000,

--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -3238,11 +3238,14 @@ enum class FlagWork_Work : int32_t {
     WK_TV_STR_DATA041_USE_GENDER = 435,
     WK_DAILY_RANDOM = 436,
     SCWK_WK_END = 437,
+    SCWK_WK_SAVE_SIZE = 500,
 
     // Luminescent Works
     WK_LAST_BATTLE_TURN_COUNTER = 449,
     WK_INCENSE_SLOT = 495,
-    SCWK_WK_SAVE_SIZE = 500,
+    WK_PUNCHINGBAG_OBJ_ID = 502,
+    WK_PUNCHINGBAG_OBJ_DIR = 503,
+    WK_PUNCHINGBAG_OBJ_TILES = 504,
 
     // Debug works, can be replaced at any time
     WORK_4000 = 4000,

--- a/src/mod/externals/GameData/DataManager.h
+++ b/src/mod/externals/GameData/DataManager.h
@@ -60,5 +60,9 @@ namespace GameData {
         static inline XLSXContent::PokemonInfo::SheetCatalog::Object* GetPokemonCatalog(int32_t monsNo, int32_t formNo, Pml::Sex sex, bool isRare, bool isEgg) {
             return external<XLSXContent::PokemonInfo::SheetCatalog::Object*>(0x02cc76a0, monsNo, formNo, sex, isRare, isEgg);
         }
+
+        static inline float GetFieldCommonParam(int32_t paramIndex) {
+            return external<float>(0x02cc4780, paramIndex);
+        }
     };
 }

--- a/src/mod/externals/UnityEngine/Camera.h
+++ b/src/mod/externals/UnityEngine/Camera.h
@@ -7,5 +7,9 @@
 namespace UnityEngine {
     struct Camera : ILClass<Camera> {
         struct Fields : UnityEngine::Behaviour::Fields {};
+
+        inline float get_fieldOfView() {
+            return external<float>(0x026a4920, this);
+        }
     };
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -90,6 +90,10 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(GetHighestRadarStreak(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_GET_TILE_ATTRIBUTE:
                     return HandleCmdStepper(GetTileAttribute(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_PLAY_BY_INDEX:
+                    return HandleCmdStepper(EventEntityClipPlayByIndex(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_WAIT_BY_INDEX:
+                    return HandleCmdStepper(EventEntityClipWaitByIndex(__this));
                 default:
                     break;
             }
@@ -136,4 +140,6 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_HIGHEST_RADAR_STREAK);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_TILE_ATTRIBUTE);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_PLAY_BY_INDEX);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_WAIT_BY_INDEX);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -94,6 +94,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(EventEntityClipPlayByIndex(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_WAIT_BY_INDEX:
                     return HandleCmdStepper(EventEntityClipWaitByIndex(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_ENTITY_MOVE:
+                    return HandleCmdStepper(EntityMove(__this));
                 default:
                     break;
             }
@@ -142,4 +144,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_TILE_ATTRIBUTE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_PLAY_BY_INDEX);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_EVENT_ENTITY_CLIP_WAIT_BY_INDEX);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ENTITY_MOVE);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -88,6 +88,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(MoveTutorUI(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_GET_HIGHEST_RADAR_STREAK:
                     return HandleCmdStepper(GetHighestRadarStreak(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GET_TILE_ATTRIBUTE:
+                    return HandleCmdStepper(GetTileAttribute(__this));
                 default:
                     break;
             }
@@ -133,4 +135,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHECK_TUTOR_MOVE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_MOVE_TUTOR_UI);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_HIGHEST_RADAR_STREAK);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_TILE_ATTRIBUTE);
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -170,3 +170,11 @@ bool MoveTutorUI(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [Work] result: The work in which to put the value of the highest radar streak.
 bool GetHighestRadarStreak(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gets the attribute data of a specified tile.
+// Arguments:
+//   [Work, Number] x: The x position of the tile to check.
+//   [Work, Number] z: The z position of the tile to check.
+//   [Work] code: The work in which to put the tile's code attribute.
+//   [Work] stop: The work in which to put the tile's stop attribute.
+bool GetTileAttribute(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -178,3 +178,14 @@ bool GetHighestRadarStreak(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work] code: The work in which to put the tile's code attribute.
 //   [Work] stop: The work in which to put the tile's stop attribute.
 bool GetTileAttribute(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Plays an animation clip on a FieldEventEntity at the specified index.
+// Arguments:
+//   [Work, Number] entity: The index of the entity to play a clip on.
+//   [Work, Number] clip: The index of the clip to play.
+bool EventEntityClipPlayByIndex(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Waits for an animation clip on a FieldEventEntity at the specified index to be finished.
+// Arguments:
+//   [Work, Number] entity: The index of the entity to wait for.
+bool EventEntityClipWaitByIndex(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -189,3 +189,12 @@ bool EventEntityClipPlayByIndex(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [Work, Number] entity: The index of the entity to wait for.
 bool EventEntityClipWaitByIndex(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Moves an entity by an amount of tiles over an amount of frames.
+// Arguments:
+//   [Work, Number, Label] entity: The ID or index of the entity to move.
+//   [Work, Number] x: Amount of tiles to move on the x axis.
+//   [Work, Number] y: Amount of tiles to move on the y axis.
+//   [Work, Number] z: Amount of tiles to move on the z axis.
+//   [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
+bool EntityMove(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/entity_move.cpp
+++ b/src/mod/features/commands/entity_move.cpp
@@ -1,0 +1,63 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldObjectEntity.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+
+static float origPosX = 0.0f;
+static float origPosY = 0.0f;
+static float origPosZ = 0.0f;
+
+bool EntityMove(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    //Logger::log("_ENTITY_MOVE\n");
+
+    system_load_typeinfo(0x438c);
+    system_load_typeinfo(0x45dc);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    auto id = GetStringText(manager, args->m_Items[1]);
+    FieldObjectEntity::Object* entity;
+    if (System::String::op_Equality(id, System::String::Create("")))
+        entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(GetWorkOrIntValue(args->m_Items[1]))->instance();
+    else
+        entity = Dpr::EvScript::EvDataManager::get_Instanse()->Find_fieldObjectEntity(id)->instance();
+
+    int32_t deltaX = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t deltaY = GetWorkOrIntValue(args->m_Items[3]);
+    int32_t deltaZ = GetWorkOrIntValue(args->m_Items[4]);
+    int32_t frames = GetWorkOrIntValue(args->m_Items[5]);
+
+    float totalTime = frames * 0.03333334;
+    float currDeltaX = deltaX * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaY = deltaY * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaZ = deltaZ * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+
+    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
+        auto origPos = entity->cast<BaseEntity>()->fields.worldPosition;
+        origPosX = origPos.fields.x;
+        origPosY = origPos.fields.y;
+        origPosZ = origPos.fields.z;
+    }
+
+    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
+        Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+
+        auto currPos = entity->cast<BaseEntity>()->fields.worldPosition;
+        currPos.fields.x += currDeltaX;
+        currPos.fields.y += currDeltaY;
+        currPos.fields.z += currDeltaZ;
+        entity->cast<BaseEntity>()->SetPositionDirect(currPos);
+
+        return false;
+    }
+    else {
+        auto currPos = entity->cast<BaseEntity>()->fields.worldPosition;
+        currPos.fields.x = origPosX + deltaX;
+        currPos.fields.y = origPosY + deltaY;
+        currPos.fields.z = origPosZ + deltaZ;
+        entity->cast<BaseEntity>()->SetPositionDirect(currPos);
+
+        return true;
+    }
+}

--- a/src/mod/features/commands/event_entity_clip_play_by_index.cpp
+++ b/src/mod/features/commands/event_entity_clip_play_by_index.cpp
@@ -1,0 +1,23 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldEventEntity.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+
+bool EventEntityClipPlayByIndex(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_EVENT_ENTITY_CLIP_PLAY_BY_INDEX\n");
+
+    system_load_typeinfo(0x4429);
+    system_load_typeinfo(0x45dc);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    int32_t index = GetWorkOrIntValue(args->m_Items[1]);
+    int32_t clip = GetWorkOrIntValue(args->m_Items[2]);
+
+    auto entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(index);
+    if (UnityEngine::_Object::op_Inequality(entity->cast<UnityEngine::_Object>(), nullptr))
+        ((FieldEventEntity::Object*)entity)->Play(clip);
+
+    return true;
+}

--- a/src/mod/features/commands/event_entity_clip_wait_by_index.cpp
+++ b/src/mod/features/commands/event_entity_clip_wait_by_index.cpp
@@ -6,7 +6,7 @@
 
 bool EventEntityClipWaitByIndex(Dpr::EvScript::EvDataManager::Object* manager)
 {
-    Logger::log("_EVENT_ENTITY_CLIP_WAIT_BY_INDEX\n");
+    //Logger::log("_EVENT_ENTITY_CLIP_WAIT_BY_INDEX\n");
 
     system_load_typeinfo(0x442a);
     system_load_typeinfo(0x45dc);

--- a/src/mod/features/commands/event_entity_clip_wait_by_index.cpp
+++ b/src/mod/features/commands/event_entity_clip_wait_by_index.cpp
@@ -1,0 +1,22 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldEventEntity.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+
+bool EventEntityClipWaitByIndex(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_EVENT_ENTITY_CLIP_WAIT_BY_INDEX\n");
+
+    system_load_typeinfo(0x442a);
+    system_load_typeinfo(0x45dc);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    int32_t index = GetWorkOrIntValue(args->m_Items[1]);
+
+    auto entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(index);
+    if (UnityEngine::_Object::op_Inequality(entity->cast<UnityEngine::_Object>(), nullptr))
+        return ((FieldEventEntity::Object*)entity)->get_isCompleted();
+    else
+        return true;
+}

--- a/src/mod/features/commands/get_tile_attribute.cpp
+++ b/src/mod/features/commands/get_tile_attribute.cpp
@@ -1,0 +1,25 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/GameManager.h"
+
+#include "features/commands/utils/utils.h"
+#include "logger/logger.h"
+
+bool GetTileAttribute(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_GET_TILE_ATTRIBUTE\n");
+
+    system_load_typeinfo(0x4881);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    int32_t x = GetWorkOrIntValue(args->m_Items[1]);
+    int32_t z = GetWorkOrIntValue(args->m_Items[2]);
+    UnityEngine::Vector2Int::Object grid = { .fields { .m_X = x, .m_Y = z } };
+
+    int32_t code = 0;
+    int32_t stop = 0;
+    GameManager::GetAttribute(grid, &code, &stop, false);
+    SetWorkToValue(args->m_Items[3], (int32_t)code);
+    SetWorkToValue(args->m_Items[4], (int32_t)stop);
+
+    return true;
+}

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -132,8 +132,11 @@ void exl_poke_radar_fixes_main();
 // Requires an edited PoketchWindow prefab with a second Pokétch button.
 void exl_poketch_main();
 
-// Replaces pickup ranges with new ranges abiding by Lumi level caps
+// Replaces pickup ranges with new ranges abiding by Lumi level caps.
 void exl_pickup_main();
+
+// Allows making pushable entities (placedata) which stop at a specific attribute.
+void exl_pushable_entities_main();
 
 // Tweaks the move relearner menu to include owned TMs.
 void exl_relearn_tms_main();

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -118,6 +118,8 @@ void CallFeatureHooks()
         exl_player_select_main();
     if (IsActivatedFeature(array_index(FEATURES, "Intro Professor Pokémon")))
         exl_intro_professor_pokemon_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Pushable Entities")))
+        exl_pushable_entities_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -12,21 +12,21 @@
 
 const static int32_t MATTR_RAIL = 237;
 const static int32_t MATTR_RAIL_STOP = 238;
-const static int32_t PUNCHINGBAG_OGI = 70;
-const static int32_t TIRES_OGI = 71;
+const static int32_t PUNCHINGBAG_OGI = 570;
+const static int32_t TIRES_OGI = 571;
 const static int32_t ParamIndx_Kairiki_PushTime = 259;
+
+static int32_t punchingBagObjIndex = -1;
+static float punchingBagPushTime;
 
 void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
     system_load_typeinfo(0x4a4e);
     system_load_typeinfo(0x4989);
 
-    if (__this->fields.KairikiPushObjectIndex != -1)
-        return;
-
-    auto oldPushTime = __this->fields.KairikiPushTime;
-    auto oldPushObj = __this->fields.KairikiPushObjectIndex;
-    __this->fields.KairikiPushObjectIndex = -1;
-    __this->fields.KairikiPushTime = 0.0f;
+    auto oldPushTime = punchingBagPushTime;
+    auto oldPushObj = punchingBagObjIndex;
+    punchingBagObjIndex = -1;
+    punchingBagPushTime = 0.0f;
 
     Dpr::EvScript::EvDataManager::getClass()->initIfNeeded();
     if (Dpr::EvScript::EvDataManager::get_Instanse()->IsRunningEvent())
@@ -80,12 +80,14 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
 
                 // TODO: Add rail attribute check here
                 if (stop != 128) {
-                    __this->fields.KairikiPushObjectIndex = i;
-                    __this->fields.KairikiPushTime = oldPushTime + deltaTime;
+                    punchingBagObjIndex = i;
+                    punchingBagPushTime = oldPushTime + deltaTime;
+
+                    Logger::log("Pushing, not stop att with old = %d, i = %d!\n", oldPushObj, i);
 
                     if (oldPushObj == i) {
                         GameData::DataManager::getClass()->initIfNeeded();
-                        if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= __this->fields.KairikiPushTime) {
+                        if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= punchingBagPushTime) {
                             Logger::log("Pushing new punching bag!\n");
 
                             __this->fields._isCrossUpdate = false;
@@ -102,7 +104,7 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                         }
                     }
                     else {
-                        __this->fields.KairikiPushTime = 0.0f;
+                        punchingBagPushTime = 0.0f;
                     }
                 }
             }

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -232,17 +232,6 @@ HOOK_DEFINE_TRAMPOLINE(FieldPlayerEntity$$KairikiPushObject) {
     }
 };
 
-HOOK_DEFINE_INLINE(EvDataManager$$LoadObjectCreate_Asset_SetOGI) {
-    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
-        auto entity = (FieldObjectEntity::Object*)ctx->X[22];
-        auto ogi = (int32_t)ctx->W[19];
-
-        entity->fields.EventParams->fields.CharacterGraphicsIndex = ogi;
-        ctx->X[3] = 0;
-    }
-};
-
 void exl_pushable_entities_main() {
     FieldPlayerEntity$$KairikiPushObject::InstallAtOffset(0x01da6500);
-    EvDataManager$$LoadObjectCreate_Asset_SetOGI::InstallAtOffset(0x02ca4160);
 }

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -1,0 +1,151 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/Dpr/Field/WA_Kairiki.h"
+#include "externals/FieldManager.h"
+#include "externals/FieldPlayerEntity.h"
+#include "externals/FlagWork.h"
+#include "externals/GameController.h"
+#include "externals/GameData/DataManager.h"
+#include "externals/GameManager.h"
+#include "externals/PlayerWork.h"
+
+const static int32_t MATTR_RAIL = 237;
+const static int32_t MATTR_RAIL_STOP = 238;
+const static int32_t PUNCHINGBAG_OGI = 70;
+const static int32_t TIRES_OGI = 71;
+const static int32_t ParamIndx_Kairiki_PushTime = 259;
+
+void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
+    system_load_typeinfo(0x4a4e);
+    system_load_typeinfo(0x4989);
+
+    if (__this->fields.KairikiPushObjectIndex != -1)
+        return;
+
+    auto oldPushTime = __this->fields.KairikiPushTime;
+    auto oldPushObj = __this->fields.KairikiPushObjectIndex;
+    __this->fields.KairikiPushObjectIndex = -1;
+    __this->fields.KairikiPushTime = 0.0f;
+
+    Dpr::EvScript::EvDataManager::getClass()->initIfNeeded();
+    if (Dpr::EvScript::EvDataManager::get_Instanse()->IsRunningEvent())
+        return;
+
+    FieldManager::getClass()->initIfNeeded();
+    if (FieldManager::getClass()->static_fields->_Instance_k__BackingField->fields._IsMenuOpen_k__BackingField ||
+        FieldManager::getClass()->static_fields->_Instance_k__BackingField->fields._isMenuOpenRequest)
+        return;
+
+    PlayerWork::getClass()->initIfNeeded();
+    if (!PlayerWork::get_isPlayerInputActive())
+        return;
+
+    __this->fields.UpdateInputAngleDisable = true;
+
+    UnityEngine::Vector2::Object stick {};
+    float stickPower = 0.0f;
+    bool analog = false;
+    __this->GetInputVector(&stick, &stickPower, 0.0f, &analog);
+
+    __this->fields.UpdateInputAngleDisable = false;
+
+    if (stickPower <= 0.0f)
+        return;
+
+    GameController::getClass()->initIfNeeded();
+    if (!analog &&
+        __this->fields.InputMoveVector.fields.x * GameController::getClass()->static_fields->digitalPad.fields.x >= 0.0f &&
+        __this->fields.InputMoveVector.fields.z * GameController::getClass()->static_fields->digitalPad.fields.y >= 0.0f)
+        return;
+
+    auto dir = FieldObjectEntity::GetDir(__this->fields.yawAngle);
+
+    for (int32_t i=0; i<Dpr::EvScript::EvDataManager::get_Instanse()->fields._fieldObjectEntity->instance()->fields._size; i++) {
+        auto entity = Dpr::EvScript::EvDataManager::get_Instanse()->fields._fieldObjectEntity->instance()->fields._items->m_Items[i];
+
+        UnityEngine::_Object::getClass()->initIfNeeded();
+        if (!UnityEngine::_Object::op_Equality(entity->cast<UnityEngine::_Object>(), nullptr) &&
+            entity->fields.EventParams->fields.CharacterGraphicsIndex == PUNCHINGBAG_OGI)
+        {
+            UnityEngine::Vector2Int::Object outgrid {};
+            bool hit = false;
+            bool pushed = Dpr::Field::WA_Kairiki::PushEntity(__this, dir, entity, &outgrid, &hit);
+
+            if (pushed) {
+                int32_t code = 0;
+                int32_t stop = 0;
+                GameManager::getClass()->initIfNeeded();
+                GameManager::GetAttribute(outgrid, &code, &stop, false);
+
+                // TODO: Add rail attribute check here
+                if (stop != 128) {
+                    __this->fields.KairikiPushObjectIndex = i;
+                    __this->fields.KairikiPushTime = oldPushTime + deltaTime;
+
+                    if (oldPushObj == i) {
+                        GameData::DataManager::getClass()->initIfNeeded();
+                        if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= __this->fields.KairikiPushTime) {
+                            Logger::log("Pushing new punching bag!\n");
+
+                            __this->fields._isCrossUpdate = false;
+                            __this->fields._crossInputDir = -1;
+                            __this->fields._crossInputVectol = { .fields = { .x = 0.0f, .y = 0.0f } };
+                            __this->fields._bicOldAcceleration = 0.0f;
+                            __this->fields._bicAccelerationTime = 0.0f;
+
+                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_ID, i);
+                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_DIR, (int32_t)dir);
+                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_TILES, 3); // TODO: Add amount of tiles here
+
+                            Dpr::EvScript::EvDataManager::get_Instanse()->JumpLabel(System::String::Create("ev_punchingbag_move"), nullptr);
+                        }
+                    }
+                    else {
+                        __this->fields.KairikiPushTime = 0.0f;
+                    }
+                }
+            }
+            else {
+                if (hit) {
+                    switch (dir) {
+                        case DIR::DIR_UP:
+                        case DIR::DIR_DOWN:
+                            __this->fields.moveVector.fields.z = 0.0f;
+                            break;
+
+                        case DIR::DIR_LEFT:
+                        case DIR::DIR_RIGHT:
+                            __this->fields.moveVector.fields.x = 0.0f;
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+HOOK_DEFINE_TRAMPOLINE(FieldPlayerEntity$$KairikiPushObject) {
+    static void Callback(FieldPlayerEntity::Object* __this, float deltaTime) {
+        Orig(__this, deltaTime);
+        PunchingBagPushObject(__this, deltaTime);
+    }
+};
+
+HOOK_DEFINE_INLINE(EvDataManager$$LoadObjectCreate_Asset_SetOGI) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto entity = (FieldObjectEntity::Object*)ctx->X[22];
+        auto ogi = (int32_t)ctx->W[19];
+
+        entity->fields.EventParams->fields.CharacterGraphicsIndex = ogi;
+        ctx->X[3] = 0;
+    }
+};
+
+void exl_pushable_entities_main() {
+    FieldPlayerEntity$$KairikiPushObject::InstallAtOffset(0x01da6500);
+    EvDataManager$$LoadObjectCreate_Asset_SetOGI::InstallAtOffset(0x02ca4160);
+}

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -116,7 +116,7 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                                 break;
                         }
                         tiles *= -1;
-                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles - 1, } };
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles, } };
                     }
                     break;
 
@@ -128,7 +128,7 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                             if (!PunchingBagAttributeCheck(nextTile, &tiles))
                                 break;
                         }
-                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles + 1, } };
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles, } };
                     }
                     break;
 
@@ -140,7 +140,7 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                             if (!PunchingBagAttributeCheck(nextTile, &tiles))
                                 break;
                         }
-                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X + tiles + 1, .m_Y = outgrid.fields.m_Y, } };
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X - tiles, .m_Y = outgrid.fields.m_Y, } };
                     }
                     break;
 
@@ -153,7 +153,7 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                                 break;
                         }
                         tiles *= -1;
-                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X + tiles - 1, .m_Y = outgrid.fields.m_Y, } };
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X - tiles, .m_Y = outgrid.fields.m_Y, } };
                     }
                     break;
 
@@ -173,18 +173,17 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
                     auto brokenEntity = Dpr::EvScript::EvDataManager::get_Instanse()->fields._fieldObjectEntity->instance()->fields._items->m_Items[j];
                     if (!UnityEngine::_Object::op_Equality(brokenEntity->cast<UnityEngine::_Object>(), nullptr) &&
                         brokenEntity->fields.EventParams->fields.CharacterGraphicsIndex == TIRES_OGI &&
+                        brokenEntity->cast<UnityEngine::Component>()->get_gameObject()->get_activeSelf() &&
                         UnityEngine::Vector2Int::op_Equality(brokenEntity->get_gridPosition(), breakableGrid))
                     {
                         tires = j;
                     }
                 }
 
-                Logger::log("Pushing, proper atts with old = %d, i = %d!\n", oldPushObj, i);
-
                 if (oldPushObj == i) {
                     GameData::DataManager::getClass()->initIfNeeded();
                     if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= punchingBagPushTime) {
-                        Logger::log("Pushing new punching bag!\n");
+                        Logger::log("Pushing punching bag with obj index %d!\n", i);
 
                         __this->fields._isCrossUpdate = false;
                         __this->fields._crossInputDir = -1;

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -10,6 +10,8 @@
 #include "externals/GameManager.h"
 #include "externals/PlayerWork.h"
 
+#include "logger/logger.h"
+
 const static int32_t MATTR_RAIL = 237;
 const static int32_t MATTR_RAIL_STOP = 238;
 const static int32_t PUNCHINGBAG_OGI = 570;
@@ -18,6 +20,35 @@ const static int32_t ParamIndx_Kairiki_PushTime = 259;
 
 static int32_t punchingBagObjIndex = -1;
 static float punchingBagPushTime;
+
+bool PunchingBagAttributeCheck(UnityEngine::Vector2Int::Object grid, int* count) {
+    int32_t code = 0;
+    int32_t stop = 0;
+    GameManager::getClass()->initIfNeeded();
+    GameManager::GetAttribute(grid, &code, &stop, false);
+
+    // Obstacle, so cancel
+    if (stop == 128) {
+        (*count) = 0;
+        return false;
+    }
+
+    // On a rail, so keep going
+    if (code == MATTR_RAIL) {
+        (*count)++;
+        return true;
+    }
+
+    // Hit a stopper on the rail, so count that and stop
+    if (code == MATTR_RAIL_STOP) {
+        (*count)++;
+        return false;
+    }
+
+    // Not a rail, so cancel
+    (*count) = 0;
+    return false;
+}
 
 void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
     system_load_typeinfo(0x4a4e);
@@ -69,43 +100,108 @@ void PunchingBagPushObject(FieldPlayerEntity::Object* __this, float deltaTime) {
             entity->fields.EventParams->fields.CharacterGraphicsIndex == PUNCHINGBAG_OGI)
         {
             UnityEngine::Vector2Int::Object outgrid {};
+            UnityEngine::Vector2Int::Object breakableGrid {};
             bool hit = false;
             bool pushed = Dpr::Field::WA_Kairiki::PushEntity(__this, dir, entity, &outgrid, &hit);
 
             if (pushed) {
-                int32_t code = 0;
-                int32_t stop = 0;
-                GameManager::getClass()->initIfNeeded();
-                GameManager::GetAttribute(outgrid, &code, &stop, false);
-
-                // TODO: Add rail attribute check here
-                if (stop != 128) {
-                    punchingBagObjIndex = i;
-                    punchingBagPushTime = oldPushTime + deltaTime;
-
-                    Logger::log("Pushing, not stop att with old = %d, i = %d!\n", oldPushObj, i);
-
-                    if (oldPushObj == i) {
-                        GameData::DataManager::getClass()->initIfNeeded();
-                        if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= punchingBagPushTime) {
-                            Logger::log("Pushing new punching bag!\n");
-
-                            __this->fields._isCrossUpdate = false;
-                            __this->fields._crossInputDir = -1;
-                            __this->fields._crossInputVectol = { .fields = { .x = 0.0f, .y = 0.0f } };
-                            __this->fields._bicOldAcceleration = 0.0f;
-                            __this->fields._bicAccelerationTime = 0.0f;
-
-                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_ID, i);
-                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_DIR, (int32_t)dir);
-                            FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_TILES, 3); // TODO: Add amount of tiles here
-
-                            Dpr::EvScript::EvDataManager::get_Instanse()->JumpLabel(System::String::Create("ev_punchingbag_move"), nullptr);
+                int tiles = 0;
+                switch (dir) {
+                    case DIR::DIR_UP: {
+                        UnityEngine::Vector2Int::Object nextTile { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y, } };
+                        auto limit = (nextTile.fields.m_Y / 32) * 32;
+                        for (int32_t j=nextTile.fields.m_Y; j>=limit; j--) {
+                            nextTile.fields.m_Y = j;
+                            if (!PunchingBagAttributeCheck(nextTile, &tiles))
+                                break;
                         }
+                        tiles *= -1;
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles - 1, } };
                     }
-                    else {
-                        punchingBagPushTime = 0.0f;
+                    break;
+
+                    case DIR::DIR_DOWN: {
+                        UnityEngine::Vector2Int::Object nextTile { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y, } };
+                        auto limit = (nextTile.fields.m_Y / 32) * 32 + 31;
+                        for (int32_t j=nextTile.fields.m_Y; j<limit; j++) {
+                            nextTile.fields.m_Y = j;
+                            if (!PunchingBagAttributeCheck(nextTile, &tiles))
+                                break;
+                        }
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y + tiles + 1, } };
                     }
+                    break;
+
+                    case DIR::DIR_LEFT: {
+                        UnityEngine::Vector2Int::Object nextTile { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y, } };
+                        auto limit = (nextTile.fields.m_X / 32) * 32;
+                        for (int32_t j=nextTile.fields.m_X; j>=limit; j--) {
+                            nextTile.fields.m_X = j;
+                            if (!PunchingBagAttributeCheck(nextTile, &tiles))
+                                break;
+                        }
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X + tiles + 1, .m_Y = outgrid.fields.m_Y, } };
+                    }
+                    break;
+
+                    case DIR::DIR_RIGHT: {
+                        UnityEngine::Vector2Int::Object nextTile { .fields { .m_X = outgrid.fields.m_X, .m_Y = outgrid.fields.m_Y, } };
+                        auto limit = (nextTile.fields.m_X / 32) * 32 + 31;
+                        for (int32_t j=nextTile.fields.m_X; j<limit; j++) {
+                            nextTile.fields.m_X = j;
+                            if (!PunchingBagAttributeCheck(nextTile, &tiles))
+                                break;
+                        }
+                        tiles *= -1;
+                        breakableGrid = { .fields { .m_X = outgrid.fields.m_X + tiles - 1, .m_Y = outgrid.fields.m_Y, } };
+                    }
+                    break;
+
+                    default: // This shouldn't happen
+                        return;
+                }
+
+                // Blocked by attributes
+                if (tiles == 0)
+                    return;
+
+                punchingBagObjIndex = i;
+                punchingBagPushTime = oldPushTime + deltaTime;
+
+                int32_t tires = -1;
+                for (int32_t j=0; j<Dpr::EvScript::EvDataManager::get_Instanse()->fields._fieldObjectEntity->instance()->fields._size; j++) {
+                    auto brokenEntity = Dpr::EvScript::EvDataManager::get_Instanse()->fields._fieldObjectEntity->instance()->fields._items->m_Items[j];
+                    if (!UnityEngine::_Object::op_Equality(brokenEntity->cast<UnityEngine::_Object>(), nullptr) &&
+                        brokenEntity->fields.EventParams->fields.CharacterGraphicsIndex == TIRES_OGI &&
+                        UnityEngine::Vector2Int::op_Equality(brokenEntity->get_gridPosition(), breakableGrid))
+                    {
+                        tires = j;
+                    }
+                }
+
+                Logger::log("Pushing, proper atts with old = %d, i = %d!\n", oldPushObj, i);
+
+                if (oldPushObj == i) {
+                    GameData::DataManager::getClass()->initIfNeeded();
+                    if (GameData::DataManager::GetFieldCommonParam(ParamIndx_Kairiki_PushTime) <= punchingBagPushTime) {
+                        Logger::log("Pushing new punching bag!\n");
+
+                        __this->fields._isCrossUpdate = false;
+                        __this->fields._crossInputDir = -1;
+                        __this->fields._crossInputVectol = { .fields = { .x = 0.0f, .y = 0.0f } };
+                        __this->fields._bicOldAcceleration = 0.0f;
+                        __this->fields._bicAccelerationTime = 0.0f;
+
+                        FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_ID, i);
+                        FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_DIR, (int32_t)dir);
+                        FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_OBJ_TILES, tiles);
+                        FlagWork::SetWork(FlagWork_Work::WK_PUNCHINGBAG_HIT_OBJ_ID, tires);
+
+                        Dpr::EvScript::EvDataManager::get_Instanse()->JumpLabel(System::String::Create("ev_punchingbag_move"), nullptr);
+                    }
+                }
+                else {
+                    punchingBagPushTime = 0.0f;
                 }
             }
             else {

--- a/src/mod/features/small_patches.cpp
+++ b/src/mod/features/small_patches.cpp
@@ -7,6 +7,7 @@
 #include "externals/Dpr/Battle/Logic/MainModule.h"
 #include "externals/Dpr/Demo/Demo_Evolve.h"
 #include "externals/Dpr/Message/MessageEnumData.h"
+#include "externals/FieldObjectEntity.h"
 
 #include "features/activated_features.h"
 #include "logger/logger.h"
@@ -46,6 +47,16 @@ HOOK_DEFINE_INLINE(BoxSearchPanel_CreateSearchDataListCore_MonIcon) {
     }
 };
 
+HOOK_DEFINE_INLINE(EvDataManager$$LoadObjectCreate_Asset_SetOGI) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        auto entity = (FieldObjectEntity::Object*)ctx->X[22];
+        auto ogi = (int32_t)ctx->W[19];
+
+        entity->fields.EventParams->fields.CharacterGraphicsIndex = ogi;
+        ctx->X[3] = 0;
+    }
+};
+
 void exl_patches_main() {
     using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;
@@ -73,4 +84,5 @@ void exl_patches_main() {
     GetMessageLangIdFromIetfCode::InstallAtOffset(0x017c21f0); // Always returns first boot language as English
     DoEvolve_ItemCancelCheck::InstallAtOffset(0x0177f16c); // All evolutions by item make the evolution non-cancellable with B, not just vanilla items
     BoxSearchPanel_CreateSearchDataListCore_MonIcon::InstallAtOffset(0x01caf0b8); // Box Search checks all characters after "_" to get monsno and not just the last 3
+    EvDataManager$$LoadObjectCreate_Asset_SetOGI::InstallAtOffset(0x02ca4160); // Always sets the "CharacterGraphicsIndex" on a FieldObjectEntity to the OGI, not just for characters
 }

--- a/src/mod/ui/components/data_viewer.h
+++ b/src/mod/ui/components/data_viewer.h
@@ -5,19 +5,31 @@
 #include "logger/logger.h"
 #include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/EntityManager.h"
+#include "externals/FieldManager.h"
+#include "externals/GameManager.h"
 #include "externals/PlayerWork.h"
 
 namespace ui {
     ELEMENT(DataViewer) {
-
         void draw() override {
+            // Player coordinates
             auto entity = (FieldObjectEntity::Object *)EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField;
+            ImGui::Text("Player info");
+            ImGui::Text("zone = %d, area = %d", PlayerWork::get_zoneID(), FieldManager::getClass()->static_fields->_Instance_k__BackingField->get_areaID());
+            ImGui::Text("x = %f, y = %f, z = %f", entity->fields.worldPosition.fields.x, entity->fields.worldPosition.fields.y, entity->fields.worldPosition.fields.z);
 
-            ImGui::Text("x = %f", entity->fields.worldPosition.fields.x);
-            ImGui::Text("y = %f", entity->fields.worldPosition.fields.y);
-            ImGui::Text("z = %f", entity->fields.worldPosition.fields.z);
+            // Camera data
+            auto camera = GameManager::getClass()->static_fields->fieldCamera;
+            auto cameraPos = camera->fields._camera->cast<UnityEngine::Component>()->get_transform()->get_position();
+            auto cameraRot = camera->fields._camera->cast<UnityEngine::Component>()->get_transform()->get_localEulerAngles();
+            ImGui::Text("\nField camera info");
+            ImGui::Text("x = %f, y = %f, z = %f", cameraPos.fields.x, cameraPos.fields.y, cameraPos.fields.z);
+            ImGui::Text("pitch (x) = %f, yaw (y) = %f, roll (z) = %f", cameraRot.fields.x, cameraRot.fields.y, cameraRot.fields.z);
+            ImGui::Text("fov = %f", camera->fields._camera->get_fieldOfView());
 
+            // Script info
             auto evManager = Dpr::EvScript::EvDataManager::get_Instanse();
+            ImGui::Text("\nScript info");
             if (evManager->fields._eventListIndex == -1)
             {
                 ImGui::Text("No script currently running.");


### PR DESCRIPTION
Closes #165.

- Adds a "Pushable Entities" feature.
  - The first entity of this kind is the punching bag for Veilstone Gym.
    - It checks the OGI of the entity so that it matches the punching bag gimmick (570).
    - It can only be pushed if the next tile(s) are of attribute MATTR_RAIL (237), with one final tile in that line as MATTR_RAIL_STOP (238). Note that only the tiles in the current attribute block are checked.
    - If a tires gimmick (571) is one tile after the "stopper", it is detected.
    - Once it's confirmed that the punching bag can move, the following works are set:
      - WK_PUNCHINGBAG_OBJ_ID (502) gets set to the index of the punching bag object.
      - WK_PUNCHINGBAG_OBJ_DIR (503) gets set to the direction, based on the DIR enum (0 is up, 1 is down, 2 is left, 3 is right).
      - WK_PUNCHINGBAG_OBJ_TILES (504) gets set to the amount of tiles the punching bag needs to move to hit a "stopper".
      - WK_PUNCHINGBAG_HIT_OBJ_ID (505) gets set to the index of the tires object that the punching bag has hit, or -1 if none.
- Restructures the "Data Viewer" in the debug menu.
  - It now shows the current zoneID and areaID, as well as the Field Camera's position and rotation.
- Adds new commands:
  - _GET_TILE_ATTRIBUTE (1259)
    - Gets the attribute data of a specified tile.
      - X [Work, Float]: The x position of the tile to check.
      - Z [Work, Float]: The z position of the tile to check.
      - Code [Work]: The work in which to put the tile's code attribute.
      - Stop [Work]: The work in which to put the tile's stop attribute.
  - _EVENT_ENTITY_CLIP_PLAY_BY_INDEX (1260)
    - Plays an animation clip on a FieldEventEntity at the specified index.
      - Entity [Work, Float]: The index of the entity to play a clip on.
      - Clip [Work, Float]: The index of the clip to play.
  - _EVENT_ENTITY_CLIP_WAIT_BY_INDEX (1261)
    - Waits for an animation clip on a FieldEventEntity at the specified index to be finished.
      - Entity [Work, Float]: The index of the entity to wait for.
  - _ENTITY_MOVE (1262)
    - Moves an entity by an amount of tiles over an amount of frames.
      - Entity [Work, Float, String]: The ID or index of the entity to move.
      - X [Work, Float]: Amount of tiles to move on the x axis.
      - Y [Work, Float]: Amount of tiles to move on the y axis.
      - Z [Work, Float]: Amount of tiles to move on the z axis.
      - Frames [Work, Float]: Amount of frames to do the movement over. (30 fps)