### PR TITLE
Yet More Command Changes

### DIFF
--- a/src/mod/data/balls.h
+++ b/src/mod/data/balls.h
@@ -39,6 +39,7 @@ static constexpr const char* BALLS[] = {
         "Vintage Gigaton Ball",
         "Vintage Origin Ball",
         "Vintage GS Ball",
+        "Clone Ball",
 };
 
 constexpr int BALL_COUNT = sizeof(BALLS) / sizeof(BALLS[0]);

--- a/src/mod/data/items.h
+++ b/src/mod/data/items.h
@@ -1311,10 +1311,10 @@ static constexpr const char* ITEMS[] = {
     "Vintage GS Ball", // ★Lep1865
     "Partner's Bandana", // ★Lep1829
     "Mini Clothing Trunk", // ★Boo5340
+    "Pro Vitamin Case", // ★Boo5506
+    "Clone Ball", // ★Boo5435
+    "Cynthia's Rage Candy Bar", // ★Boo5602
 
-    "★Boo5506",
-    "★Boo5435",
-    "★Boo5602",
     "★Boo5733",
     "★Boo5235",
     "★Boo5351",

--- a/src/mod/externals/BaseEntity.h
+++ b/src/mod/externals/BaseEntity.h
@@ -56,6 +56,10 @@ struct BaseEntity : ILClass<BaseEntity> {
         external<void>(0x01d67740, this, posProxy);
     }
 
+    inline void SetYawAngleDirect(float angle) {
+        external<void>(0x01d67790, this, angle);
+    }
+
     static_assert(sizeof(VTable) == 0xe0);
     static_assert(offsetof(VTable, _4_get_entityType) == 0x40);
     static_assert(offsetof(VTable, _5_GetAnimationPlayer) == 0x50);

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1288,6 +1288,7 @@ namespace Dpr::EvScript {
             _GAMEOBJECT_ROTATE = 1278,
             _LEDGE_JUMP = 1279,
             _JUMP_AND_ROTATE = 1280,
+            _WAIT_FOR_GAMEOBJECT = 1281,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Pml/PmlUse.h
+++ b/src/mod/externals/Pml/PmlUse.h
@@ -3,12 +3,13 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/XLSXContent/ItemTable.h"
+#include "externals/XLSXContent/PersonalTable.h"
 
 namespace Pml {
     struct PmlUse : ILClass<PmlUse, 0x04c5b4d0> {
         struct Fields {
             bool isAutoLoad;
-            void* personalTotal; // XLSXContent_PersonalTable_o*
+            XLSXContent::PersonalTable::Object* personalTotal;
             void* growTableTotal; // XLSXContent_GrowTable_o*
             void* evolveTableTotal; // XLSXContent_EvolveTable_o*
             void* wazaOboeTotal; // XLSXContent_WazaOboeTable_o*

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -40,6 +40,10 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(FirstPokeNoGet(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_HONEY_TREE_BTL_SET:
                     return HandleCmdStepper(HoneyTreeBattleSet(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_SXY_DIR_CHANGE:
+                    return HandleCmdStepper(ObjDirChange(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_OBJ_DIR_CHANGE:
+                    return HandleCmdStepper(ObjDirChange(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_STOP_EFFECT:
                     return HandleCmdStepper(StopEffect(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_TEMOTI_FORMNO:
@@ -153,6 +157,8 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_FIRST_POKE_SELECT_PROC);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_FIRST_POKE_NO_GET);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_HONEY_TREE_BTL_SET);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SXY_DIR_CHANGE);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_OBJ_DIR_CHANGE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_STOP_EFFECT);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_TEMOTI_FORMNO);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_TEMOTI_BOX_FORMNO);

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -136,6 +136,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(LedgeJump(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_JUMP_AND_ROTATE:
                     return HandleCmdStepper(JumpAndRotate(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_WAIT_FOR_GAMEOBJECT:
+                    return HandleCmdStepper(WaitForGameObject(__this));
                 default:
                     break;
             }
@@ -205,4 +207,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_JUMP_AND_ROTATE);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_WAIT_FOR_GAMEOBJECT);
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -334,3 +334,8 @@ bool LedgeJump(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] relativeHeight: Unknown. (Default is 0.75)
 //   [Work, Number] relativeLower: Unknown. (Default is -0.5)
 bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Waits for a specific GameObject to exist. WARNING: Will completely get stuck on this command if it cannot ever find the GameObject.
+// Arguments:
+//   [String] gameObject: The name of the GameObject to wait on.
+bool WaitForGameObject(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -22,6 +22,12 @@ bool FirstPokeNoGet(Dpr::EvScript::EvDataManager::Object* manager);
 //   None.
 bool HoneyTreeBattleSet(Dpr::EvScript::EvDataManager::Object* manager);
 
+// Sets an entity's yaw angle.
+// Arguments:
+//   [String, Work, Number] entity: The entity ID or index to check for.
+//   [Work, Number] angle: The value to set the angle to.
+bool ObjDirChange(Dpr::EvScript::EvDataManager::Object* manager);
+
 // Stops a Field Effect.
 // Arguments:
 //   [Work, Number] index: The index of the field effect to stop. 0-10

--- a/src/mod/features/commands/entity_move.cpp
+++ b/src/mod/features/commands/entity_move.cpp
@@ -16,12 +16,7 @@ bool EntityMove(Dpr::EvScript::EvDataManager::Object* manager)
     system_load_typeinfo(0x45dc);
     EvData::Aregment::Array* args = manager->fields._evArg;
 
-    auto id = GetStringText(manager, args->m_Items[1]);
-    FieldObjectEntity::Object* entity;
-    if (System::String::op_Equality(id, System::String::Create("")))
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(GetWorkOrIntValue(args->m_Items[1]))->instance();
-    else
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->Find_fieldObjectEntity(id)->instance();
+    FieldObjectEntity::Object* entity = FindEntity(manager, args->m_Items[1]);
 
     int32_t deltaX = GetWorkOrIntValue(args->m_Items[2]);
     int32_t deltaY = GetWorkOrIntValue(args->m_Items[3]);

--- a/src/mod/features/commands/ifcoords_call.cpp
+++ b/src/mod/features/commands/ifcoords_call.cpp
@@ -12,12 +12,7 @@ bool IfCoordsCall(Dpr::EvScript::EvDataManager::Object* manager) {
 
     EvData::Aregment::Array* args = manager->fields._evArg;
 
-    auto id = GetStringText(manager, args->m_Items[1]);
-    FieldObjectEntity::Object* entity;
-    if (System::String::op_Equality(id, System::String::Create("")))
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(GetWorkOrIntValue(args->m_Items[1]))->instance();
-    else
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->Find_fieldObjectEntity(id)->instance();
+    FieldObjectEntity::Object* entity = FindEntity(manager, args->m_Items[1]);
 
     auto currentGrid = entity->get_gridPosition();
     int32_t currentX = currentGrid.fields.m_X;

--- a/src/mod/features/commands/ifcoords_jump.cpp
+++ b/src/mod/features/commands/ifcoords_jump.cpp
@@ -12,12 +12,7 @@ bool IfCoordsJump(Dpr::EvScript::EvDataManager::Object* manager) {
 
     EvData::Aregment::Array* args = manager->fields._evArg;
 
-    auto id = GetStringText(manager, args->m_Items[1]);
-    FieldObjectEntity::Object* entity;
-    if (System::String::op_Equality(id, System::String::Create("")))
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->GetFieldObject(GetWorkOrIntValue(args->m_Items[1]))->instance();
-    else
-        entity = Dpr::EvScript::EvDataManager::get_Instanse()->Find_fieldObjectEntity(id)->instance();
+    FieldObjectEntity::Object* entity = FindEntity(manager, args->m_Items[1]);
 
     auto currentGrid = entity->get_gridPosition();
     int32_t currentX = currentGrid.fields.m_X;

--- a/src/mod/features/commands/obj_dir_change.cpp
+++ b/src/mod/features/commands/obj_dir_change.cpp
@@ -1,0 +1,29 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldObjectEntity.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+bool ObjDirChange(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    //Logger::log("_OBJ_DIR_CHANGE\n");
+
+    system_load_typeinfo(0x44d6);
+    system_load_typeinfo(0x45dc);
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    auto entity = FindEntity(manager, args->m_Items[1]);
+    int32_t angle = GetWorkOrIntValue(args->m_Items[2]);
+
+    if (UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)entity, nullptr))
+    {
+        Logger::log("Setting the angle of %s to %d\n", entity->cast<UnityEngine::_Object>()->get_Name()->asCString().c_str(), angle);
+        entity->cast<BaseEntity>()->SetYawAngleDirect(angle + 360);
+    }
+    else
+    {
+        Logger::log("Could not find entity to set the angle of!\n");
+    }
+
+    return true;
+}

--- a/src/mod/features/commands/utils/cmd_utils.cpp
+++ b/src/mod/features/commands/utils/cmd_utils.cpp
@@ -131,3 +131,19 @@ UnityEngine::Transform::Object* FindTransform(System::String::Object* name)
     else
         return go->get_transform();
 }
+
+FieldObjectEntity::Object* FindEntity(Dpr::EvScript::EvDataManager::Object* manager, EvData::Aregment::Object arg)
+{
+    switch ((EvData::ArgType)arg.fields.argType)
+    {
+        case EvData::ArgType::String:
+            return manager->Find_fieldObjectEntity(GetStringText(manager, arg))->instance();
+
+        case EvData::ArgType::Float:
+        case EvData::ArgType::Work:
+            return manager->GetFieldObject(GetWorkOrIntValue(arg))->instance();
+
+        default:
+            return nullptr;
+    }
+}

--- a/src/mod/features/commands/utils/cmd_utils.h
+++ b/src/mod/features/commands/utils/cmd_utils.h
@@ -3,6 +3,7 @@
 #include "externals/il2cpp-api.h"
 
 #include "externals/EvData.h"
+#include "externals/FieldObjectEntity.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
 #include "externals/Dpr/EvScript/EvDataManager.h"
 
@@ -36,3 +37,9 @@ System::String::Object* GetStringText(Dpr::EvScript::EvDataManager::Object* mana
 // A value of "HERO" will return the active player's transform.
 // Returns null if it can't find it.
 UnityEngine::Transform::Object* FindTransform(System::String::Object* name);
+
+// Finds a specific entity.
+// Returns the entity at the given index if the argument is a work or float.
+// Returns the entity with the given ID if the argument is a string.
+// Returns null otherwise.
+FieldObjectEntity::Object* FindEntity(Dpr::EvScript::EvDataManager::Object* manager, EvData::Aregment::Object arg);

--- a/src/mod/features/commands/wait_for_gameobject.cpp
+++ b/src/mod/features/commands/wait_for_gameobject.cpp
@@ -6,7 +6,7 @@
 #include "logger/logger.h"
 
 bool WaitForGameObject(Dpr::EvScript::EvDataManager::Object* manager) {
-    Logger::log("_WAIT_FOR_GAMEOBJECT\n");
+    //Logger::log("_WAIT_FOR_GAMEOBJECT\n");
 
     system_load_typeinfo(0x4af3);
 

--- a/src/mod/features/commands/wait_for_gameobject.cpp
+++ b/src/mod/features/commands/wait_for_gameobject.cpp
@@ -1,0 +1,17 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+#include "externals/UnityEngine/GameObject.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+bool WaitForGameObject(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_WAIT_FOR_GAMEOBJECT\n");
+
+    system_load_typeinfo(0x4af3);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    auto objTF = FindTransform(GetStringText(manager, args->m_Items[1]));
+    return objTF != nullptr && UnityEngine::_Object::op_Inequality(objTF->cast<UnityEngine::_Object>(), nullptr);
+}

--- a/src/mod/ui/debug_menu_hooks.cpp
+++ b/src/mod/ui/debug_menu_hooks.cpp
@@ -8,6 +8,7 @@
 #include "externals/DPData/Form_Enums.h"
 #include "externals/Dpr/Message/MessageEnumData.h"
 #include "externals/FieldCanvas.h"
+#include "externals/Pml/PmlUse.h"
 #include "externals/Pml/PokeParty.h"
 #include "externals/ZukanWork.h"
 #include "save/save.h"
@@ -71,8 +72,12 @@ void setFlyOverride(bool b) {
 
 void setFullDex(int getStatus) {
     for (int i=1; i<=DexSize; i++) {
-        ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, 0, true, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
-        ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, 0, false, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
+        auto formMax = Pml::PmlUse::get_Instance()->fields.personalTotal->fields.Personal->m_Items[i]->fields.form_max;
+
+        for (int j=0; j<formMax; j++) {
+            ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, j, true, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
+            ZukanWork::DebugSet(i, (DPData::GET_STATUS)getStatus, Pml::Sex::UNKNOWN, j, false, (DPData::GET_STATUS)getStatus >= DPData::GET_STATUS::GET);
+        }
 
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::JPN);
         ZukanWork::AddLangFlag(i, Dpr::Message::MessageEnumData::MsgLangId::USA);


### PR DESCRIPTION
- Adds the following new command:
  - _WAIT_FOR_GAMEOBJECT (1281):
    - Waits for a specific GameObject to exist.
    - [String] gameObject: The name of the GameObject to wait on.
- Overrides the following vanilla commands:
  - _SXY_DIR_CHANGE (506) and _OBJ_DIR_CHANGE (509):
    - Sets an entity's yaw angle.
    - Now allows for using the entity index as the first argument.
    - [String, Work, Number] entity: The entity ID or index to check for.
    - [Work, Number] angle: The value to set the angle to.
- Updates the item list and the balls list.
- The option to set the full Pokédex's caught status now applies the status to all forms.