### PR TITLE
Initial ExeFS in preparation for Distortion World

### DIFF
--- a/src/mod/data/areas.h
+++ b/src/mod/data/areas.h
@@ -697,6 +697,18 @@ static constexpr const char *AREAS[] = {
     "Galactic HQ - Speech Room",
     "Distortion World 2",
     "Veilstone - Department Store B1F",
+    "Sunyshore - Regieleki Room",
+    "Route 210 - Regidrago Room (North)",
+    "Eterna Forest - Grotto",
+    "Route 212 - Grotto (South)",
+    "Route 214 - Grotto",
+    "Route 217 - Grotto",
+    "Oldlore Town",
+    "Oldlore - Large House",
+    "Oldlore - House 1 (West)",
+    "Oldlore - House 2 (Center)",
+    "Oldlore - House 3 (South)",
+    "Ilex Forest",
 };
 
 static constexpr const char *AREA_CODES[] = {
@@ -1396,6 +1408,18 @@ static constexpr const char *AREA_CODES[] = {
     "D26R0109",
     "DISTORTIONR0102",
     "C07R0207",
+    "C08R0901",
+    "R210BR0201",
+    "GROTTOR0101",
+    "GROTTOR0201",
+    "GROTTOR0301",
+    "GROTTOR0401",
+    "T08",
+    "T08R0101",
+    "T08R0201",
+    "T08R0301",
+    "T08R0401",
+    "JOHTOD01R0101",
 };
 
 constexpr int AREA_COUNT = sizeof(AREAS) / sizeof(AREAS[0]);

--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -57,6 +57,7 @@ static constexpr const char* FEATURES[] = {
     "Intro Professor Pokémon",
     "Pushable Entities",
     "Select Poffin Case",
+    "Fake StopData",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/data/zones.h
+++ b/src/mod/data/zones.h
@@ -681,6 +681,18 @@ static constexpr const char *ZONES[] = {
     "Galactic HQ - Speech Room",
     "Distortion World 2",
     "Veilstone - Department Store B1F",
+    "Sunyshore - Regieleki Room",
+    "Route 210 - Regidrago Room (North)",
+    "Eterna Forest - Grotto",
+    "Route 212 - Grotto (South)",
+    "Route 214 - Grotto",
+    "Route 217 - Grotto",
+    "Oldlore Town",
+    "Oldlore - Large House",
+    "Oldlore - House 1 (West)",
+    "Oldlore - House 2 (Center)",
+    "Oldlore - House 3 (South)",
+    "Ilex Forest",
 };
 
 static constexpr const char *ZONE_CODES[] = {
@@ -1364,6 +1376,18 @@ static constexpr const char *ZONE_CODES[] = {
     "D26R0109",
     "DISTORTIONR0102",
     "C07R0207",
+    "C08R0901",
+    "R210BR0201",
+    "GROTTOR0101",
+    "GROTTOR0201",
+    "GROTTOR0301",
+    "GROTTOR0401",
+    "T08",
+    "T08R0101",
+    "T08R0201",
+    "T08R0301",
+    "T08R0401",
+    "JOHTOD01R0101",
 };
 
 constexpr int ZONE_COUNT = sizeof(ZONES) / sizeof(ZONES[0]);

--- a/src/mod/externals/AnimationPlayer.h
+++ b/src/mod/externals/AnimationPlayer.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+struct AnimationPlayer : ILClass<AnimationPlayer> {
+    struct Fields {
+        // TODO
+    };
+
+    inline int32_t get_currentIndex() {
+        return external<int32_t>(0x0211d8a0, this);
+    }
+};

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1286,6 +1286,7 @@ namespace Dpr::EvScript {
             _TRAINER_DEFEATED_COUNT = 1276,
             _ATTACH_TRANSFORM = 1277,
             _GAMEOBJECT_ROTATE = 1278,
+            _LEDGE_JUMP = 1279,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1287,6 +1287,7 @@ namespace Dpr::EvScript {
             _ATTACH_TRANSFORM = 1277,
             _GAMEOBJECT_ROTATE = 1278,
             _LEDGE_JUMP = 1279,
+            _JUMP_AND_ROTATE = 1280,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1285,6 +1285,7 @@ namespace Dpr::EvScript {
             _DEL_POFFIN = 1275,
             _TRAINER_DEFEATED_COUNT = 1276,
             _ATTACH_TRANSFORM = 1277,
+            _GAMEOBJECT_ROTATE = 1278,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1284,6 +1284,7 @@ namespace Dpr::EvScript {
             _GET_POFFIN_FLAVOR = 1274,
             _DEL_POFFIN = 1275,
             _TRAINER_DEFEATED_COUNT = 1276,
+            _ATTACH_TRANSFORM = 1277,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -174,7 +174,7 @@ namespace Dpr::EvScript {
             void * _se_datas;
             void * _voice_datas;
             UnityEngine::Vector2Int::Object _eventEndPosition;
-            void * _posEventLabelReserve;
+            System::String::Object* _posEventLabelReserve;
             void * _entityParamList;
             void * _stopRoot;
             bool _isInitFirstMap;
@@ -479,6 +479,14 @@ namespace Dpr::EvScript {
 
         inline FieldEventEntity* FindEventDoorEntity(System::String::Object* name) {
             return external<FieldEventEntity*>(0x02c88930, this, name);
+        }
+
+        inline void PlayerInputActive(bool active, bool animation) {
+            external<void>(0x02c45e10, this, active, animation);
+        }
+
+        inline int32_t SetupHeroMoveGridCenterFrontDir(UnityEngine::RectInt::Object* stopGridArea, UnityEngine::Vector2Int::Object* nowGrid, UnityEngine::Vector2Int::Object* oldGrid) {
+            return external<int32_t>(0x02c47760, this, stopGridArea, nowGrid, oldGrid);
         }
 
         static inline Dpr::EvScript::EvDataManager::Object* get_Instanse() {

--- a/src/mod/externals/FieldCharacterEntity.h
+++ b/src/mod/externals/FieldCharacterEntity.h
@@ -2,6 +2,7 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/AnimationPlayer.h"
 #include "externals/Effect/EffectInstance.h"
 #include "externals/FieldObjectEntity.h"
 #include "externals/System/Func.h"
@@ -13,7 +14,7 @@
 struct FieldCharacterEntity : ILClass<FieldCharacterEntity, 0x04c5ece8> {
     struct Fields : FieldObjectEntity::Fields {
         float HandScale;
-        void* _animationPlayer; // AnimationPlayer_o*
+        AnimationPlayer::Object* _animationPlayer;
         void* _blinkPatterns; // CurvePatterns_o*
         void* _variations; // FieldCharacterVariation_array*
         int32_t _eyePatternIndex;

--- a/src/mod/externals/FieldManager.h
+++ b/src/mod/externals/FieldManager.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/Effect/EffectInstance.h"
+#include "externals/FieldObjectEntity.h"
 #include "externals/System/Action.h"
 #include "externals/UnityEngine/GameObject.h"
 #include "externals/UnityEngine/Material.h"
@@ -88,5 +89,13 @@ struct FieldManager : ILClass<FieldManager, 0x04c5a638> {
 
     inline int32_t get_areaID() {
         return external<int32_t>(0x01797f90, this);
+    }
+
+    inline void RequestAttributeEffect(FieldObjectEntity::Object* entity, int32_t attri) {
+        external<void>(0x017a0090, this, entity, attri);
+    }
+
+    inline void RequestAttributeSE(FieldObjectEntity::Object* entity, int32_t attri) {
+        external<void>(0x017a0130, this, entity, attri);
     }
 };

--- a/src/mod/externals/FieldObjectEntity.h
+++ b/src/mod/externals/FieldObjectEntity.h
@@ -39,6 +39,11 @@ struct FieldObjectEntity : ILClass<FieldObjectEntity> {
     static inline DIR GetDir(float dir) {
         return external<DIR>(0x01d55140, dir);
     }
+
+    static inline UnityEngine::Vector2Int::Object PositionToGrid(UnityEngine::Vector3::Object position) {
+        UnityEngine::Vector3::Fields positionProxy = { .x = position.fields.x, .y = position.fields.y, .z = position.fields.z };
+        return external<UnityEngine::Vector2Int::Object>(0x01d54ae0, positionProxy);
+    }
 };
 
 namespace System::Collections::Generic {

--- a/src/mod/externals/FieldPlayerEntity.h
+++ b/src/mod/externals/FieldPlayerEntity.h
@@ -138,6 +138,10 @@ struct FieldPlayerEntity : ILClass<FieldPlayerEntity> {
         return external<bool>(0x01da7c70, this);
     }
 
+    inline void StopCrossInputAndBicycle() {
+        external<void>(0x01da4ed0, this);
+    }
+
     static_assert(offsetof(Fields, _hatRenderers) == 0x198);
     static_assert(offsetof(Fields, _path) == 0x1F8);
     static_assert(sizeof(Fields) == 0x3e8);

--- a/src/mod/externals/FieldPlayerEntity.h
+++ b/src/mod/externals/FieldPlayerEntity.h
@@ -5,6 +5,7 @@
 #include "externals/Audio/AudioInstance.h"
 #include "externals/Effect/EffectInstance.h"
 #include "externals/FieldCharacterEntity.h"
+#include "externals/JumpCalculator.h"
 #include "externals/System/Action.h"
 #include "externals/System/Func.h"
 #include "externals/UnityEngine/Color.h"
@@ -31,7 +32,7 @@ struct FieldPlayerEntity : ILClass<FieldPlayerEntity> {
         int32_t _bicycleColorIndex_k__BackingField;
         bool isExtrudable;
         bool _DashFlag_k__BackingField;
-        void* _path; // JumpCalculator_o*
+        JumpCalculator::Object* _path;
         bool _setupMaterials;
         bool _hit_se_request;
         float _hit_se_wait;
@@ -121,6 +122,23 @@ struct FieldPlayerEntity : ILClass<FieldPlayerEntity> {
         external<void>(0x01dabb10, this, stickL, stickPowerSq, deltatime, analogstick);
     }
 
+    inline void PlayJumpStart() {
+        external<void>(0x01da7b50, this);
+    }
+
+    inline void PlayJumpLoop() {
+        external<void>(0x01da9ed0, this);
+    }
+
+    inline void PlayJumpEnd() {
+        external<void>(0x01da9fc0, this);
+    }
+
+    inline bool IsRideBicycle() {
+        return external<bool>(0x01da7c70, this);
+    }
+
     static_assert(offsetof(Fields, _hatRenderers) == 0x198);
+    static_assert(offsetof(Fields, _path) == 0x1F8);
     static_assert(sizeof(Fields) == 0x3e8);
 };

--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -3247,6 +3247,8 @@ enum class FlagWork_Work : int32_t {
     WK_PUNCHINGBAG_OBJ_DIR = 503,
     WK_PUNCHINGBAG_OBJ_TILES = 504,
     WK_PUNCHINGBAG_HIT_OBJ_ID = 505,
+    WK_CONTACTABLE_OBJ_ID = 507,
+    WK_CONTACTABLE_OBJ_DIR = 508,
 
     // Debug works, can be replaced at any time
     WORK_4000 = 4000,

--- a/src/mod/externals/JumpCalculator.h
+++ b/src/mod/externals/JumpCalculator.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/UnityEngine/Vector3.h"
+
+struct JumpCalculator : ILClass<JumpCalculator> {
+    struct Fields {
+        float _duration;
+        float _gravity;
+        UnityEngine::Vector3::Object _velocity;
+        UnityEngine::Vector3::Object _startingPoint;
+        float _timeSinceStartup;
+    };
+
+    static_assert(offsetof(Fields, _timeSinceStartup) == 0x20);
+
+    inline UnityEngine::Vector3::Object Process(float deltaTime, bool *isFinished) {
+        return {
+            .fields = external<UnityEngine::Vector3::Fields>(0x01aec2d0, this, deltaTime, isFinished)
+        };
+    }
+
+    inline void Startup(UnityEngine::Transform::Object* transform, float moveDistance, float relativeHeight, float relativeLower, float duration) {
+        external<void>(0x01aec160, this, transform, moveDistance, relativeHeight, relativeLower, duration);
+    }
+};

--- a/src/mod/externals/System/String.h
+++ b/src/mod/externals/System/String.h
@@ -56,6 +56,10 @@ namespace System {
             return external<int32_t>(0x026f6ef0, this, value);
         }
 
+        inline bool StartsWith(String::Object* value) {
+            return external<bool>(0x026f78d0, this, value);
+        }
+
         inline String::Object* Truncate(int32_t maxLength) {
             String::Object* str = this->instance();
             if (IsNullOrEmpty(str))

--- a/src/mod/externals/UnityEngine/Component.h
+++ b/src/mod/externals/UnityEngine/Component.h
@@ -10,6 +10,7 @@
 // These are all to avoid cyclical definitions
 struct BattleCharacterEntity;
 struct FieldCharacterEntity;
+struct FieldObjectEntity;
 struct PokemonCustomNodeAnim;
 
 namespace System::Collections::Generic {
@@ -56,6 +57,7 @@ namespace UnityEngine {
         static inline StaticILMethod<0x04c67050, UnityEngine::BoxCollider> Method$$BoxCollider$$GetComponent {};
         static inline StaticILMethod<0x04c66d60, BattleCharacterEntity> Method$$BattleCharacterEntity$$GetComponent {};
         static inline StaticILMethod<0x04c66fc0, FieldCharacterEntity> Method$$FieldCharacterEntity$$GetComponent {};
+        static inline StaticILMethod<0x04c66808, FieldObjectEntity> Method$$FieldObjectEntity$$GetComponent {};
         static inline StaticILMethod<0x04c66840, PokemonCustomNodeAnim> Method$$PokemonCustomNodeAnim$$GetComponent {};
         static inline StaticILMethod<0x04c669c0, XMenuTopItem> Method$$XMenuTopItem$$GetComponent {};
 

--- a/src/mod/externals/UnityEngine/Transform.h
+++ b/src/mod/externals/UnityEngine/Transform.h
@@ -91,6 +91,12 @@ namespace UnityEngine {
             };
         }
 
+        inline void RotateAround(UnityEngine::Vector3::Object point, UnityEngine::Vector3::Object axis, float angle) {
+            UnityEngine::Vector3::Fields pointProxy = { .x = point.fields.x, .y = point.fields.y, .z = point.fields.z };
+            UnityEngine::Vector3::Fields axisProxy = { .x = axis.fields.x, .y = axis.fields.y, .z = axis.fields.z };
+            external<void>(0x0299ec40, this, pointProxy, axisProxy, angle);
+        }
+
         // utility functions
         UnityEngine::Transform::Object* GetChild(std::initializer_list<std::int32_t> index) {
             UnityEngine::Transform* transform = this;

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -130,6 +130,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(GameObjectRotate(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP:
                     return HandleCmdStepper(LedgeJump(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_JUMP_AND_ROTATE:
+                    return HandleCmdStepper(JumpAndRotate(__this));
                 default:
                     break;
             }
@@ -196,4 +198,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_JUMP_AND_ROTATE);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -124,6 +124,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(DelPoffin(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_TRAINER_DEFEATED_COUNT:
                     return HandleCmdStepper(TrainerDefeatedCount(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM:
+                    return HandleCmdStepper(AttachTransform(__this));
                 default:
                     break;
             }
@@ -187,4 +189,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_POFFIN_FLAVOR);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_DEL_POFFIN);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_TRAINER_DEFEATED_COUNT);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -128,6 +128,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(AttachTransform(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE:
                     return HandleCmdStepper(GameObjectRotate(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP:
+                    return HandleCmdStepper(LedgeJump(__this));
                 default:
                     break;
             }
@@ -193,4 +195,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_TRAINER_DEFEATED_COUNT);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP);
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -126,6 +126,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(TrainerDefeatedCount(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM:
                     return HandleCmdStepper(AttachTransform(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE:
+                    return HandleCmdStepper(GameObjectRotate(__this));
                 default:
                     break;
             }
@@ -190,4 +192,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_DEL_POFFIN);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_TRAINER_DEFEATED_COUNT);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ATTACH_TRANSFORM);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE);
 }

--- a/src/mod/features/commands/attach_transform.cpp
+++ b/src/mod/features/commands/attach_transform.cpp
@@ -1,0 +1,43 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/UnityEngine/GameObject.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+UnityEngine::Transform::Object* FindTransform(System::String::Object* name)
+{
+    EntityManager::getClass()->initIfNeeded();
+
+    auto go = System::String::op_Equality(name, System::String::Create("HERO")) ?
+              EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField->cast<UnityEngine::Component>()->get_gameObject()->instance() :
+              UnityEngine::GameObject::Find(name);
+
+    if (go == nullptr)
+        return nullptr;
+    else
+        return go->get_transform();
+}
+
+bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_ATTACH_TRANSFORM\n");
+
+    system_load_typeinfo(0x3f9a);
+    system_load_typeinfo(0x4af3);
+    system_load_typeinfo(0x5a55);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    auto objTF = FindTransform(GetStringText(manager, args->m_Items[1]));
+    auto parentTF = FindTransform(GetStringText(manager, args->m_Items[2]));
+    bool worldPositionStays = GetWorkOrIntValue(args->m_Items[3]) == 1;
+
+    if (objTF != nullptr && parentTF != nullptr)
+    {
+        if (!worldPositionStays)
+            objTF->set_localPosition({ .fields = { .x = 0.0f, .y = 0.0f, .z = 0.0f } });
+        objTF->SetParent(parentTF, worldPositionStays);
+    }
+
+    return true;
+}

--- a/src/mod/features/commands/attach_transform.cpp
+++ b/src/mod/features/commands/attach_transform.cpp
@@ -29,6 +29,14 @@ bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager) {
             objTF->set_localPosition({ .fields = { .x = 0.0f, .y = 0.0f, .z = 0.0f } });
         objTF->SetParent(parentTF, worldPositionStays);
     }
+    else
+    {
+        if (objTF == nullptr)
+            Logger::log("Could not find object %s???\n", GetStringText(manager, args->m_Items[1])->asCString().c_str());
+
+        if (parentTF == nullptr)
+            Logger::log("Could not find parent %s???\n", GetStringText(manager, args->m_Items[2])->asCString().c_str());
+    }
 
     return true;
 }

--- a/src/mod/features/commands/attach_transform.cpp
+++ b/src/mod/features/commands/attach_transform.cpp
@@ -11,6 +11,7 @@ bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager) {
     system_load_typeinfo(0x3f9a);
     system_load_typeinfo(0x4af3);
     system_load_typeinfo(0x5a55);
+    system_load_typeinfo(0x9412);
 
     EvData::Aregment::Array* args = manager->fields._evArg;
 
@@ -20,6 +21,10 @@ bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager) {
 
     if (objTF != nullptr && parentTF != nullptr)
     {
+        auto fieldObject = objTF->cast<UnityEngine::Component>()->GetComponent(UnityEngine::Component::Method$$FieldObjectEntity$$GetComponent);
+        if (fieldObject != nullptr)
+            fieldObject->fields.isLanding = false;
+
         if (!worldPositionStays)
             objTF->set_localPosition({ .fields = { .x = 0.0f, .y = 0.0f, .z = 0.0f } });
         objTF->SetParent(parentTF, worldPositionStays);

--- a/src/mod/features/commands/attach_transform.cpp
+++ b/src/mod/features/commands/attach_transform.cpp
@@ -5,20 +5,6 @@
 #include "features/commands/utils/cmd_utils.h"
 #include "logger/logger.h"
 
-UnityEngine::Transform::Object* FindTransform(System::String::Object* name)
-{
-    EntityManager::getClass()->initIfNeeded();
-
-    auto go = System::String::op_Equality(name, System::String::Create("HERO")) ?
-              EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField->cast<UnityEngine::Component>()->get_gameObject()->instance() :
-              UnityEngine::GameObject::Find(name);
-
-    if (go == nullptr)
-        return nullptr;
-    else
-        return go->get_transform();
-}
-
 bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager) {
     Logger::log("_ATTACH_TRANSFORM\n");
 

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -316,13 +316,14 @@ bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] The time in seconds that the jump will take. (Default is 0.5)
 bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager);
 
-// Makes the player ledge jump with the given parameters, while rotating a given GameObject over an amount of frames.
+// Makes the player ledge jump with the given parameters, while rotating a given GameObject over an amount of frames around a specific pivot.
 // Arguments:
 //   [String] gameObject: The name of the GameObject to rotate.
 //   [Work, Number] x: Degrees to rotate on the x axis.
 //   [Work, Number] y: Degrees to rotate on the y axis.
 //   [Work, Number] z: Degrees to rotate on the z axis.
 //   [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
+//   [String] pivot: The name of the GameObject that will act as a pivot point.
 //   [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
 //   [Work, Number] relativeHeight: Unknown. (Default is 0.75)
 //   [Work, Number] relativeLower: Unknown. (Default is -0.5)

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -298,3 +298,12 @@ bool TrainerDefeatedCount(Dpr::EvScript::EvDataManager::Object* manager);
 //   [String] parent: The name of the GameObject that will be the new parent. "HERO" will refer to the player.
 //   [Work, Number] keepWorldPosition: If the child GameObject should keep its current world position. 0 is false and 1 is true.
 bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Rotates a GameObject over an amount of frames.
+// Arguments:
+//   [String] gameObject: The name of the GameObject to rotate.
+//   [Work, Number] x: Degrees to rotate on the x axis.
+//   [Work, Number] y: Degrees to rotate on the y axis.
+//   [Work, Number] z: Degrees to rotate on the z axis.
+//   [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
+bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -313,5 +313,17 @@ bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
 //   [Work, Number] relativeHeight: Unknown. (Default is 0.75)
 //   [Work, Number] relativeLower: Unknown. (Default is -0.5)
-//   [Work, Number] duration: Unknown. (Default is 0.5)
+//   [Work, Number] The time in seconds that the jump will take. (Default is 0.5)
 bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Makes the player ledge jump with the given parameters, while rotating a given GameObject over an amount of frames.
+// Arguments:
+//   [String] gameObject: The name of the GameObject to rotate.
+//   [Work, Number] x: Degrees to rotate on the x axis.
+//   [Work, Number] y: Degrees to rotate on the y axis.
+//   [Work, Number] z: Degrees to rotate on the z axis.
+//   [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
+//   [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
+//   [Work, Number] relativeHeight: Unknown. (Default is 0.75)
+//   [Work, Number] relativeLower: Unknown. (Default is -0.5)
+bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -307,3 +307,11 @@ bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] z: Degrees to rotate on the z axis.
 //   [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
 bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Makes the player ledge jump with the given parameters.
+// Arguments:
+//   [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
+//   [Work, Number] relativeHeight: Unknown. (Default is 0.75)
+//   [Work, Number] relativeLower: Unknown. (Default is -0.5)
+//   [Work, Number] duration: Unknown. (Default is 0.5)
+bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -291,3 +291,10 @@ bool DelPoffin(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [Work] result: The work in which to put the result in.
 bool TrainerDefeatedCount(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Attaches the given GameObject to the given parent transform.
+// Arguments:
+//   [String] entity: The name of the GameObject to attach. "HERO" will refer to the player.
+//   [String] parent: The name of the GameObject that will be the new parent. "HERO" will refer to the player.
+//   [Work, Number] keepWorldPosition: If the child GameObject should keep its current world position. 0 is false and 1 is true.
+bool AttachTransform(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/gameobject_rotate.cpp
+++ b/src/mod/features/commands/gameobject_rotate.cpp
@@ -1,0 +1,62 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/UnityEngine/GameObject.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+static float origRotX = 0.0f;
+static float origRotY = 0.0f;
+static float origRotZ = 0.0f;
+
+bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    //Logger::log("_GAMEOBJECT_ROTATE\n");
+
+    system_load_typeinfo(0x3f9a);
+    system_load_typeinfo(0x438c);
+    system_load_typeinfo(0x45dc);
+    system_load_typeinfo(0x4af3);
+    system_load_typeinfo(0x5a55);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    auto objTF = FindTransform(GetStringText(manager, args->m_Items[1]));
+
+    int32_t deltaX = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t deltaY = GetWorkOrIntValue(args->m_Items[3]);
+    int32_t deltaZ = GetWorkOrIntValue(args->m_Items[4]);
+    int32_t frames = GetWorkOrIntValue(args->m_Items[5]);
+
+    float totalTime = frames * 0.03333334;
+    float currDeltaX = deltaX * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaY = deltaY * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaZ = deltaZ * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+
+    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
+        auto origPos = objTF->get_localEulerAngles();
+        origRotX = origPos.fields.x;
+        origRotY = origPos.fields.y;
+        origRotZ = origPos.fields.z;
+    }
+
+    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
+        Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+
+        auto currRot = objTF->get_localEulerAngles();
+        currRot.fields.x += currDeltaX;
+        currRot.fields.y += currDeltaY;
+        currRot.fields.z += currDeltaZ;
+        objTF->set_localEulerAngles(currRot);
+
+        return false;
+    }
+    else {
+        auto currRot = objTF->get_localEulerAngles();
+        currRot.fields.x = origRotX + deltaX;
+        currRot.fields.y = origRotY + deltaY;
+        currRot.fields.z = origRotZ + deltaZ;
+        objTF->set_localEulerAngles(currRot);
+
+        return true;
+    }
+}

--- a/src/mod/features/commands/gameobject_rotate.cpp
+++ b/src/mod/features/commands/gameobject_rotate.cpp
@@ -5,6 +5,8 @@
 #include "features/commands/utils/cmd_utils.h"
 #include "logger/logger.h"
 
+static bool rot_startedRotating = false;
+
 static float origRotX = 0.0f;
 static float origRotY = 0.0f;
 static float origRotZ = 0.0f;
@@ -32,14 +34,16 @@ bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager)
     float currDeltaY = deltaY * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
     float currDeltaZ = deltaZ * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
 
-    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
+    if (!rot_startedRotating && Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
         auto origPos = objTF->get_localEulerAngles();
         origRotX = origPos.fields.x;
         origRotY = origPos.fields.y;
         origRotZ = origPos.fields.z;
-    }
 
-    if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
+        rot_startedRotating = true;
+        return false;
+    }
+    else if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
         Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
 
         auto currRot = objTF->get_localEulerAngles();
@@ -57,6 +61,7 @@ bool GameObjectRotate(Dpr::EvScript::EvDataManager::Object* manager)
         currRot.fields.z = origRotZ + deltaZ;
         objTF->set_localEulerAngles(currRot);
 
+        rot_startedRotating = false;
         return true;
     }
 }

--- a/src/mod/features/commands/jump_and_rotate.cpp
+++ b/src/mod/features/commands/jump_and_rotate.cpp
@@ -9,42 +9,37 @@
 
 static bool jar_initializedJump = false;
 static bool jar_startedRotating = false;
-static float jar_origRotX = 0.0f;
-static float jar_origRotY = 0.0f;
-static float jar_origRotZ = 0.0f;
 
-static bool jar_rotDone = false;
+static float jar_accumulatedAngle = 0.0f;
+
 static bool jar_jumpDone = false;
+static bool jar_rotDone = false;
 
-bool JumpAndRotate_Rotate(UnityEngine::Transform::Object* objTF, float totalTime, float currDeltaX, float currDeltaY, float currDeltaZ, float deltaX, float deltaY, float deltaZ)
+bool JumpAndRotate_Rotate(UnityEngine::Transform::Object* objTF, float totalTime, UnityEngine::Vector3::Object axis, UnityEngine::Vector3::Object pivotPoint, float angle)
 {
     if (!jar_startedRotating && Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
-        auto origPos = objTF->get_localEulerAngles();
-        jar_origRotX = origPos.fields.x;
-        jar_origRotY = origPos.fields.y;
-        jar_origRotZ = origPos.fields.z;
-
         jar_startedRotating = true;
+        jar_accumulatedAngle = 0.0f;
         return false;
     }
-    else if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
-        Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+    else if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime &&
+        jar_accumulatedAngle + std::abs(angle * Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime) < std::abs(angle)) {
 
-        auto currRot = objTF->get_localEulerAngles();
-        currRot.fields.x += currDeltaX;
-        currRot.fields.y += currDeltaY;
-        currRot.fields.z += currDeltaZ;
-        objTF->set_localEulerAngles(currRot);
+        Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+        float addedAngle = angle * Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+        jar_accumulatedAngle += std::abs(addedAngle);
+
+        objTF->RotateAround(pivotPoint, axis, addedAngle);
 
         return false;
     }
     else {
-        auto currRot = objTF->get_localEulerAngles();
-        currRot.fields.x = jar_origRotX + deltaX;
-        currRot.fields.y = jar_origRotY + deltaY;
-        currRot.fields.z = jar_origRotZ + deltaZ;
-        objTF->set_localEulerAngles(currRot);
+        float angleError = std::abs(angle) - jar_accumulatedAngle;
 
+        if (angle > 0.0f)
+            objTF->RotateAround(pivotPoint, axis, angleError);
+        else
+            objTF->RotateAround(pivotPoint, axis, -angleError);
         jar_startedRotating = false;
         return true;
     }
@@ -101,6 +96,7 @@ bool JumpAndRotate_Jump(Dpr::EvScript::EvDataManager::Object* manager, FieldPlay
 bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager) {
     //Logger::log("_JUMP_AND_ROTATE\n");
 
+    system_load_typeinfo(0x2a5e);
     system_load_typeinfo(0x3f9a);
     system_load_typeinfo(0x438c);
     system_load_typeinfo(0x45dc);
@@ -122,17 +118,32 @@ bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager) {
     int32_t deltaZ = GetWorkOrIntValue(args->m_Items[4]);
     int32_t frames = GetWorkOrIntValue(args->m_Items[5]);
 
-    float totalTime = frames * 0.03333334;
-    float currDeltaX = deltaX * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
-    float currDeltaY = deltaY * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
-    float currDeltaZ = deltaZ * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    UnityEngine::Vector3::Object axis = { .fields = { .x = 0.0f,  .y = 0.0f,  .z = 0.0f,  } };
+    float angle = 0.0f;
+    if (deltaX > 0 || deltaX < 0) {
+        axis = { .fields = { .x = 1.0f,  .y = 0.0f,  .z = 0.0f,  } };
+        angle = (float)deltaX;
+    }
+    else if (deltaY > 0 || deltaY < 0) {
+        axis = { .fields = { .x = 0.0f,  .y = 1.0f,  .z = 0.0f,  } };
+        angle = (float)deltaY;
+    }
+    else if (deltaZ > 0 || deltaZ < 0) {
+        axis = { .fields = { .x = 0.0f,  .y = 0.0f,  .z = 1.0f,  } };
+        angle = (float)deltaZ;
+    }
 
-    float moveDistance   = args->max_length > 6 ? GetWorkOrFloatValue(args->m_Items[6]) : 2.0f;
-    float relativeHeight = args->max_length > 7 ? GetWorkOrFloatValue(args->m_Items[7]) : 0.75f;
-    float relativeLower  = args->max_length > 8 ? GetWorkOrFloatValue(args->m_Items[8]) : -0.5f;
+    auto pivot = FindTransform(GetStringText(manager, args->m_Items[6]));
+    auto pivotPoint = pivot->get_position();
+
+    float totalTime = frames * 0.03333334;
+
+    float moveDistance   = args->max_length > 6 ? GetWorkOrFloatValue(args->m_Items[7]) : 2.0f;
+    float relativeHeight = args->max_length > 7 ? GetWorkOrFloatValue(args->m_Items[8]) : 0.75f;
+    float relativeLower  = args->max_length > 8 ? GetWorkOrFloatValue(args->m_Items[9]) : -0.5f;
 
     if (!jar_rotDone)
-        jar_rotDone = JumpAndRotate_Rotate(objTF, totalTime, currDeltaX, currDeltaY, currDeltaZ, deltaX, deltaY, deltaZ);
+        jar_rotDone = JumpAndRotate_Rotate(objTF, totalTime, axis, pivotPoint, angle);
     if (!jar_jumpDone)
         jar_jumpDone = JumpAndRotate_Jump(manager, player, moveDistance, relativeHeight, relativeLower, totalTime);
 

--- a/src/mod/features/commands/jump_and_rotate.cpp
+++ b/src/mod/features/commands/jump_and_rotate.cpp
@@ -1,0 +1,147 @@
+#include "externals/Audio/AudioManager.h"
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/FieldManager.h"
+#include "externals/UnityEngine/GameObject.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+static bool jar_initializedJump = false;
+static bool jar_startedRotating = false;
+static float jar_origRotX = 0.0f;
+static float jar_origRotY = 0.0f;
+static float jar_origRotZ = 0.0f;
+
+static bool jar_rotDone = false;
+static bool jar_jumpDone = false;
+
+bool JumpAndRotate_Rotate(UnityEngine::Transform::Object* objTF, float totalTime, float currDeltaX, float currDeltaY, float currDeltaZ, float deltaX, float deltaY, float deltaZ)
+{
+    if (!jar_startedRotating && Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait == 0.0f) {
+        auto origPos = objTF->get_localEulerAngles();
+        jar_origRotX = origPos.fields.x;
+        jar_origRotY = origPos.fields.y;
+        jar_origRotZ = origPos.fields.z;
+
+        jar_startedRotating = true;
+        return false;
+    }
+    else if (Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait <= totalTime) {
+        Dpr::EvScript::EvDataManager::get_Instanse()->fields._timeWait += Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime;
+
+        auto currRot = objTF->get_localEulerAngles();
+        currRot.fields.x += currDeltaX;
+        currRot.fields.y += currDeltaY;
+        currRot.fields.z += currDeltaZ;
+        objTF->set_localEulerAngles(currRot);
+
+        return false;
+    }
+    else {
+        auto currRot = objTF->get_localEulerAngles();
+        currRot.fields.x = jar_origRotX + deltaX;
+        currRot.fields.y = jar_origRotY + deltaY;
+        currRot.fields.z = jar_origRotZ + deltaZ;
+        objTF->set_localEulerAngles(currRot);
+
+        jar_startedRotating = false;
+        return true;
+    }
+}
+
+bool JumpAndRotate_Jump(Dpr::EvScript::EvDataManager::Object* manager, FieldPlayerEntity::Object* player, float moveDistance, float relativeHeight, float relativeLower, float duration)
+{
+    if (jar_initializedJump)
+    {
+        bool done = false;
+
+        auto oldPos = player->cast<BaseEntity>()->get_transform()->get_position();
+        auto newPos = player->fields._path->Process(manager->fields._deltatime, &done);
+        player->cast<BaseEntity>()->get_transform()->set_position(newPos);
+
+        if (player->fields._animationPlayer->get_currentIndex() == 20 && newPos.fields.y < oldPos.fields.y)
+            player->PlayJumpLoop();
+
+        if (done)
+        {
+            FieldManager::getClass()->initIfNeeded();
+            FieldManager::getClass()->static_fields->_Instance_k__BackingField->RequestAttributeEffect(player->cast<FieldObjectEntity>(), 1);
+            if (player->IsRideBicycle())
+            {
+                Audio::AudioManager::getClass()->initIfNeeded();
+                Audio::AudioManager::get_Instance()->PlaySe(2667891493, nullptr);
+            }
+
+            player->PlayJumpEnd();
+            player->fields.isLanding = true;
+
+            jar_initializedJump = false;
+            return true;
+        }
+
+        return false;
+    }
+    else
+    {
+        jar_initializedJump = true;
+
+        player->fields.isLanding = false;
+        player->fields._path->Startup(player->cast<BaseEntity>()->get_transform(), moveDistance, relativeHeight, relativeLower, duration);
+
+        FieldManager::getClass()->initIfNeeded();
+        FieldManager::getClass()->static_fields->_Instance_k__BackingField->RequestAttributeSE(player->cast<FieldObjectEntity>(), 1);
+
+        player->PlayJumpStart();
+
+        return false;
+    }
+}
+
+bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager) {
+    //Logger::log("_JUMP_AND_ROTATE\n");
+
+    system_load_typeinfo(0x3f9a);
+    system_load_typeinfo(0x438c);
+    system_load_typeinfo(0x45dc);
+    system_load_typeinfo(0x4989);
+    system_load_typeinfo(0x4a68);
+    system_load_typeinfo(0x4a72);
+    system_load_typeinfo(0x4af3);
+    system_load_typeinfo(0x5a55);
+    system_load_typeinfo(0x6c0b);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    EntityManager::getClass()->initIfNeeded();
+    auto player = EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField;
+    auto objTF = FindTransform(GetStringText(manager, args->m_Items[1]));
+
+    int32_t deltaX = GetWorkOrIntValue(args->m_Items[2]);
+    int32_t deltaY = GetWorkOrIntValue(args->m_Items[3]);
+    int32_t deltaZ = GetWorkOrIntValue(args->m_Items[4]);
+    int32_t frames = GetWorkOrIntValue(args->m_Items[5]);
+
+    float totalTime = frames * 0.03333334;
+    float currDeltaX = deltaX * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaY = deltaY * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+    float currDeltaZ = deltaZ * (Dpr::EvScript::EvDataManager::get_Instanse()->fields._deltatime / totalTime);
+
+    float moveDistance   = args->max_length > 6 ? GetWorkOrFloatValue(args->m_Items[6]) : 2.0f;
+    float relativeHeight = args->max_length > 7 ? GetWorkOrFloatValue(args->m_Items[7]) : 0.75f;
+    float relativeLower  = args->max_length > 8 ? GetWorkOrFloatValue(args->m_Items[8]) : -0.5f;
+
+    if (!jar_rotDone)
+        jar_rotDone = JumpAndRotate_Rotate(objTF, totalTime, currDeltaX, currDeltaY, currDeltaZ, deltaX, deltaY, deltaZ);
+    if (!jar_jumpDone)
+        jar_jumpDone = JumpAndRotate_Jump(manager, player, moveDistance, relativeHeight, relativeLower, totalTime);
+
+    if (jar_rotDone && jar_jumpDone)
+    {
+        jar_rotDone = false;
+        jar_jumpDone = false;
+        return true;
+    }
+
+    return false;
+}

--- a/src/mod/features/commands/ledge_jump.cpp
+++ b/src/mod/features/commands/ledge_jump.cpp
@@ -44,6 +44,7 @@ bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager) {
             }
 
             player->PlayJumpEnd();
+            player->fields.isLanding = true;
 
             initializedJump = false;
             return true;
@@ -60,8 +61,7 @@ bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager) {
 
         initializedJump = true;
 
-        Logger::log("_LEDGE_JUMP with moveDistance = %f, relativeHeight = %f, relativeLower = %f, duration = %f\n", moveDistance, relativeHeight, relativeLower, duration);
-
+        player->fields.isLanding = false;
         player->fields._path->Startup(player->cast<BaseEntity>()->get_transform(), moveDistance, relativeHeight, relativeLower, duration);
 
         FieldManager::getClass()->initIfNeeded();

--- a/src/mod/features/commands/ledge_jump.cpp
+++ b/src/mod/features/commands/ledge_jump.cpp
@@ -1,0 +1,74 @@
+#include "externals/Audio/AudioManager.h"
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/FieldManager.h"
+#include "externals/UnityEngine/GameObject.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+static bool initializedJump = false;
+
+bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager) {
+    //Logger::log("_LEDGE_JUMP\n");
+
+    system_load_typeinfo(0x4989);
+    system_load_typeinfo(0x4a68);
+    system_load_typeinfo(0x4a72);
+    system_load_typeinfo(0x6c0b);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    EntityManager::getClass()->initIfNeeded();
+    auto player = EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField;
+
+    if (initializedJump)
+    {
+        bool done = false;
+
+        auto oldPos = player->cast<BaseEntity>()->get_transform()->get_position();
+        auto newPos = player->fields._path->Process(manager->fields._deltatime, &done);
+        player->cast<BaseEntity>()->get_transform()->set_position(newPos);
+
+        if (player->fields._animationPlayer->get_currentIndex() == 20 && newPos.fields.y < oldPos.fields.y)
+            player->PlayJumpLoop();
+
+        if (done)
+        {
+            FieldManager::getClass()->initIfNeeded();
+            FieldManager::getClass()->static_fields->_Instance_k__BackingField->RequestAttributeEffect(player->cast<FieldObjectEntity>(), 1);
+            if (player->IsRideBicycle())
+            {
+                Audio::AudioManager::getClass()->initIfNeeded();
+                Audio::AudioManager::get_Instance()->PlaySe(2667891493, nullptr);
+            }
+
+            player->PlayJumpEnd();
+
+            initializedJump = false;
+            return true;
+        }
+
+        return false;
+    }
+    else
+    {
+        float moveDistance   = args->max_length > 1 ? GetWorkOrFloatValue(args->m_Items[1]) : 2.0f;
+        float relativeHeight = args->max_length > 2 ? GetWorkOrFloatValue(args->m_Items[2]) : 0.75f;
+        float relativeLower  = args->max_length > 3 ? GetWorkOrFloatValue(args->m_Items[3]) : -0.5f;
+        float duration       = args->max_length > 4 ? GetWorkOrFloatValue(args->m_Items[4]) : 0.5f;
+
+        initializedJump = true;
+
+        Logger::log("_LEDGE_JUMP with moveDistance = %f, relativeHeight = %f, relativeLower = %f, duration = %f\n", moveDistance, relativeHeight, relativeLower, duration);
+
+        player->fields._path->Startup(player->cast<BaseEntity>()->get_transform(), moveDistance, relativeHeight, relativeLower, duration);
+
+        FieldManager::getClass()->initIfNeeded();
+        FieldManager::getClass()->static_fields->_Instance_k__BackingField->RequestAttributeSE(player->cast<FieldObjectEntity>(), 1);
+
+        player->PlayJumpStart();
+
+        return false;
+    }
+}

--- a/src/mod/features/commands/utils/cmd_utils.cpp
+++ b/src/mod/features/commands/utils/cmd_utils.cpp
@@ -1,5 +1,6 @@
 #include "externals/il2cpp-api.h"
 
+#include "externals/EntityManager.h"
 #include "externals/EvData.h"
 #include "externals/FieldPoketch.h"
 #include "externals/PlayerWork.h"
@@ -115,4 +116,18 @@ bool AddPokemonToParty(int32_t monsno, int32_t formno, uint32_t level, uint8_t m
     }
 
     return added;
+}
+
+UnityEngine::Transform::Object* FindTransform(System::String::Object* name)
+{
+    EntityManager::getClass()->initIfNeeded();
+
+    auto go = System::String::op_Equality(name, System::String::Create("HERO")) ?
+              EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField->cast<UnityEngine::Component>()->get_gameObject()->instance() :
+              UnityEngine::GameObject::Find(name);
+
+    if (go == nullptr)
+        return nullptr;
+    else
+        return go->get_transform();
 }

--- a/src/mod/features/commands/utils/cmd_utils.h
+++ b/src/mod/features/commands/utils/cmd_utils.h
@@ -31,3 +31,8 @@ bool AddPokemonToParty(int32_t monsno, int32_t formno, uint32_t level, uint8_t m
 // Returns the string from the provided argument if its type is string.
 // Returns "" otherwise.
 System::String::Object* GetStringText(Dpr::EvScript::EvDataManager::Object* manager, EvData::Aregment::Object arg);
+
+// Finds a specific transform in the scene.
+// A value of "HERO" will return the active player's transform.
+// Returns null if it can't find it.
+UnityEngine::Transform::Object* FindTransform(System::String::Object* name);

--- a/src/mod/features/fake_stopdata.cpp
+++ b/src/mod/features/fake_stopdata.cpp
@@ -1,0 +1,81 @@
+#include "exlaunch.hpp"
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/FieldEventEntity.h"
+#include "externals/FlagWork.h"
+#include "externals/System/String.h"
+
+#include "logger/logger.h"
+
+HOOK_DEFINE_TRAMPOLINE(Dpr_EvScript_EvDataManager$$OnEventEnter) {
+    static void Callback(Dpr::EvScript::EvDataManager::Object* __this, float deltaTime, FieldEventEntity::Object* eventEntity) {
+        Orig(__this, deltaTime, eventEntity);
+
+        system_load_typeinfo(0x4382);
+
+        auto player = EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField;
+        if (player->fields._currentSequence_k__BackingField != 4096)
+            return;
+
+        // Not any of these types
+        if (__this->fields._liftEntity == nullptr &&
+            __this->fields._nagisaGymGearEntity == nullptr &&
+            __this->fields._nomoseGymSwitchEntity == nullptr &&
+            __this->fields._eyePaintingEntity == nullptr &&
+            __this->fields._embankmentEntity == nullptr &&
+            __this->fields._doorEntity == nullptr) {
+
+            Logger::log("[Fake StopData] Not any specific type\n");
+
+            // Starts with "STOPDATA_"
+            if (eventEntity->fields._enityName->StartsWith(System::String::Create("STOPDATA_"))) {
+
+                Logger::log("[Fake StopData] Starts with \"STOPDATA_\"\n");
+
+                // Grab the script name after the prefix
+                auto script = eventEntity->fields._enityName->Substring(9);
+
+                // Check the assigned work and that the script name is not empty
+                if ((eventEntity->fields.locatorIndex == 500 || FlagWork::GetWork(eventEntity->fields.locatorIndex) == eventEntity->fields.clipIndex) &&
+                    !System::String::IsNullOrEmpty(script)) {
+
+                    Logger::log("[Fake StopData] Work is good\n");
+                    Logger::log("[Fake StopData] checkHeight is %d\n", eventEntity->fields.checkHeight);
+
+                    __this->PlayerInputActive(false, false);
+                    /*UnityEngine::RectInt::Object rect = { .fields = {
+                            .m_XMin =   (int32_t)-eventEntity->cast<UnityEngine::Component>()->get_transform()->get_position().fields.x,
+                            .m_YMin =   (int32_t)eventEntity->cast<UnityEngine::Component>()->get_transform()->get_position().fields.z - 1,
+                            .m_Width =  (int32_t)eventEntity->fields.size.fields.x,
+                            .m_Height = (int32_t)eventEntity->fields.size.fields.y,
+                        }
+                    };
+                    auto playerNowGrid = FieldObjectEntity::PositionToGrid(player->fields.worldPosition);
+                    __this->fields._heroMoveGridCenterFrontDir = __this->SetupHeroMoveGridCenterFrontDir(&rect, &playerNowGrid, &player->fields._oldGridPosition_k__BackingField);*/
+                    player->StopCrossInputAndBicycle();
+                    __this->JumpLabel(script, nullptr);
+
+                    Logger::log("[Fake StopData] Script %s should start soon\n", script->asCString().c_str());
+                }
+            }
+        }
+    }
+};
+
+HOOK_DEFINE_TRAMPOLINE(FieldEventEntity$$Awake) {
+    static void Callback(FieldEventEntity::Object* __this) {
+        Orig(__this);
+
+        // Starts with "STOPDATA_"
+        if (__this->fields._enityName->StartsWith(System::String::Create("STOPDATA_"))) {
+            __this->fields.checkHeight = true;
+        }
+    }
+};
+
+void exl_fake_stopdata_main() {
+    Dpr_EvScript_EvDataManager$$OnEventEnter::InstallAtOffset(0x02c4cd00);
+    FieldEventEntity$$Awake::InstallAtOffset(0x01792d50);
+};

--- a/src/mod/features/fake_stopdata.cpp
+++ b/src/mod/features/fake_stopdata.cpp
@@ -27,12 +27,8 @@ HOOK_DEFINE_TRAMPOLINE(Dpr_EvScript_EvDataManager$$OnEventEnter) {
             __this->fields._embankmentEntity == nullptr &&
             __this->fields._doorEntity == nullptr) {
 
-            Logger::log("[Fake StopData] Not any specific type\n");
-
             // Starts with "STOPDATA_"
             if (eventEntity->fields._enityName->StartsWith(System::String::Create("STOPDATA_"))) {
-
-                Logger::log("[Fake StopData] Starts with \"STOPDATA_\"\n");
 
                 // Grab the script name after the prefix
                 auto script = eventEntity->fields._enityName->Substring(9);
@@ -41,19 +37,6 @@ HOOK_DEFINE_TRAMPOLINE(Dpr_EvScript_EvDataManager$$OnEventEnter) {
                 if ((eventEntity->fields.locatorIndex == 500 || FlagWork::GetWork(eventEntity->fields.locatorIndex) == eventEntity->fields.clipIndex) &&
                     !System::String::IsNullOrEmpty(script)) {
 
-                    Logger::log("[Fake StopData] Work is good\n");
-                    Logger::log("[Fake StopData] checkHeight is %d\n", eventEntity->fields.checkHeight);
-
-                    __this->PlayerInputActive(false, false);
-                    /*UnityEngine::RectInt::Object rect = { .fields = {
-                            .m_XMin =   (int32_t)-eventEntity->cast<UnityEngine::Component>()->get_transform()->get_position().fields.x,
-                            .m_YMin =   (int32_t)eventEntity->cast<UnityEngine::Component>()->get_transform()->get_position().fields.z - 1,
-                            .m_Width =  (int32_t)eventEntity->fields.size.fields.x,
-                            .m_Height = (int32_t)eventEntity->fields.size.fields.y,
-                        }
-                    };
-                    auto playerNowGrid = FieldObjectEntity::PositionToGrid(player->fields.worldPosition);
-                    __this->fields._heroMoveGridCenterFrontDir = __this->SetupHeroMoveGridCenterFrontDir(&rect, &playerNowGrid, &player->fields._oldGridPosition_k__BackingField);*/
                     player->StopCrossInputAndBicycle();
                     __this->JumpLabel(script, nullptr);
 

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -76,6 +76,9 @@ void exl_evolution_methods_main();
 // Redirects TM learnsets to external JSON files that contain more data.
 void exl_extended_tm_learnsets_main();
 
+// Allows using FieldEventEntity components in a map prefab to simulate stopdata.
+void exl_fake_stopdata_main();
+
 // Allows dynamically changing Pokémon icons based on the Pokémon's Form Argument.
 void exl_form_arg_icons_main();
 

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -122,6 +122,8 @@ void CallFeatureHooks()
         exl_pushable_entities_main();
     if (IsActivatedFeature(array_index(FEATURES, "Select Poffin Case")))
         exl_select_poffin_case_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Fake StopData")))
+        exl_fake_stopdata_main();
 
     exl_debug_features_main();
     exl_items_changes_main();

--- a/src/mod/features/npc_collision_audio.cpp
+++ b/src/mod/features/npc_collision_audio.cpp
@@ -5,19 +5,24 @@
 #include "externals/UnityEngine/Vector2.h"
 #include "externals/UnityEngine/Vector3.h"
 
+void PlayerBonkCheck(FieldPlayerEntity::Object* player)
+{
+    system_load_typeinfo(0x35f1);
+    GameController::getClass()->initIfNeeded();
+    bool movingStick = UnityEngine::Vector2::op_Inequality(GameController::getClass()->static_fields->analogStickL, UnityEngine::Vector2::get_zero());
+    bool movingDpad = UnityEngine::Vector2::op_Inequality(GameController::getClass()->static_fields->digitalPad, UnityEngine::Vector2::get_zero());
+
+    if (movingStick || movingDpad)
+    {
+        player->fields._hit_se_request = true;
+    }
+}
+
 HOOK_DEFINE_TRAMPOLINE(FieldPlayerEntity_CheckMapCollision_AfterCharacterHit) {
     static bool Callback(FieldPlayerEntity::Object* __this, UnityEngine::Vector3::Fields moveVelocity, UnityEngine::Vector3::Object* afterMoveVector, UnityEngine::Vector3::Object* hitNormal) {
         bool collision = Orig(__this, moveVelocity, afterMoveVector, hitNormal);
 
-        system_load_typeinfo(0x35f1);
-        GameController::getClass()->initIfNeeded();
-        bool movingStick = UnityEngine::Vector2::op_Inequality(GameController::getClass()->static_fields->analogStickL, UnityEngine::Vector2::get_zero());
-        bool movingDpad = UnityEngine::Vector2::op_Inequality(GameController::getClass()->static_fields->digitalPad, UnityEngine::Vector2::get_zero());
-
-        if (movingStick || movingDpad)
-        {
-            __this->fields._hit_se_request = true;
-        }
+        PlayerBonkCheck(__this);
 
         return collision;
     }

--- a/src/mod/features/pushable_entities.cpp
+++ b/src/mod/features/pushable_entities.cpp
@@ -263,7 +263,6 @@ void ContactLabelCallOnPush(FieldPlayerEntity::Object* __this, float deltaTime) 
             entity->fields.EventParams->fields.CharacterGraphicsIndex == CONTACTABLE_OGI)
         {
             UnityEngine::Vector2Int::Object outgrid {};
-            UnityEngine::Vector2Int::Object breakableGrid {};
             bool hit = false;
             bool pushed = Dpr::Field::WA_Kairiki::PushEntity(__this, dir, entity, &outgrid, &hit);
 


### PR DESCRIPTION
Closes #169.
Contributes to https://github.com/TeamLumi/Romhack_Unity/issues/44.

- Adds the following commands:
  - _ATTACH_TRANSFORM (1277):
    - Attaches the given GameObject to the given parent transform.
    - [String] entity: The name of the GameObject to attach. "HERO" will refer to the player.
    - [String] parent: The name of the GameObject that will be the new parent. "HERO" will refer to the player.
    - [Work, Number] keepWorldPosition: If the child GameObject should keep its current world position. 0 is false and 1 is true.
  - _GAMEOBJECT_ROTATE (1278):
    - Rotates a GameObject over an amount of frames.
    - [String] gameObject: The name of the GameObject to rotate.
    - [Work, Number] x: Degrees to rotate on the x axis.
    - [Work, Number] y: Degrees to rotate on the y axis.
    - [Work, Number] z: Degrees to rotate on the z axis.
    - [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
  - _LEDGE_JUMP (1279):
    - Makes the player ledge jump with the given parameters.
    - [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
    - [Work, Number] relativeHeight: Unknown. (Default is 0.75)
    - [Work, Number] relativeLower: Unknown. (Default is -0.5)
    - [Work, Number] The time in seconds that the jump will take. (Default is 0.5)
  - _JUMP_AND_ROTATE (1280):
    - Makes the player ledge jump with the given parameters, while rotating a given GameObject over an amount of frames around a specific pivot.
    - [String] gameObject: The name of the GameObject to rotate.
    - [Work, Number] x: Degrees to rotate on the x axis.
    - [Work, Number] y: Degrees to rotate on the y axis.
    - [Work, Number] z: Degrees to rotate on the z axis.
    - [Work, Number] frames: Amount of frames to do the movement over. (30 fps)
    - [String] pivot: The name of the GameObject that will act as a pivot point.
    - [Work, Number] moveDistance: The amount of tiles to jump. (Default 2.0)
    - [Work, Number] relativeHeight: Unknown. (Default is 0.75)
    - [Work, Number] relativeLower: Unknown. (Default is -0.5)
- Implements "contactable" placedata, which use OGI [TBD].
  - Whenever the player pushes up against them (similarly to a strength boulder), their _TalkLabel_ is called (as opposed to their _ContactLabel_).
  - This feature is tied to the "Pushable Entities" feature in features.json.
- Implements a first draft of the new "Fake StopData" feature.
  - This affects FieldEventEntity placed in a map prefab that have an _enityName that starts with "STOPDATA_".
  - Whenever they are stepped on, if the work with index locatorIndex (acts as the work index) has a value equal to clipIndex (acts as the work value), a script is triggered.
  - The name of the script that is triggered is the part after "STOPDATA_" in _enityName.
- Adds the zone codes and names, as well as the area codes and names of the last remaining ones in preparation for Re:Lumi.