### PR TITLE
Fix for Disabled moves softlock

### DIFF
--- a/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION.h
@@ -1,26 +1,8 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
-#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
 
 namespace Dpr::Battle::Logic {
     struct BTL_ACTION : ILClass<BTL_ACTION> {
-
-        struct PARAM : ILStruct<PARAM> {
-
-            struct Fields {
-                long raw;
-            };
-
-            uint8_t get_gen_cmd() {
-                return external<uint8_t>(0x01f4d680, this);
-            }
-        };
-
-        struct PARAM_OBJ : ILClass<PARAM_OBJ, 0x04c5a7e8> {
-            struct Fields {
-                PARAM::Object value;
-            };
-        };
     };
 }

--- a/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION_PARAM.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION_PARAM.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Dpr::Battle::Logic {
+    struct BTL_ACTION_PARAM : ILStruct<BTL_ACTION_PARAM, 0x04c5a7e8> {
+        struct Fields {
+            long raw;
+        };
+
+        uint8_t get_gen_cmd() {
+            return external<uint8_t>(0x01f4d680, this);
+        }
+
+        void set_fight_cmd(uint8_t value) {
+            external<void>(0x01f4d580, this, value);
+        }
+    };
+}

--- a/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION_PARAM_OBJ.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BTL_ACTION_PARAM_OBJ.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM.h"
+
+namespace Dpr::Battle::Logic {
+    struct BTL_ACTION_PARAM_OBJ : ILClass<BTL_ACTION_PARAM_OBJ, 0x04c5a7e8> {
+        struct Fields {
+            BTL_ACTION_PARAM::Object value;
+        };
+    };
+}

--- a/src/mod/externals/Dpr/Battle/Logic/BTL_CLIENT.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BTL_CLIENT.h
@@ -1,21 +1,24 @@
 #pragma once
 
 #include "externals/il2cpp-api.h"
-#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
-#include "externals/Dpr/Battle/Logic/ServerSendData.h"
-#include "externals/Dpr/Battle/Logic/MainModule.h"
+
 #include "externals/Dpr/Battle/Logic/BattleEnv.h"
