### PR TITLE
Add ExtraData for OpenBoxParams

### DIFF
--- a/src/mod/externals/Dpr/Message/MessageGlossaryParseDataModel.h
+++ b/src/mod/externals/Dpr/Message/MessageGlossaryParseDataModel.h
@@ -2,6 +2,8 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/System/String.h"
+
 namespace Dpr::Message {
     struct MessageGlossaryParseDataModel : ILClass<MessageGlossaryParseDataModel> {
         struct Fields {
@@ -15,6 +17,10 @@ namespace Dpr::Message {
             float strWidth;
             float fontSize;
         };
+
+        inline System::String::Object* GetName() {
+            return external<System::String::Object*>(0x020ff740, this);
+        }
     };
 }
 

--- a/src/mod/externals/Dpr/Message/MessageMsgFile.h
+++ b/src/mod/externals/Dpr/Message/MessageMsgFile.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/Dpr/Message/MsbtDataModel.h"
+#include "externals/Dpr/Message/MessageGlossaryParseDataModel.h"
 #include "externals/Dpr/Message/MessageTextParseDataModel.h"
 #include "externals/System/String.h"
 
@@ -14,6 +15,10 @@ namespace Dpr::Message {
 
         inline MessageTextParseDataModel::Object* GetTextDataModel(System::String::Object* label) {
             return external<MessageTextParseDataModel::Object*>(0x0210db00, this, label);
+        }
+
+        inline MessageGlossaryParseDataModel::Object* GetNameDataModel(System::String::Object* label) {
+            return external<MessageGlossaryParseDataModel::Object*>(0x0210d940, this, label);
         }
     };
 }

--- a/src/mod/externals/Dpr/UI/BoxStatusPanel.h
+++ b/src/mod/externals/Dpr/UI/BoxStatusPanel.h
@@ -1,10 +1,12 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/UI/UIText.h"
+#include "externals/Pml/PokePara/CoreParam.h"
+#include "externals/UnityEngine/GameObject.h"
 #include "externals/UnityEngine/MonoBehaviour.h"
 #include "externals/UnityEngine/UI/Image.h"
