### PR TITLE
Various Bug Fixes

### DIFF
--- a/src/mod/features/items/exp_share_item.cpp
+++ b/src/mod/features/items/exp_share_item.cpp
@@ -6,8 +6,11 @@
 #include "externals/Dpr/Battle/Logic/MyStatus.h"
 #include "externals/Dpr/Battle/Logic/MainModule.h"
 #include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
+#include "data/features.h"
 #include "data/items.h"
 #include "data/utils.h"
+#include "features/activated_features.h"
+#include "save/save.h"
 
 using namespace Dpr::Battle::Logic;
 HOOK_DEFINE_REPLACE(CalcExp) {
@@ -29,10 +32,24 @@ HOOK_DEFINE_REPLACE(CalcExp) {
             calc->fields.getPokeLevel = (*bpp)->GetValue(BTL_POKEPARAM::ValueID::BPP_LEVEL);
             calc->fields.getPokeFriendship = (*mainModule)->GetPokeFriendship(*bpp);
             calc->fields.getPokeLanguageId = param->GetLangId();
+            calc->fields.isMatch = (*deadPoke)->CONFRONT_REC_IsMatch((*bpp)->GetID());
 
-            calc->fields.isMatch = (*deadPoke)->CONFRONT_REC_IsMatch((*bpp)->GetID()) || (*bpp)->GetItem() == array_index(ITEMS, "Exp. Share");
-            calc->fields.isGakusyuSoutiOn = false;
-            calc->fields.haveSiawasetamago = (*bpp)->GetItem() == array_index(ITEMS, "Lucky Egg");
+            auto hasExpShareItem = (*bpp)->GetItem() == array_index(ITEMS, "Exp. Share");
+            auto hasLuckyEggItem = (*bpp)->GetItem() == array_index(ITEMS, "Lucky Egg");
+
+            if (IsActivatedSmallPatchFeature(array_index(SMALL_PATCH_FEATURES, "Global Exp. Share Toggle")) &&
+                !getCustomSaveData()->settings.expShareEnabled)
+            {
+                // Global Exp. Share in settings and turned off
+                calc->fields.isGakusyuSoutiOn = hasExpShareItem;
+                calc->fields.haveSiawasetamago = hasLuckyEggItem;
+            }
+            else
+            {
+                // Global Exp. Share always ON
+                calc->fields.isGakusyuSoutiOn = true;
+                calc->fields.haveSiawasetamago = hasLuckyEggItem || hasExpShareItem;
+            }
 
             system_load_typeinfo(0x47a0);
             calc::getClass()->initIfNeeded();

--- a/src/mod/features/move_tutor_relearner.cpp
+++ b/src/mod/features/move_tutor_relearner.cpp
@@ -193,9 +193,6 @@ HOOK_DEFINE_REPLACE(UIWazaManage$$OnUpdate) {
                     }
                     else
                     {
-                        disp->fields.learnWazaNo = __this->fields.param.fields.LearnWazaNo;
-                        disp->fields.unlearnWazaNo = disp->fields.selectWazaNo;
-
                         Dpr::Message::MessageWordSetHelper::getClass()->initIfNeeded();
                         Dpr::Message::MessageWordSetHelper::SetWazaNameWord(0, disp->fields.selectWazaNo);
                         labelName = System::String::Create("SS_waza_remember_043");

--- a/src/mod/features/save_data/dex_expansion.cpp
+++ b/src/mod/features/save_data/dex_expansion.cpp
@@ -30,6 +30,7 @@ void exl_save_dex_expansion_main() {
     using namespace exl::armv8::reg;
     exl::patch::CodePatcher p(0);
     auto inst = nn::vector<exl::patch::Instruction> {
+        { 0x017da928, Movz(W19, DexSize) },
         { 0x017dbd3c, CmpImmediate(W19, DexSize - 1) },
         { 0x017dc8b4, CmpImmediate(W20, DexSize - 1) },
         { 0x017dc9d0, CmpImmediate(W19, DexSize - 1) },

--- a/src/mod/features/surf_end_check.cpp
+++ b/src/mod/features/surf_end_check.cpp
@@ -9,14 +9,14 @@
 #include "logger/logger.h"
 
 HOOK_DEFINE_TRAMPOLINE(FieldPlayerEntity$$CheckEndSwim) {
-    static void Callback(FieldPlayerEntity::Object* __this, UnityEngine::Vector2::Object inputDir) {
+    static bool Callback(FieldPlayerEntity::Object* __this, UnityEngine::Vector2::Fields inputDir) {
         if (PlayerWork::get_zoneID() == array_index(ZONES, "Distortion World 1")) {
-            Logger::log("[FieldPlayerEntity$$CheckEndSwim] We're in the DW, so ignore swim end\n");
-            return;
+            //Logger::log("[FieldPlayerEntity$$CheckEndSwim] We're in the DW, so ignore swim end\n");
+            return false;
         }
         else {
-            Logger::log("[FieldPlayerEntity$$CheckEndSwim] We're NOT in the DW, so CheckEndSwim\n");
-            Orig(__this, inputDir);
+            //Logger::log("[FieldPlayerEntity$$CheckEndSwim] We're NOT in the DW, so CheckEndSwim\n");
+            return Orig(__this, inputDir);
         }
     }
 };


### PR DESCRIPTION
- Fixes the logic when the Exp. Share Item feature is enabled.
  - If the global Exp. Share feature is enabled and the Exp. Share was disabled in the settings, only share experience if the Pokémon is holding the Exp. Share item.
  - Otherwise, always share experience. The Exp. Share item acts as a Lucky Egg when held.
- Adds a missing Pokédex size patch.
- Fixes the wrong textbox showing when cancelling learning a move from the field.
- Fixes the Surf End Check feature not returning the right values.