### PR TITLE
Hook _CHARA_LOOK_LOCK to populate SCWK_LOOK_TARGET_OBJID

### DIFF
--- a/src/mod/externals/FlagWork_Enums.h
+++ b/src/mod/externals/FlagWork_Enums.h
@@ -3241,6 +3241,7 @@ enum class FlagWork_Work : int32_t {
     SCWK_WK_SAVE_SIZE = 500,
 
     // Luminescent Works
+    SCWK_LOOK_TARGET_OBJID = 448,
     WK_LAST_BATTLE_TURN_COUNTER = 449,
     WK_INCENSE_SLOT = 495,
     WK_PUNCHINGBAG_OBJ_ID = 502,

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -138,6 +138,9 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(JumpAndRotate(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_WAIT_FOR_GAMEOBJECT:
                     return HandleCmdStepper(WaitForGameObject(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_CHARA_LOOK_LOCK:
+                    CharaLookLock(__this);  // Set work variable before original runs
+                    return HandleCmdStepper(Orig(__this, index));
                 default:
                     break;
             }
@@ -208,4 +211,5 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_LEDGE_JUMP);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_JUMP_AND_ROTATE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_WAIT_FOR_GAMEOBJECT);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CHARA_LOOK_LOCK);
 }

--- a/src/mod/features/commands/chara_look_lock.cpp
+++ b/src/mod/features/commands/chara_look_lock.cpp
@@ -1,0 +1,40 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldObjectEntity.h"
+#include "externals/PlayerWork.h"
+#include "externals/FlagWork_Enums.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+bool CharaLookLock(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    // args[1] = source entity (who is looking)
+    // args[2] = target entity (what they're looking at)
+
+    EvData::Aregment::Object targetArg = args->m_Items[2];
+
+    if ((EvData::ArgType)targetArg.fields.argType == EvData::ArgType::String)
+    {
+        // Find the entity by name and get its index from EventParams
+        auto entity = manager->Find_fieldObjectEntity(GetStringText(manager, targetArg));
+        if (entity != nullptr && entity->instance() != nullptr)
+        {
+            int32_t objIndex = entity->instance()->fields.EventParams->fields.FieldObjectIndex;
+            PlayerWork::SetInt((int32_t)FlagWork_Work::SCWK_LOOK_TARGET_OBJID, objIndex);
+            Logger::log("CharaLookLock: Set SCWK_LOOK_TARGET_OBJID to %d\n", objIndex);
+        }
+    }
+    else if ((EvData::ArgType)targetArg.fields.argType == EvData::ArgType::Work ||
+             (EvData::ArgType)targetArg.fields.argType == EvData::ArgType::Float)
+    {
+        // Target is a work variable or numeric index - get the value
+        int32_t objIndex = GetWorkOrIntValue(targetArg);
+        PlayerWork::SetInt((int32_t)FlagWork_Work::SCWK_LOOK_TARGET_OBJID, objIndex);
+        Logger::log("CharaLookLock: Set SCWK_LOOK_TARGET_OBJID to %d (from work/number)\n", objIndex);
+    }
+
+    // Return false to let the original implementation run
+    return false;
+}

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -344,3 +344,10 @@ bool JumpAndRotate(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [String] gameObject: The name of the GameObject to wait on.
 bool WaitForGameObject(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Hooks _CHARA_LOOK_LOCK to populate SCWK_LOOK_TARGET_OBJID with target entity index.
+// Arguments:
+//   [String] source: The entity that will look.
+//   [String] target: The entity to look at.
+// Side effect: Sets SCWK_LOOK_TARGET_OBJID (448) to target's object index.
+bool CharaLookLock(Dpr::EvScript::EvDataManager::Object* manager);


### PR DESCRIPTION
## Summary
- Adds a hook to `_CHARA_LOOK_LOCK` that stores the target entity's `FieldObjectIndex` in `SCWK_LOOK_TARGET_OBJID` (448)
- Enables scripts to identify the look target for animation purposes
- Supports string entity names, work variables, and numeric indices as the target parameter

## Usage
```c
_CHARA_LOOK_LOCK('HERO', 'R213_GINGAM')
_DEBUG_LOG(@SCWK_LOOK_TARGET_OBJID)  // Shows target's object index
```

Closes #210