### PR TITLE
Shiny EvCmdAddPokemonUIExtra

### DIFF
--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -12,7 +12,7 @@
 
 void EvCmdAddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager, int32_t addMemberResult) {
     EvData::Aregment::Array* args = manager->fields._evArg;
-    if (args->max_length >= 7) {
+    if (args->max_length >= 8) {
         manager->fields._azukariyaSequence = -1;
         return;
     }
@@ -26,7 +26,7 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
     EvData::Aregment::Array* args = manager->fields._evArg;
     auto azukariyaSeq = manager->fields._azukariyaSequence;
 
-    if (args->max_length >= 7) {
+    if (args->max_length >= 8) {
         if (azukariyaSeq == 0) {
             SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
             auto uiManager = Dpr::UI::UIManager::get_Instance();
@@ -44,6 +44,7 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto item = GetWorkOrIntValue(args->m_Items[4]);
             auto maxIVs = GetWorkOrIntValue(args->m_Items[5]);
             auto ball = GetWorkOrIntValue(args->m_Items[6]);
+            auto shiny = GetWorkOrIntValue(args->m_Items[7]);
 
             Pml::PokePara::InitialSpec::Object* initialSpec = Pml::PokePara::InitialSpec::newInstance();
             initialSpec->fields.monsno = monsNo;
@@ -53,6 +54,9 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
             if (item != 0) coreParam->SetItem(item);
             coreParam->SetGetBall(ball);
+            if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED);
+            if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED);
+            if (shiny == 3) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE);
 
             PlayerWork::getClass()->initIfNeeded();
             auto pMyStatus = PlayerWork::get_playerStatus();

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -131,6 +131,7 @@ bool CaseCall(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] item: ID of the item the Pokémon is to hold.
 //   [Work, Number] maxIVs: Number of max IVs the Pokémon will have.
 //   [Work, Number] ball: ID of the ball the Pokémon will reside in.
+//   [Work, Number] shiny: Determines if the Pokémon is forced to be shiny. 0 = Random, 1 = Shiny, 2 = Square Shiny, 3 = Never Shiny
 bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager);
 
 // Inserts a string of the specified Pokémon's form name into the supplied tagIndex.


### PR DESCRIPTION
Adds a field to EvCmdAddPokemonUIExtra determine the shininess of a Pokémon. Does not follow the internal shininess enum. 0 = Random, 1 = Shiny, 2 = Square Shiny, 3 = Never Shiny