### PR TITLE
Add _GET_PLAYER_POS_PRECISE for OOB ledge jump prevention

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1294,6 +1294,7 @@ namespace Dpr::EvScript {
             _GAMEOBJECT_ROTATE_PIVOT = 1284,
             _SET_CAMERA_OFFSET_ANGLE = 1285,
             _SP_WILD_BTL_SET_EXTRA = 1286,
+            _GET_PLAYER_POS_PRECISE = 1287,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -150,6 +150,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(SetCameraOffsetAngle(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_SP_WILD_BTL_SET_EXTRA:
                     return HandleCmdStepper(SpWildBtlSetExtra(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GET_PLAYER_POS_PRECISE:
+                    return HandleCmdStepper(GetPlayerPosPrecise(__this));
                 default:
                     break;
             }
@@ -235,6 +237,7 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GAMEOBJECT_ROTATE_PIVOT);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_CAMERA_OFFSET_ANGLE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SP_WILD_BTL_SET_EXTRA);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_PLAYER_POS_PRECISE);
 
     exl_commands_hooks_main();
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -415,3 +415,11 @@ bool SetCameraOffsetAngle(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] isCantUseBall: (optional) Whether or not the player can catch the Pokémon.
 //   [String] overrideBGM: (optional) Overrides the Battle Background Music.
 bool SpWildBtlSetExtra(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Returns the player's world position with 2 decimal places of precision.
+// Coordinates are multiplied by 100 so that e.g. position 12.34 becomes 1234.
+// Arguments:
+//   [Work] x: Work to store the x coordinate * 100.
+//   [Work] y: Work to store the y coordinate * 100.
+//   [Work] z: Work to store the z coordinate * 100.
+bool GetPlayerPosPrecise(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/get_player_pos_precise.cpp
+++ b/src/mod/features/commands/get_player_pos_precise.cpp
@@ -1,0 +1,38 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/EntityManager.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+
+// Returns the player's world position with 2 decimal places of precision.
+// Coordinates are multiplied by 100 and truncated to int so that e.g.
+// position 12.34 becomes 1234 in the work variable.
+// Arguments:
+//   [Work] x: Work to store the x coordinate * 100.
+//   [Work] y: Work to store the y coordinate * 100.
+//   [Work] z: Work to store the z coordinate * 100.
+bool GetPlayerPosPrecise(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_GET_PLAYER_POS_PRECISE\n");
+
+    system_load_typeinfo(0x4989);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    EntityManager::getClass()->initIfNeeded();
+    auto player = EntityManager::getClass()->static_fields->_activeFieldPlayer_k__BackingField;
+
+    if (player == nullptr)
+        return true;
+
+    auto pos = player->cast<BaseEntity>()->fields.worldPosition;
+
+    if (args->max_length > 1)
+        SetWorkToValue(args->m_Items[1], (int32_t)(pos.fields.x * 100.0f));
+    if (args->max_length > 2)
+        SetWorkToValue(args->m_Items[2], (int32_t)(pos.fields.y * 100.0f));
+    if (args->max_length > 3)
+        SetWorkToValue(args->m_Items[3], (int32_t)(pos.fields.z * 100.0f));
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- Adds new script command `_GET_PLAYER_POS_PRECISE` (ID 1287) that returns the player's world position with 2 decimal places of float precision
- Coordinates are multiplied by 100 and stored as integers in work variables (e.g. position 12.34 becomes 1234)
- Enables scripters to check exact player position before calling `_LEDGE_JUMP`, preventing out-of-bounds jumps

## Usage
```
_GET_PLAYER_POS_PRECISE(@SCWK_TEMP0, @SCWK_TEMP1, @SCWK_TEMP2)
// @SCWK_TEMP0 = x * 100
// @SCWK_TEMP1 = y * 100
// @SCWK_TEMP2 = z * 100
```

Scripters can then compare against boundary values before allowing the jump.

## Test plan
- [ ] Verify coordinates are returned correctly with sub-tile precision
- [ ] Verify coordinate values match expected world positions
- [ ] Test boundary checking logic in a script that gates _LEDGE_JUMP

Closes #211