### PR TITLE
Update add_pokemon_ui_extra.cpp

### DIFF
--- a/src/mod/features/commands/add_pokemon_ui_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_ui_extra.cpp
@@ -12,7 +12,7 @@
 
 void EvCmdAddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager, int32_t addMemberResult) {
     EvData::Aregment::Array* args = manager->fields._evArg;
-    if (args->max_length >= 8) {
+    if (args->max_length >= 7) {
         manager->fields._azukariyaSequence = -1;
         return;
     }
@@ -26,7 +26,7 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
     EvData::Aregment::Array* args = manager->fields._evArg;
     auto azukariyaSeq = manager->fields._azukariyaSequence;
 
-    if (args->max_length >= 8) {
+    if (args->max_length >= 7) {
         if (azukariyaSeq == 0) {
             SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
             auto uiManager = Dpr::UI::UIManager::get_Instance();
@@ -44,7 +44,11 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto item = GetWorkOrIntValue(args->m_Items[4]);
             auto maxIVs = GetWorkOrIntValue(args->m_Items[5]);
             auto ball = GetWorkOrIntValue(args->m_Items[6]);
-            auto shiny = GetWorkOrIntValue(args->m_Items[7]);
+            auto shiny = -1; // Defaults to regular shiny calculation in case arg not given
+
+            if (args->max_length >= 8) {
+                shiny = GetWorkOrIntValue(args->m_Items[7]);
+            }
 
             Pml::PokePara::InitialSpec::Object* initialSpec = Pml::PokePara::InitialSpec::newInstance();
             initialSpec->fields.monsno = monsNo;
@@ -54,9 +58,9 @@ bool AddPokemonUIExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
             if (item != 0) coreParam->SetItem(item);
             coreParam->SetGetBall(ball);
-            if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED);
-            if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED);
-            if (shiny == 3) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE);
+            if (shiny == 0) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE); // Never shiny
+            if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED); // Shiny
+            if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED); // Square shiny
 
             PlayerWork::getClass()->initIfNeeded();
             auto pMyStatus = PlayerWork::get_playerStatus();


### PR DESCRIPTION
Updated the shiny arg of _ADD_POKEMON_UI_EXTRA to be optional and matched it to the internal enum: -1 = Random, 0 = Never Shiny, 1 = Shiny, 2 = Square Shiny