-#include "externals/Dpr/UI/UIText.h"
-#include "externals/UnityEngine/GameObject.h"
 
 namespace Dpr::UI {
     struct BoxStatusPanel : ILClass<BoxStatusPanel> {

--- a/src/mod/externals/Dpr/UI/BoxWindow.h
+++ b/src/mod/externals/Dpr/UI/BoxWindow.h
@@ -1,13 +1,51 @@
 #pragma once
+
 #include "externals/il2cpp-api.h"
-#include "externals/Dpr/UI/UIWindow.h"
-#include "BoxStatusPanel.h"
-#include "BoxTray.h"
+
 #include "externals/DG/Tweening/Tween.h"
+#include "externals/Dpr/UI/UIWindow.h"
+#include "externals/Dpr/UI/BoxStatusPanel.h"
+#include "externals/Dpr/UI/BoxTray.h"
 #include "externals/System/Action.h"
 
 namespace Dpr::UI {
     struct BoxWindow : ILClass<BoxWindow> {
+        struct OpenParam : ILClass<OpenParam, 0x04c5ef90> {
+            struct Fields {
+                int32_t dispMode;
+                int32_t tray;
+                int32_t index;
+                int32_t teamIndex;
+                bool isSelectParty;
+                int32_t openType;
+                int32_t selectCount;
+                int32_t targetLevel;
+                bool isEnableDying;
+                bool isEnableEgg;
+                bool isEnableTeam;
+                bool isEnableParty;
+                bool isShowSelectCount;
+                bool isEnableKeyboard;
+                bool isOpenFromBattleTeam;
+                bool isDisableUseful;
+                bool isDisableDuplicate;
+                bool isDontDuckOffBGM;
+                bool isExternalTrade;
+                bool isGMS;
+                System::Int32_array* targetsPokeNo;
+                System::Int32_array* selectNgPokeNos;
+                System::String::Object* tradeName;
+                void* selected; // System_Collections_Generic_List_BoxWindow_SelectedPokemon__o*
+                void* searchData; // Dpr_UI_BoxWindow_SEARCH_DATA_o*
+            };
+
+            static_assert(offsetof(Fields, searchData) == 0x50);
+
+            inline void ctor() {
+                external<void>(0x01a27970, this);
+            }
+        };
+
         struct __c__DisplayClass200_0 : ILClass<__c__DisplayClass200_0> {
             struct Fields {
                 BoxWindow::Object* __4__this;
@@ -154,5 +192,11 @@ namespace Dpr::UI {
             bool _isControlEnable; // 0x3DC
             bool _isForceClosing; // 0x3DD
         };
+
+        static_assert(offsetof(Fields, _isForceClosing) == 0x3CD);
+
+        inline void Open(OpenParam::Object* param, System::Action::Object* onSelected, int32_t prevWindowId) {
+            external<void>(0x01cb64c0, this, param, onSelected, prevWindowId);
+        }
     };
 }

--- a/src/mod/externals/Dpr/UI/UIManager.h
+++ b/src/mod/externals/Dpr/UI/UIManager.h
@@ -128,6 +128,10 @@ namespace Dpr::UI {
         inline UnityEngine::Sprite::Object* GetSpriteMonsterBall(uint8_t ballId) {
             return external<UnityEngine::Sprite::Object*>(0x017c2300, this, ballId);
         }
+
+        inline XLSXContent::UIDatabase::SheetBoxOpenParam::Object* GetBoxOpenData(int32_t type) {
+            return external<XLSXContent::UIDatabase::SheetBoxOpenParam::Object*>(0x017c2bd0, this, type);
+        }
     };
 }
 

--- a/src/mod/externals/XLSXContent/UIDatabase.h
+++ b/src/mod/externals/XLSXContent/UIDatabase.h
@@ -33,6 +33,17 @@ namespace XLSXContent {
             };
         };
 
+        struct SheetBoxOpenParam : ILClass<SheetBoxOpenParam> {
+            struct Fields {
+                System::Int32_array* MonsNo;
+                int32_t SelectCount;
+                int32_t Level;
+                bool IsTrade;
+                bool IsEnableParty;
+                bool IsEnableDying;
+            };
+        };
+
         struct Fields : UnityEngine::ScriptableObject::Fields {
             void* UIWindow; // XLSXContent_UIDatabase_SheetUIWindow_array*
             void* Transition; // XLSXContent_UIDatabase_SheetTransition_array*
@@ -63,7 +74,7 @@ namespace XLSXContent {
             void* HideWazaName; // XLSXContent_UIDatabase_SheetHideWazaName_array*
             void* HideTokusei; // XLSXContent_UIDatabase_SheetHideTokusei_array*
             void* ZukanRating; // XLSXContent_UIDatabase_SheetZukanRating_array*
-            void* BoxOpenParam; // XLSXContent_UIDatabase_SheetBoxOpenParam_array*
+            SheetBoxOpenParam::Array* BoxOpenParam;
             void* SealTemplate; // XLSXContent_UIDatabase_SheetSealTemplate_array*
             void* RankingDisplay; // XLSXContent_UIDatabase_SheetRankingDisplay_array*
         };

--- a/src/mod/romdata/box_open_params.cpp
+++ b/src/mod/romdata/box_open_params.cpp
@@ -1,0 +1,41 @@
+#include "exlaunch.hpp"
+
+#include "helpers.h"
+#include "memory/json.h"
+#include "memory/string.h"
+
+#include "romdata/data/BoxOpenParam.h"
+
+#include "logger/logger.h"
+
+const char* boxOpenParamFolderPath = "rom:/Data/ExtraData/UI/BoxOpenParam/";
+
+void LogBoxOpenParam(const RomData::BoxOpenParam& p)
+{
+    Logger::log("SELECTED BOX OPEN PARAM\n");
+    Logger::log("Trade ID: %d\n", p.tradeId);
+}
+
+RomData::BoxOpenParam GetExtraBoxOpenParamData(int32_t paramId)
+{
+    nn::string filePath(boxOpenParamFolderPath);
+    filePath.append("param_" + nn::to_string(paramId) + ".json");
+
+    nn::json j = FsHelper::loadJsonFileFromPath(filePath.c_str());
+    if (j != nullptr && !j.is_discarded())
+    {
+        RomData::BoxOpenParam boxOpenParam = {};
+        boxOpenParam = j.get<RomData::BoxOpenParam>();
+
+        return boxOpenParam;
+    }
+    else
+    {
+        Logger::log("Error when parsing BoxOpenParam data!\n");
+    }
+
+    // Default: No associated local trade
+    return {
+        .tradeId = -1,
+    };
+}

--- a/src/mod/romdata/data/BoxOpenParam.h
+++ b/src/mod/romdata/data/BoxOpenParam.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+#include "memory/json.h"
+
+namespace RomData
+{
+    struct BoxOpenParam
+    {
+        int32_t tradeId;
+    };
+
+    JSON_TEMPLATE
+    void to_json(GENERIC_JSON& j, const BoxOpenParam& p) {
+        j = nn::json {
+            {"tradeId", p.tradeId},
+        };
+    }
+
+    JSON_TEMPLATE
+    void from_json(const GENERIC_JSON& j, BoxOpenParam& p) {
+        j.at("tradeId").get_to(p.tradeId);
+    }
+}

--- a/src/mod/romdata/romdata.h
+++ b/src/mod/romdata/romdata.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "romdata/data/Arena.h"
+#include "romdata/data/BoxOpenParam.h"
 #include "romdata/data/ColorSet.h"
 #include "romdata/data/FormHeldItemMon.h"
 #include "romdata/data/HoneyTreeEncounters.h"
@@ -90,5 +91,8 @@ RomData::SmeargleColor GetSmeargleColorData(int32_t zoneID);
 
 // Rolls a Smeargle color based on the data for the given zoneID.
 int32_t RollForSmeargleColor(int32_t zoneID);
+
+// Returns the extra BoxOpenParam data.
+RomData::BoxOpenParam GetExtraBoxOpenParamData(int32_t paramId);
 
 void LoadFeaturesFromJSON(nn::json j);

--- a/src/mod/romdata/zone_rates.cpp
+++ b/src/mod/romdata/zone_rates.cpp
@@ -24,7 +24,7 @@ int32_t Roll(nn::vector<uint32_t>* rates)
     int32_t currentSum = 0;
     for (size_t i=0; i<(*rates).size(); i++)
     {
-        if (roll < currentSum + (*rates)[i])
+        if (roll < currentSum + (int32_t)(*rates)[i])
             return i;
 
         currentSum += (*rates)[i];


### PR DESCRIPTION
Closes #183.

- Adds ExtraData for OpenBoxParams that define which local trade it's associated with.
  - A value of -1 (which is the default if no file is defined for that OpenBoxParam) indicates no associated local trade.
  - Adjusts the code determining which local trade to use for a given OpenBoxParam to make use of this ExtraData.