+#include "externals/Dpr/Battle/Logic/BattleViewBase.h"
 #include "externals/Dpr/Battle/Logic/BTL_ACTION.h"
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM_OBJ.h"
+#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
+#include "externals/Dpr/Battle/Logic/MainModule.h"
+#include "externals/Dpr/Battle/Logic/ServerSendData.h"
 
 namespace Dpr::Battle::Logic {
     struct BTL_CLIENT : ILClass<BTL_CLIENT> {
         struct Fields {
             Dpr::Battle::Logic::MainModule::Object* m_mainModule;
             Dpr::Battle::Logic::BattleEnv::Object* m_pBattleEnv;
-            void* m_procPoke; // BTL_POKEPARAM_o*
+            Dpr::Battle::Logic::BTL_POKEPARAM::Object* m_procPoke;
             uint8_t m_actCountSum;
             int32_t m_procActionIndex;
-            Dpr::Battle::Logic::BTL_ACTION::PARAM_OBJ::Object* m_procActionUIRet;
+            Dpr::Battle::Logic::BTL_ACTION_PARAM_OBJ::Object* m_procActionUIRet;
             int32_t m_currentActionIndex;
             void* m_recData; // rec_Data_o*
             void* m_btlRecReader; // rec_Reader_o*
@@ -70,8 +73,8 @@ namespace Dpr::Battle::Logic {
             uint8_t m_myPuttablePokeCnt;
             void* m_myChangePokePos; // BtlPokePos_o*
             ushort m_returnDataSerialNumber;
-            void* m_returnDataServerSeq; // ServerSequence_o*
-            void* m_returnDataServerRequest; // ServerRequest_o*
+            uint8_t m_returnDataServerSeq;
+            uint8_t m_returnDataServerRequest;
             void* m_returnDataPtr;
             uint m_returnDataSize;
             uint* m_dummyReturnData;
@@ -92,7 +95,7 @@ namespace Dpr::Battle::Logic {
             void* _m_viewCore; // BattleViewBase_o*
             void* m_viewExpGetDesc; // BattleViewBase_ExpGetDesc_o*
             void* m_viewExpGetResult; // BattleViewBase_ExpGetResult_o*
-            void* m_actionParam; // BTL_ACTION_PARAM_o*
+            BTL_ACTION_PARAM::Array* m_actionParam;
             System::Int32_array* m_cmdArgs;
             void* m_stdVariableArgs; // BTL_CLIENT_VariableArgs_o*
             void* m_tmpVariableArgs; // BTL_CLIENT_VariableArgs_o*
@@ -109,7 +112,7 @@ namespace Dpr::Battle::Logic {
             void* m_pokeSelParam; // PokeSelParam_o*
             void* m_pokeSelResult; // PokeSelResult_o*
             void* m_scProc; // BTL_CLIENT_ServerCmdProc_o*
-            void* m_serverCmd; // ServerCommand_o*
+            uint16_t m_serverCmd;
             int32_t m_scSeq;
             void* m_deadPokePos; // BtlPokePos_o*
             bool m_isLiveRecSeedSetup;
@@ -128,9 +131,16 @@ namespace Dpr::Battle::Logic {
             int32_t scProc_ACT_FriendshipEffectMsg_msgSeq;
             uint32_t scProc_ACTOP_SwapTokusei_timer;
         };
-        
-        inline int32_t checkForbidChangeEscapeCommon(BTL_POKEPARAM *procPoke, uint8_t *pokeID, uint16_t *tokuseiID) {
+
+        static_assert(offsetof(Fields, scProc_ACTOP_SwapTokusei_timer) == 0x28C);
+        static_assert(sizeof(Fields) == 0x290);
+
+        inline int32_t checkForbidChangeEscapeCommon(BTL_POKEPARAM* procPoke, uint8_t* pokeID, uint16_t* tokuseiID) {
             return external<int32_t>(0x01f574e0, this, procPoke, pokeID, tokuseiID);
+        }
+
+        inline void setupSelectActionUIParam(BattleViewBase::SelectActionParam::Object* pViewParam, BTL_POKEPARAM* pActPoke, uint8_t actPokeIdx) {
+            external<void>(0x01f53970, this, pViewParam, pActPoke, actPokeIdx);
         }
     };
 }

--- a/src/mod/externals/Dpr/Battle/Logic/BattleViewBase.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BattleViewBase.h
@@ -2,14 +2,16 @@
 
 #include "externals/il2cpp-api.h"
 
-#include "externals/Dpr/Battle/Logic/BTL_CLIENT.h"
-#include "externals/Dpr/Battle/Logic/MainModule.h"
-
 namespace Dpr::Battle::Logic {
+    struct BTL_ACTION_PARAM_OBJ;
+    struct BTL_CLIENT;
+    struct BTL_POKEPARAM;
+    struct MainModule;
+
     struct BattleViewBase : ILClass<BattleViewBase> {
-        struct SelectActionParam : ILClass<SelectActionParam> {
+        struct SelectActionParam : ILClass<SelectActionParam, 0x04c5a8d8> {
             struct Fields {
-                Dpr::Battle::Logic::BTL_POKEPARAM::Object* pActPoke;
+                BTL_POKEPARAM* pActPoke;
                 uint8_t pokeIndex;
                 bool fReturnable;
                 bool bGEnable;
@@ -23,18 +25,337 @@ namespace Dpr::Battle::Logic {
             };
 
             static_assert(offsetof(Fields, buttonMode_Cheer) == 0x20);
+
+            inline void ctor() {
+                external<void>(0x0188a4c0, this);
+            }
         };
+
         struct Fields {
-            Dpr::Battle::Logic::MainModule::Object* m_pMainModule;
-            Dpr::Battle::Logic::BTL_CLIENT::Object* m_iPtrClient;
+            MainModule* m_pMainModule;
+            BTL_CLIENT* m_iPtrClient;
             void* m_pBattleEnv;
             int32_t m_bagMode;
             int32_t m_msgSpeed;
             void* m_battleSimulator;
         };
 
+        struct VirtualInvokeData_CMD_UI_SelectAction_Start {
+            typedef void(*Il2CppMethodPointer)(BattleViewBase::Object*, BattleViewBase::SelectActionParam::Object**, BTL_ACTION_PARAM_OBJ*, const MethodInfo*);
+            Il2CppMethodPointer methodPtr;
+            const MethodInfo* method;
+        };
+
+        struct VirtualInvokeData_CMD_UI_SelectWaza_Restart {
+            typedef void(*Il2CppMethodPointer)(BattleViewBase::Object*, uint8_t, const MethodInfo*);
+            Il2CppMethodPointer methodPtr;
+            const MethodInfo* method;
+        };
+
+        struct VTable {
+            VirtualInvokeData _0_Equals;
+            VirtualInvokeData _1_Finalize;
+            VirtualInvokeData _2_GetHashCode;
+            VirtualInvokeData _3_ToString;
+            VirtualInvokeData _4_GetMainModule;
+            VirtualInvokeData _5_GetBattleEnv;
+            VirtualInvokeData _6_GetBattleContainer;
+            VirtualInvokeData _7_GetBattlePokeParam;
+            VirtualInvokeData _8_GetBattlePokeParam_forUI;
+            VirtualInvokeData _9_GetViewSrcData;
+            VirtualInvokeData _10_GetBattleParty_Self;
+            VirtualInvokeData _11_GetBattleParty_Friend;
+            VirtualInvokeData _12_GetBattleParty_Enemy;
+            VirtualInvokeData _13_GetBattleParty;
+            VirtualInvokeData _14_GetClient;
+            VirtualInvokeData _15_GetFieldStatus;
+            VirtualInvokeData _16_GetSideEffectStatus;
+            VirtualInvokeData _17_GetPosEffectStatus;
+            VirtualInvokeData _18_GetBattleCompetitor;
+            VirtualInvokeData _19_GetBattleRule;
+            VirtualInvokeData _20_GetCommMode;
+            VirtualInvokeData _21_IsCommMode;
+            VirtualInvokeData _22_IsCommChild;
+            VirtualInvokeData _23_IsMultiMode;
+            VirtualInvokeData _24_IsPokeExist;
+            VirtualInvokeData _25_IsFriendExist;
+            VirtualInvokeData _26_IsClientTrainerExist;
+            VirtualInvokeData _27_IsWatchMode;
+            VirtualInvokeData _28_GetClientID;
+            VirtualInvokeData _29_GetFriendCleintID;
+            VirtualInvokeData _30_GetEnemyClientID;
+            VirtualInvokeData _31_GetEnemyClientNum;
+            VirtualInvokeData _32_IsClientNpc;
+            VirtualInvokeData _33_GetClientIdToBtlvPos;
+            VirtualInvokeData _34_GetBtlvPosToClientId;
+            VirtualInvokeData _35_GetBtlvPosToPosIdx;
+            VirtualInvokeData _36_GetBtlvPosToTrainerIdx;
+            VirtualInvokeData _37_GetTrainerID;
+            VirtualInvokeData _38_GetTrainerType;
+            VirtualInvokeData _39_GetTrainerModelID;
+            VirtualInvokeData _40_GetTrainerColorID;
+            VirtualInvokeData _41_GetTrainerWinEffect;
+            VirtualInvokeData _42_GetTrainerName;
+            VirtualInvokeData _43_GetTrainerNameLabel;
+            VirtualInvokeData _44_GetTrainerSex;
+            VirtualInvokeData _45_IsClientRatingDisplay;
+            VirtualInvokeData _46_GetClientRating;
+            VirtualInvokeData _47_GetMessageSpeed;
+            VirtualInvokeData _48_IsClientCheerMode;
+            VirtualInvokeData _49_GetFrontPosCount_Self;
+            VirtualInvokeData _50_GetFrontPosCount_Friend;
+            VirtualInvokeData _51_GetBenchPosIndex_Self;
+            VirtualInvokeData _52_GetBenchPosIndex_Friend;
+            VirtualInvokeData _53_IsSkyBattle;
+            VirtualInvokeData _54_IsZukanRegistered;
+            VirtualInvokeData _55_IsEnableWazaEffect;
+            VirtualInvokeData _56_IsItemEnable;
+            VirtualInvokeData _57_GetSetupStatusFlag;
+            VirtualInvokeData _58_GetEnableTimeStop;
+            VirtualInvokeData _59_GetEnableVoiceChat;
+            VirtualInvokeData _60_IsRecordPlayMode;
+            VirtualInvokeData _61_GetEscapeMode;
+            VirtualInvokeData _62_CanUseEscapeItem;
+            VirtualInvokeData _63_GetMiseaiData;
+            VirtualInvokeData _64_GetTurnCount;
+            VirtualInvokeData _65_IsWazaEffectEnable;
+            VirtualInvokeData _66_IsPlayerInLeftSide;
+            VirtualInvokeData _67_BtlPosToViewPos;
+            VirtualInvokeData _68_ViewPosToBtlPos;
+            VirtualInvokeData _69_ViewPosToBtlSide;
+            VirtualInvokeData _70_PokeIDToViewPos;
+            VirtualInvokeData _71_IsPlayerSide;
+            VirtualInvokeData _72_GetGameTime;
+            VirtualInvokeData _73_GetCommandTime;
+            VirtualInvokeData _74_GetClientTime;
+            VirtualInvokeData _75_GetUiDisplay_Turn_Weather;
+            VirtualInvokeData _76_GetUiDisplay_Turn_Ground;
+            VirtualInvokeData _77_GetUiDisplay_Turn_Hikarinokabe;
+            VirtualInvokeData _78_GetUiDisplay_Turn_Reflector;
+            VirtualInvokeData _79_GetUiDisplay_Turn_AuroraVeil;
+            VirtualInvokeData _80_GetUiDisplay_Turn_SideEffect;
+            VirtualInvokeData _81_GetUiDisplay_Turn;
+            VirtualInvokeData _82_GetUiDisplay_PokeType;
+            VirtualInvokeData _83_GetUiDisplay_WazaType;
+            VirtualInvokeData _84_GetUiDisplay_WazaPower;
+            VirtualInvokeData _85_GetUiDisplay_WazaHitPer;
+            VirtualInvokeData _86_GetUiDisplay_WazaDamageType;
+            VirtualInvokeData _87_GetUiDisplay_IsPokemonAppearedOnBattleField;
+            VirtualInvokeData _88_GetUiDisplay_GetClientPublicInfomation;
+            VirtualInvokeData _89_GetUiDisplay_IsCheerMode;
+            VirtualInvokeData _90_GetUIDisplay_GetMultiMode;
+            VirtualInvokeData _91_GetUiDisplay_GetPlayerName;
+            VirtualInvokeData _92_IsWazaAffinityDisplayEnable;
+            VirtualInvokeData _93_CalcWazaAffinityAbout;
+            VirtualInvokeData _94_GetRaidActionIconID;
+            VirtualInvokeData _95_IsGWallGaugeDisplay;
+            VirtualInvokeData _96_GetGWallGaugeMax;
+            VirtualInvokeData _97_GetGWallGaugeNow;
+            VirtualInvokeData _98_CheckTrainerActionRequest;
+            VirtualInvokeData _99_SetTrainerActionRequest;
+            VirtualInvokeData _100_ClearTrainerActionRequest;
+            VirtualInvokeData _101_IsTutorial;
+            VirtualInvokeData _102_GetSafariBallNum;
+            VirtualInvokeData _103_Initialize;
+            VirtualInvokeData _104_FinalizeApp;
+            VirtualInvokeData _105_FinalizeAppForce;
+            VirtualInvokeData _106_CMD_StartSetup;
+            VirtualInvokeData _107_CMD_WaitSetup;
+            VirtualInvokeData _108_CMD_StartCleanUp;
+            VirtualInvokeData _109_CMD_WaitCleanUp;
+            VirtualInvokeData _110_CMD_InitStartWaitCameraEffect;
+            VirtualInvokeData _111_CMD_WaitStartWaitCameraEffect;
+            VirtualInvokeData _112_CMD_InitFinishWaitCameraEffect;
+            VirtualInvokeData _113_CMD_WaitFinishWaitCameraEffect;
+            VirtualInvokeData _114_CMD_UI_OnFirstSelectActionStart;
+            VirtualInvokeData_CMD_UI_SelectAction_Start _115_CMD_UI_SelectAction_Start;
+            VirtualInvokeData _116_CMD_UI_SelectAction_Wait;
+            VirtualInvokeData _117_CMD_UI_SelectAction_ForceQuit;
+            VirtualInvokeData _118_CMD_UI_SelectAction_AllFinished;
+            VirtualInvokeData _119_CMD_UI_SelectAction_AllFinished_Wait;
+            VirtualInvokeData _120_CMD_UI_SelectWaza_Start;
+            VirtualInvokeData_CMD_UI_SelectWaza_Restart _121_CMD_UI_SelectWaza_Restart;
+            VirtualInvokeData _122_CMD_UI_SelectWaza_Wait;
+            VirtualInvokeData _123_CMD_UI_SelectWaza_End;
+            VirtualInvokeData _124_CMD_UI_SelectWaza_ForceQuit;
+            VirtualInvokeData _125_CMD_UI_SelectTarget_Start;
+            VirtualInvokeData _126_CMD_UI_SelectTarget_Wait;
+            VirtualInvokeData _127_CMD_UI_SelectTarget_ForceQuit;
+            VirtualInvokeData _128_CMD_UI_RestartIfNotStandBy;
+            VirtualInvokeData _129_CMD_UI_Restart;
+            VirtualInvokeData _130_CMD_UI_WaitRestart;
+            VirtualInvokeData _131_CMD_StartMemberChangeAct;
+            VirtualInvokeData _132_CMD_WaitMemberChangeAct;
+            VirtualInvokeData _133_CMD_StartMsgInBuffer;
+            VirtualInvokeData _134_CMD_StartPokeList;
+            VirtualInvokeData _135_CMD_WaitPokeList;
+            VirtualInvokeData _136_CMD_ForceQuitPokeList;
+            VirtualInvokeData _137_CMD_WaitForceQuitPokeList;
+            VirtualInvokeData _138_CMD_StartPokeSelect;
+            VirtualInvokeData _139_CMD_WaitPokeSelect;
+            VirtualInvokeData _140_CMD_ForceQuitPokeSelect;
+            VirtualInvokeData _141_CMD_WaitForceQuitPokeSelect;
+            VirtualInvokeData _142_CMD_StartMsg;
+            VirtualInvokeData _143_CMD_StartMsgWaza;
+            VirtualInvokeData _144_CMD_StartMsgStd;
+            VirtualInvokeData _145_CMD_StartMsgSet;
+            VirtualInvokeData _146_CMD_StartMsgTrainer;
+            VirtualInvokeData _147_CMD_WaitMsg;
+            VirtualInvokeData _148_CMD_WaitMsg_WithoutHide;
+            VirtualInvokeData _149_CMD_HideMsg;
+            VirtualInvokeData _150_CMD_ACT_WazaEffect_Start;
+            VirtualInvokeData _151_CMD_ACT_WazaEffect_Wait;
+            VirtualInvokeData _152_CMD_ACT_WazaEffect_NotView;
+            VirtualInvokeData _153_CMD_ACT_DamageEffectSingle_Start;
+            VirtualInvokeData _154_CMD_ACT_DamageEffectSingle_Wait;
+            VirtualInvokeData _155_CMD_ACT_DamageEffectPlural_Start;
+            VirtualInvokeData _156_CMD_ACT_DamageEffectPlural_Wait;
+            VirtualInvokeData _157_CMD_ACT_MigawariDamageEffect_Start;
+            VirtualInvokeData _158_CMD_ACT_MigawariDamageEffect_Wait;
+            VirtualInvokeData _159_CMD_StartDeadAct;
+            VirtualInvokeData _160_CMD_WaitDeadAct;
+            VirtualInvokeData _161_CMD_StartReliveAct;
+            VirtualInvokeData _162_CMD_WaitReliveAct;
+            VirtualInvokeData _163_CMD_ACT_MemberOut_Start;
+            VirtualInvokeData _164_CMD_ACT_MemberOut_Wait;
+            VirtualInvokeData _165_CMD_ACT_TameWazaHide;
+            VirtualInvokeData _166_CMD_ACT_SimpleHPEffect_Start;
+            VirtualInvokeData _167_CMD_ACT_SimpleHPEffect_Wait;
+            VirtualInvokeData _168_CMD_AddEffect;
+            VirtualInvokeData _169_CMD_WaitEffect;
+            VirtualInvokeData _170_CMD_AddEffectByPos;
+            VirtualInvokeData _171_CMD_WaitEffectByPos;
+            VirtualInvokeData _172_CMD_AddEffectByDir;
+            VirtualInvokeData _173_CMD_WaitEffectByDir;
+            VirtualInvokeData _174_CMD_AddEffectBySide;
+            VirtualInvokeData _175_CMD_WaitEffectBySide;
+            VirtualInvokeData _176_CMD_TokWin_DispStart;
+            VirtualInvokeData _177_CMD_TokWin_DispWait;
+            VirtualInvokeData _178_CMD_QuitTokWin;
+            VirtualInvokeData _179_CMD_QuitTokWinWait;
+            VirtualInvokeData _180_CMD_TokWin_Renew_Start;
+            VirtualInvokeData _181_CMD_TokWin_Renew_Wait;
+            VirtualInvokeData _182_CMD_StartRankDownEffect;
+            VirtualInvokeData _183_CMD_StartRankUpEffect;
+            VirtualInvokeData _184_CMD_WaitRankEffect;
+            VirtualInvokeData _185_CMD_StartCommWait;
+            VirtualInvokeData _186_CMD_WaitCommWait;
+            VirtualInvokeData _187_CMD_ResetCommWaitInfo;
+            VirtualInvokeData _188_CMD_ItemAct_Start;
+            VirtualInvokeData _189_CMD_ItemAct_Wait;
+            VirtualInvokeData _190_CMD_KinomiAct_Start;
+            VirtualInvokeData _191_CMD_KinomiAct_Wait;
+            VirtualInvokeData _192_CMD_FakeDisable_Start;
+            VirtualInvokeData _193_CMD_FakeDisable_Wait;
+            VirtualInvokeData _194_CMD_ChangeForm_Start;
+            VirtualInvokeData _195_CMD_ChangeForm_Wait;
+            VirtualInvokeData _196_CMD_Hensin_Start;
+            VirtualInvokeData _197_CMD_Hensin_Wait;
+            VirtualInvokeData _198_CMD_ACT_MoveMember_Start;
+            VirtualInvokeData _199_CMD_ACT_MoveMember_Wait;
+            VirtualInvokeData _200_CMD_ITEMSELECT_Start;
+            VirtualInvokeData _201_CMD_ITEMSELECT_Wait;
+            VirtualInvokeData _202_CMD_ITEMSELECT_ForceQuit;
+            VirtualInvokeData _203_CMD_ITEMSELECT_GetItemID;
+            VirtualInvokeData _204_CMD_ITEMSELECT_GetTargetIdx;
+            VirtualInvokeData _205_CMD_ITEMSELECT_GetWazaIdx;
+            VirtualInvokeData _206_CMD_ITEMSELECT_ReflectUsedItem;
+            VirtualInvokeData _207_CMD_YESNO_Start;
+            VirtualInvokeData _208_CMD_YESNO_Wait;
+            VirtualInvokeData _209_CMD_YESNO_ForceQuit;
+            VirtualInvokeData _210_CMD_YESNO_Delete;
+            VirtualInvokeData _211_CMD_ExpGet_Start;
+            VirtualInvokeData _212_CMD_ExpGet_Wait;
+            VirtualInvokeData _213_CMD_RecPlayFadeOut_Start;
+            VirtualInvokeData _214_CMD_RecPlayFadeOut_Wait;
+            VirtualInvokeData _215_CMD_RecPlayFadeIn_Start;
+            VirtualInvokeData _216_CMD_RecPlayFadeIn_Wait;
+            VirtualInvokeData _217_CMD_RecDispTurnGauge_Start;
+            VirtualInvokeData _218_CMD_RecDispTurnGauge_Wait;
+            VirtualInvokeData _219_CMD_Naderu_Start;
+            VirtualInvokeData _220_CMD_Naderu_Wait;
+            VirtualInvokeData _221_CMD_VsNusiWinEffect_Start;
+            VirtualInvokeData _222_CMD_VsNusiWinEffect_Wait;
+            VirtualInvokeData _223_CMD_GRightsGet_Start;
+            VirtualInvokeData _224_CMD_GRightsGet_Wait;
+            VirtualInvokeData _225_CMD_MsgWinHide_Start;
+            VirtualInvokeData _226_CMD_MsgWinHide_Wait;
+            VirtualInvokeData _227_CMD_ForceQuitInput_Notify;
+            VirtualInvokeData _228_CMD_ForceQuitInput_Wait;
+            VirtualInvokeData _229_CMD_RecPlayer_Init;
+            VirtualInvokeData _230_CMD_CheckRecPlayerInput;
+            VirtualInvokeData _231_CMD_UpdateRecPlayerInput;
+            VirtualInvokeData _232_CMD_RecPlayer_StartSkip;
+            VirtualInvokeData _233_CMD_RecPlayer_StartSkipDisplay;
+            VirtualInvokeData _234_CMD_RecPlayer_StartQuit;
+            VirtualInvokeData _235_CMD_TrainerIn_Win;
+            VirtualInvokeData _236_CMD_TrainerIn_Lose;
+            VirtualInvokeData _237_CMD_TrainerIn_Event;
+            VirtualInvokeData _238_CMD_WaitTrainerIn;
+            VirtualInvokeData _239_CMD_EFFECT_SetGaugeStatus;
+            VirtualInvokeData _240_CMD_EFFECT_BallThrow;
+            VirtualInvokeData _241_CMD_EFFECT_BallThrowTrainer;
+            VirtualInvokeData _242_CMD_EFFECT_WaitBallThrow;
+            VirtualInvokeData _243_CMD_EFFECT_WaitBallThrowTrainer;
+            VirtualInvokeData _244_CMD_EFFECT_DrawEnableTimer;
+            VirtualInvokeData _245_CMD_ChangeWheather;
+            VirtualInvokeData _246_CMD_ChangeWheather_Wait;
+            VirtualInvokeData _247_CMD_ChangeGround;
+            VirtualInvokeData _248_CMD_ChangeGround_Wait;
+            VirtualInvokeData _249_CMD_FadeOutBGM;
+            VirtualInvokeData _250_CMD_FadeInBGM;
+            VirtualInvokeData _251_CMD_CheckFadeOnBGM;
+            VirtualInvokeData _252_CMD_StopBGM;
+            VirtualInvokeData _253_CMD_PlayWinBGM;
+            VirtualInvokeData _254_CMD_PlaySE;
+            VirtualInvokeData _255_CMD_IsSEFinished;
+            VirtualInvokeData _256_CMD_StopAllSE;
+            VirtualInvokeData _257_CMD_StartGMode;
+            VirtualInvokeData _258_CMD_StartGMode_Wait;
+            VirtualInvokeData _259_CMD_EndGMode;
+            VirtualInvokeData _260_CMD_EndGMode_Wait;
+            VirtualInvokeData _261_CMD_SummarizedGShockEffect;
+            VirtualInvokeData _262_CMD_SummarizedGShockEffect_Wait;
+            VirtualInvokeData _263_CMD_Raid_StartCoopCapture;
+            VirtualInvokeData _264_CMD_Raid_StartCoopCapture_Wait;
+            VirtualInvokeData _265_CMD_Raid_SelectBall;
+            VirtualInvokeData _266_CMD_Raid_SelectBall_Wait;
+            VirtualInvokeData _267_CMD_Raid_SelectBall_ForceQuit;
+            VirtualInvokeData _268_CMD_Raid_Capture;
+            VirtualInvokeData _269_CMD_Raid_Capture_Wait;
+            VirtualInvokeData _270_CMD_Raid_Capture_vsJoker;
+            VirtualInvokeData _271_CMD_Raid_Capture_vsJoker_Wait;
+            VirtualInvokeData _272_CMD_Raid_Win;
+            VirtualInvokeData _273_CMD_Raid_Win_Wait;
+            VirtualInvokeData _274_CMD_Raid_Result;
+            VirtualInvokeData _275_CMD_Raid_Result_Wait;
+            VirtualInvokeData _276_CMD_Raid_Lose;
+            VirtualInvokeData _277_CMD_Raid_Lose_Wait;
+            VirtualInvokeData _278_CMD_FinalizeFadeSkip;
+            VirtualInvokeData _279_CMD_Tips_G;
+            VirtualInvokeData _280_CMD_Tips_G_Wait;
+            VirtualInvokeData _281_CMD_DemoCapture_Start;
+            VirtualInvokeData _282_CMD_DemoCapture_Wait;
+            VirtualInvokeData _283_GetBagMode;
+            VirtualInvokeData _284_RaidReward_Start;
+            VirtualInvokeData _285_RaidReward_Wait;
+            VirtualInvokeData _286_SetUIControlEnableForLiveCup;
+            VirtualInvokeData _287_CMD_ACT_Safari_Start;
+            VirtualInvokeData _288_CMD_ACT_Safari_Wait;
+        };
+
         inline int32_t BtlPosToViewPos(uint8_t pos) {
             return external<int32_t>(0x01888200, this, pos);
+        }
+
+        inline void virtual_CMD_UI_SelectWaza_Restart(uint8_t pokeIndex) {
+            (*(this->instance()->klass->vtable)._121_CMD_UI_SelectWaza_Restart.methodPtr)
+                    (this->instance(), pokeIndex, this->instance()->klass->vtable._121_CMD_UI_SelectWaza_Restart.method);
+        }
+
+        inline void virtual_CMD_UI_SelectAction_Start(BattleViewBase::SelectActionParam::Object** param, BTL_ACTION_PARAM_OBJ* dest) {
+            (*(this->instance()->klass->vtable)._115_CMD_UI_SelectAction_Start.methodPtr)
+                    (this->instance(), param, dest, this->instance()->klass->vtable._115_CMD_UI_SelectAction_Start.method);
         }
     };
 }

--- a/src/mod/externals/Dpr/Battle/Logic/SVCL_ACTION.h
+++ b/src/mod/externals/Dpr/Battle/Logic/SVCL_ACTION.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include "externals/il2cpp-api.h"
-#include "externals/Dpr/Battle/Logic/BTL_ACTION.h"
+
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM.h"
 
 namespace Dpr::Battle::Logic {
     struct SVCL_ACTION : ILClass<SVCL_ACTION> {
@@ -9,8 +11,8 @@ namespace Dpr::Battle::Logic {
             System::Byte_array *count;
         };
 
-        static inline Dpr::Battle::Logic::BTL_ACTION::PARAM::Object* Get(SVCL_ACTION::Object* clientAction,uint8_t clientID, uint8_t posIdx) {
-            return external<Dpr::Battle::Logic::BTL_ACTION::PARAM::Object*>(0x020d52f0, clientAction, clientID, posIdx);
+        static inline Dpr::Battle::Logic::BTL_ACTION_PARAM::Object* Get(SVCL_ACTION::Object* clientAction, uint8_t clientID, uint8_t posIdx) {
+            return external<Dpr::Battle::Logic::BTL_ACTION_PARAM::Object*>(0x020d52f0, clientAction, clientID, posIdx);
         }
 
         static inline uint8_t GetNumAction(SVCL_ACTION::Object* clientAction, uint8_t clientID) {

--- a/src/mod/externals/Dpr/Battle/Logic/Section_StoreActions.h
+++ b/src/mod/externals/Dpr/Battle/Logic/Section_StoreActions.h
@@ -2,9 +2,9 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM.h"
 #include "externals/Dpr/Battle/Logic/Section.h"
 #include "externals/Dpr/Battle/Logic/Section_CommonParam.h"
-#include "externals/Dpr/Battle/Logic/BTL_ACTION.h"
 
 namespace Dpr::Battle::Logic {
     struct Section_StoreActions : ILClass<Section_StoreActions, 0x04c5bc70> {
@@ -16,12 +16,12 @@ namespace Dpr::Battle::Logic {
         }
 
 
-        inline BTL_POKEPARAM::Object* getActionPoke(BTL_ACTION::PARAM::Object* clientInstruction, uint8_t clientID) {
+        inline BTL_POKEPARAM::Object* getActionPoke(BTL_ACTION_PARAM::Object* clientInstruction, uint8_t clientID) {
             return external<BTL_POKEPARAM::Object*>(0x021cdea0, this, clientInstruction, clientID);
         }
 
         inline bool setupPokeAction_FromClientInstruction(Dpr::Battle::Logic::PokeAction::Object* pokeAction,
-                                                          Dpr::Battle::Logic::BTL_ACTION::PARAM::Object* clientInstructions,
+                                                          Dpr::Battle::Logic::BTL_ACTION_PARAM::Object* clientInstructions,
                                                           uint8_t clientID) {
             return external<bool>(0x021cdbf0, this, pokeAction, clientInstructions, clientID);
         }

--- a/src/mod/externals/Dpr/Battle/View/UI/BUITargetSelect.h
+++ b/src/mod/externals/Dpr/Battle/View/UI/BUITargetSelect.h
@@ -2,7 +2,7 @@
 
 #include "externals/il2cpp-api.h"
 
-#include "externals/Dpr/Battle/Logic/BTL_ACTION.h"
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM_OBJ.h"
 #include "externals/Dpr/Battle/Logic/BtlPokePos.h"
 #include "externals/Dpr/Battle/View/UI/BattleViewUICanvasBase.h"
 #include "externals/UnityEngine/UI/Image.h"
@@ -14,7 +14,7 @@ namespace Dpr::Battle::View::UI {
             void* _targetCursor;
             UnityEngine::UI::Image::Array* _boardImage;
             Dpr::Battle::Logic::BtlPokePos _Result_k__BackingField;
-            Dpr::Battle::Logic::BTL_ACTION::PARAM_OBJ::Object* _destActionParam;
+            Dpr::Battle::Logic::BTL_ACTION_PARAM_OBJ::Object* _destActionParam;
             int32_t _actionVPos;
             int32_t _targetType;
             int32_t _overrideTargetType;

--- a/src/mod/externals/Dpr/Battle/View/UI/BUIWazaList.h
+++ b/src/mod/externals/Dpr/Battle/View/UI/BUIWazaList.h
@@ -2,8 +2,8 @@
 
 #include "externals/il2cpp-api.h"
 
+#include "externals/Dpr/Battle/Logic/BTL_ACTION_PARAM_OBJ.h"
 #include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
-#include "externals/Dpr/Battle/Logic/BTL_ACTION.h"
 #include "externals/Dpr/Battle/View/UI/BattleViewUICanvasBase.h"
 #include "externals/Dpr/Battle/View/UI/BUIWazaButton.h"
 #include "externals/UnityEngine/GameObject.h"
@@ -24,7 +24,7 @@ namespace Dpr::Battle::View::UI {
             UnityEngine::Color::Object _ppColorWarning;
             UnityEngine::Color::Object _ppColorDanger;
             UnityEngine::Color::Object _ppColorEmpty;
-            Dpr::Battle::Logic::BTL_ACTION::PARAM_OBJ::Object* _destActionParam;
+            Dpr::Battle::Logic::BTL_ACTION_PARAM_OBJ::Object* _destActionParam;
             void* _btlvWazaInfos;
             Dpr::Battle::Logic::BTL_POKEPARAM::Object* _btlPokeParam;
             int32_t _wazaCount;
@@ -55,7 +55,7 @@ namespace Dpr::Battle::View::UI {
             external<void>(0x01d2c490, this, deltaTime);
         }
 
-        inline void Initialize(Dpr::Battle::Logic::BTL_POKEPARAM::Object* bpp, uint8_t pokeIndex, Dpr::Battle::Logic::BTL_ACTION::PARAM_OBJ::Object* dest) {
+        inline void Initialize(Dpr::Battle::Logic::BTL_POKEPARAM::Object* bpp, uint8_t pokeIndex, Dpr::Battle::Logic::BTL_ACTION_PARAM_OBJ::Object* dest) {
             external<void>(0x01d2b800, this, bpp, pokeIndex, dest);
         }
 


### PR DESCRIPTION
Closes #150.

- Fixes the bug where moves that can't be used (for example, because of disable or torment) would softlock the game by repeating the message over and over.
- Adjusts a few structs in headers that were incorrect.