### PR TITLE
AddTamagoExtra and AddPokemonExtra

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1302,6 +1302,7 @@ namespace Dpr::EvScript {
             _SET_EFFORT_VALUE = 1292,
             _SET_INDIVIDUAL_VALUE = 1293,
             _CUSTOM_NUMBER_INPUT = 1294,
+            _ADD_TAMAGO_EXTRA = 1295,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1303,6 +1303,7 @@ namespace Dpr::EvScript {
             _SET_INDIVIDUAL_VALUE = 1293,
             _CUSTOM_NUMBER_INPUT = 1294,
             _ADD_TAMAGO_EXTRA = 1295,
+            _ADD_POKEMON_EXTRA = 1296,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/externals/Dpr/EvScript/EvDataManager.h
+++ b/src/mod/externals/Dpr/EvScript/EvDataManager.h
@@ -392,6 +392,7 @@ namespace Dpr::EvScript {
         static inline StaticILMethod<0x04c7cf70, bool, System::String::Object*>    Method$$EvDataManager_EvCmdNameInPoke_OnComplete {};
         static inline StaticILMethod<0x04c7cfd0>                                   Method$$EvDataManager_CmdFirstPokeSelectProc {};
         static inline StaticILMethod<0x04c7cfd8, int32_t>                          Method$$EvDataManager_EvCmdAddPokemonUI {};
+        static inline StaticILMethod<0x04c7cfe0, int32_t>                          Method$$EvDataManager_EvCmdAddTamago {};
         static inline StaticILMethod<0x04c7d040, int32_t, int32_t>                 Method$$EvDataManager_EvCmdCallWazaOmoidashiUi {};
         static inline StaticILMethod<0x04c7d1e0, Dpr::UI::UIWindow::Object*>       Method$$EvDataManager_EvCmd_USE_SPECIAL_ITEM_b__1719_0 {};
         static inline StaticILMethod<0x04c77cf8, System::String::Object*, int32_t, System::ValueTuple2$$Bool$$String> Method$$EvDataManager_EvCmdBirthDayInput_OnInputCheck {};
@@ -437,6 +438,13 @@ namespace Dpr::EvScript {
             if (Method$$EvCmdAddPokemonUIExtra == nullptr)
                 Method$$EvCmdAddPokemonUIExtra = (*Method$$EvDataManager_EvCmdAddPokemonUI)->copyWith(method);
             return Method$$EvCmdAddPokemonUIExtra;
+        };
+
+        static inline MethodInfo* Method$$EvCmdAddTamagoExtra = nullptr;
+        static MethodInfo* getMethod$$EvCmdAddTamagoExtra(Il2CppMethodPointer method) {
+            if (Method$$EvCmdAddTamagoExtra == nullptr)
+                Method$$EvCmdAddTamagoExtra = (*Method$$EvDataManager_EvCmdAddTamago)->copyWith(method);
+            return Method$$EvCmdAddTamagoExtra;
         };
 
         static inline MethodInfo* Method$$EvCmdBirthDayInput_CompleteCustomNumberInput = nullptr;

--- a/src/mod/externals/Dpr/UI/UIZukanRegister.h
+++ b/src/mod/externals/Dpr/UI/UIZukanRegister.h
@@ -43,5 +43,9 @@ namespace Dpr::UI {
         inline void Open(Pml::PokePara::PokemonParam::Object* pokemonParam, bool isSkipAddMemberProc, int32_t prevWindowId) {
             external<void>(0x01a3cd30, this, pokemonParam, isSkipAddMemberProc, prevWindowId);
         }
+
+        inline void OpenAddMemberOnly(Pml::PokePara::PokemonParam::Object* pokemonParam, bool isNotAddMember, int32_t prevWindowId) {
+            external<void>(0x01a3cfd0, this, pokemonParam, isNotAddMember, prevWindowId);
+        }
     };
 }

--- a/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
+++ b/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
@@ -15,6 +15,9 @@ namespace poketool::poke_memo {
         static inline void SetFromCapture(Pml::PokePara::CoreParam::Object* pParam, DPData::MYSTATUS::Object* pMystatus, uint32_t placeNo) {
             external<void>(0x02bacb10, pParam, pMystatus, placeNo);
         }
+        static inline void SetFromEggTaken(Pml::PokePara::CoreParam::Object* pParam, DPData::MYSTATUS::Object* pMystatus, uint32_t placeNo) {
+            external<void>(0x02bad060, pParam, pMystatus, placeNo);
+        }
 
         static inline void ClearPlaceTime(Pml::PokePara::CoreParam::Object* pParam, poketool::poke_memo::DataType type) {
             external<void>(0x02bacca0, pParam, type);

--- a/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
+++ b/src/mod/externals/poketool/poke_memo/poketool_poke_memo.h
@@ -15,6 +15,7 @@ namespace poketool::poke_memo {
         static inline void SetFromCapture(Pml::PokePara::CoreParam::Object* pParam, DPData::MYSTATUS::Object* pMystatus, uint32_t placeNo) {
             external<void>(0x02bacb10, pParam, pMystatus, placeNo);
         }
+
         static inline void SetFromEggTaken(Pml::PokePara::CoreParam::Object* pParam, DPData::MYSTATUS::Object* pMystatus, uint32_t placeNo) {
             external<void>(0x02bad060, pParam, pMystatus, placeNo);
         }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -178,6 +178,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(CustomNumberInput(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA:
                     return HandleCmdStepper(AddTamagoExtra(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_EXTRA:
+                    return HandleCmdStepper(AddPokemonExtra(__this));
                 default:
                     break;
             }
@@ -277,6 +279,7 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_INDIVIDUAL_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ADD_POKEMON_EXTRA);
 
     exl_commands_hooks_main();
 }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -176,8 +176,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(SetIndividualValue(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT:
                     return HandleCmdStepper(CustomNumberInput(__this));
-            case Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA:
-                return HandleCmdStepper(AddTamagoExtra(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA:
+                    return HandleCmdStepper(AddTamagoExtra(__this));
                 default:
                     break;
             }

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -176,6 +176,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(SetIndividualValue(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT:
                     return HandleCmdStepper(CustomNumberInput(__this));
+            case Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA:
+                return HandleCmdStepper(AddTamagoExtra(__this));
                 default:
                     break;
             }
@@ -274,6 +276,7 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_EFFORT_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_INDIVIDUAL_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_ADD_TAMAGO_EXTRA);
 
     exl_commands_hooks_main();
 }

--- a/src/mod/features/commands/add_pokemon_extra.cpp
+++ b/src/mod/features/commands/add_pokemon_extra.cpp
@@ -1,0 +1,101 @@
+#include "features/commands/utils/cmd_utils.h"
+
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/FieldPoketch.h"
+#include "externals/PlayerWork.h"
+#include "externals/poketool/poke_memo/poketool_poke_memo.h"
+#include "externals/ZukanWork.h"
+
+#include "logger/logger.h"
+
+bool AddPokemonExtra(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    Logger::log("_ADD_POKEMON_EXTRA\n");
+    system_load_typeinfo(0x43be);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    if (args->max_length >= 4) {
+
+        auto monsNo = GetWorkOrIntValue(args->m_Items[1]);
+        auto formNo = GetWorkOrIntValue(args->m_Items[2]);
+        auto level = GetWorkOrIntValue(args->m_Items[3]);
+        auto item = -1; // Defaults to none in case arg not given
+        auto maxIVs = -1; // Defaults to none in case arg not given
+        auto ball = -1; // Defaults to regular poke ball in case arg not given
+        auto shiny = -1; // Defaults to regular shiny calculation in case arg not given
+        auto gender = -1; // Defaults to regular gender calculation in case arg not given
+        auto formArg = -1; // Defaults to no variant in case arg not given
+        auto nature = -1; // Defaults to regular nature calculation in case arg not given
+        auto ability = -1; // Defaults to regular ability calculation in case arg not given
+
+        if (args->max_length >= 5) {
+            item = GetWorkOrIntValue(args->m_Items[4]);
+            if (item == -1) {
+                item = 0;
+            }
+        }
+        if (args->max_length >= 6) {
+            maxIVs = GetWorkOrIntValue(args->m_Items[5]);
+        }
+        if (args->max_length >= 7) {
+            ball = GetWorkOrIntValue(args->m_Items[6]);
+        }
+        if (args->max_length >= 8) {
+            shiny = GetWorkOrIntValue(args->m_Items[7]);
+        }
+        if (args->max_length >= 9) {
+            gender = GetWorkOrIntValue(args->m_Items[8]);
+        }
+        if (args->max_length >= 10) {
+            formArg = GetWorkOrIntValue(args->m_Items[9]);
+        }
+        if (args->max_length >= 11) {
+            nature = GetWorkOrIntValue(args->m_Items[10]);
+        }
+        if (args->max_length >= 12) {
+            ability = GetWorkOrIntValue(args->m_Items[11]);
+        }
+
+        Pml::PokePara::InitialSpec::Object* initialSpec = Pml::PokePara::InitialSpec::newInstance();
+        initialSpec->fields.monsno = monsNo;
+        initialSpec->fields.formno = formNo;
+        initialSpec->fields.level = level;
+        if (maxIVs >= 0) initialSpec->fields.talentVNum = maxIVs;
+        if (gender >= 0) initialSpec->fields.sex = gender;
+        if (nature >= 0) initialSpec->fields.seikaku = nature;
+        if (ability >= 0) initialSpec->fields.tokuseiIndex = ability;
+        auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
+        if (item > 0) coreParam->SetItem(item);
+
+        if (ball == -1) {
+            ball = 4;
+        }
+        coreParam->SetGetBall(ball);
+
+        if (shiny == 0) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE); // Never shiny
+        if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED); // Shiny
+        if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED); // Square shiny
+        if (formArg >= 0) coreParam->SetMultiPurposeWork(formArg);
+
+        PlayerWork::getClass()->initIfNeeded();
+        auto pMyStatus = PlayerWork::get_playerStatus();
+        auto placeNo = PlayerWork::get_zoneID();
+        poketool::poke_memo::poketool_poke_memo::SetFromCapture(coreParam, pMyStatus, placeNo);
+
+        auto party = PlayerWork::get_playerParty();
+        auto member = reinterpret_cast<Pml::PokePara::PokemonParam::Object*>(coreParam);
+        auto result = party->AddMember(member);
+
+        //Resolves a vanilla bug with _ADD_POKEMON setting the dex entry even if there was no space in the party.
+        if (result == true) {
+            ZukanWork::SetPoke(member, 3);
+            FieldPoketch::AddPokemonHistory(member);
+        }
+        else {
+            Logger::log("No space in the party. Member not added and dex entry not set.\n");
+        }
+
+    }
+    return true;
+}

--- a/src/mod/features/commands/add_tamago_extra.cpp
+++ b/src/mod/features/commands/add_tamago_extra.cpp
@@ -1,12 +1,13 @@
-#include "externals/Dpr/EvScript/EvDataManager.h"
-#include "externals/PlayerWork.h"
-
 #include "features/commands/utils/cmd_utils.h"
-#include "logger/logger.h"
-#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+
+#include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/Dpr/UI/UIManager.h"
 #include "externals/Dpr/UI/UIZukanRegister.h"
+#include "externals/PlayerWork.h"
 #include "externals/poketool/poke_memo/poketool_poke_memo.h"
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+
+#include "logger/logger.h"
 
 void EvCmdAddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager, int32_t addMemberResult) {
     EvData::Aregment::Array* args = manager->fields._evArg;
@@ -40,7 +41,7 @@ bool AddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager)
             auto formNo = GetWorkOrIntValue(args->m_Items[2]);
             auto receivedFrom = -1; // Defaults to ZoneID in case arg not given
             auto maxIVs = -1; // Defaults to regular IVs calculation in case arg not given
-            auto ball = 4; // Defaults to regular Poke Ball in case arg not given
+            auto ball = -1; // Defaults to regular Poke Ball in case arg not given
             auto shiny = -1; // Defaults to regular shiny calculation in case arg not given
             auto gender = -1; // Defaults to regular gender calculation in case arg not given
             auto formArg = -1; // Defaults to no variant in case arg not given
@@ -80,7 +81,12 @@ bool AddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager)
             if (nature >= 0) initialSpec->fields.seikaku = nature;
             if (ability >= 0) initialSpec->fields.tokuseiIndex = ability;
             auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
+
+            if (ball == -1) {
+                ball = 4;
+            }
             coreParam->SetGetBall(ball);
+
             if (shiny == 0) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE); // Never shiny
             if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED); // Shiny
             if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED); // Square shiny

--- a/src/mod/features/commands/add_tamago_extra.cpp
+++ b/src/mod/features/commands/add_tamago_extra.cpp
@@ -1,0 +1,104 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+#include "externals/PlayerWork.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+#include "externals/SmartPoint/AssetAssistant/SingletonMonoBehaviour.h"
+#include "externals/Dpr/UI/UIManager.h"
+#include "externals/Dpr/UI/UIZukanRegister.h"
+#include "externals/poketool/poke_memo/poketool_poke_memo.h"
+
+void EvCmdAddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager, int32_t addMemberResult) {
+    EvData::Aregment::Array* args = manager->fields._evArg;
+    if (args->max_length >= 3) {
+        manager->fields._azukariyaSequence = -1;
+        return;
+    }
+}
+
+bool AddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager)
+{
+    //Logger::log("_ADD_TAMAGO_EXTRA\n");
+    system_load_typeinfo(0x43bf);
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+    auto azukariyaSeq = manager->fields._azukariyaSequence;
+
+    if (args->max_length >= 3) {
+        if (azukariyaSeq == 0) {
+            SmartPoint::AssetAssistant::SingletonMonoBehaviour::getClass()->initIfNeeded();
+            auto uiManager = Dpr::UI::UIManager::get_Instance();
+            auto uiZukanReg = uiManager->CreateUIWindow<Dpr::UI::UIZukanRegister>(UIWindowID::ZUKAN_REGISTER);
+
+            MethodInfo* mi = Dpr::EvScript::EvDataManager::getMethod$$EvCmdAddTamagoExtra((Il2CppMethodPointer) &EvCmdAddTamagoExtra);
+            auto onComplete = System::Action::getClass(
+                    System::Action::UIZukanRegister_AddMemberResult_TypeInfo)->newInstance(manager, mi);
+
+            uiZukanReg->add_OnComplete(onComplete);
+
+            auto monsNo = GetWorkOrIntValue(args->m_Items[1]);
+            auto formNo = GetWorkOrIntValue(args->m_Items[2]);
+            auto receivedFrom = -1; // Defaults to ZoneID in case arg not given
+            auto maxIVs = -1; // Defaults to regular IVs calculation in case arg not given
+            auto ball = 4; // Defaults to regular Poke Ball in case arg not given
+            auto shiny = -1; // Defaults to regular shiny calculation in case arg not given
+            auto gender = -1; // Defaults to regular gender calculation in case arg not given
+            auto formArg = -1; // Defaults to no variant in case arg not given
+            auto nature = -1; // Defaults to regular nature calculation in case arg not given
+            auto ability = -1; // Defaults to regular ability calculation in case arg not given
+
+            if (args->max_length >= 4) {
+                receivedFrom = GetWorkOrIntValue(args->m_Items[3]);
+            }
+            if (args->max_length >= 5) {
+                maxIVs = GetWorkOrIntValue(args->m_Items[4]);
+            }
+            if (args->max_length >= 6) {
+                ball = GetWorkOrIntValue(args->m_Items[5]);
+            }
+            if (args->max_length >= 7) {
+                shiny = GetWorkOrIntValue(args->m_Items[6]);
+            }
+            if (args->max_length >= 8) {
+                gender = GetWorkOrIntValue(args->m_Items[7]);
+            }
+            if (args->max_length >= 9) {
+                formArg = GetWorkOrIntValue(args->m_Items[8]);
+            }
+            if (args->max_length >= 10) {
+                nature = GetWorkOrIntValue(args->m_Items[9]);
+            }
+            if (args->max_length >= 11) {
+                ability = GetWorkOrIntValue(args->m_Items[10]);
+            }
+
+            Pml::PokePara::InitialSpec::Object* initialSpec = Pml::PokePara::InitialSpec::newInstance();
+            initialSpec->fields.monsno = monsNo;
+            initialSpec->fields.formno = formNo;
+            if (maxIVs >= 0) initialSpec->fields.talentVNum = maxIVs;
+            if (gender >= 0) initialSpec->fields.sex = gender;
+            if (nature >= 0) initialSpec->fields.seikaku = nature;
+            if (ability >= 0) initialSpec->fields.tokuseiIndex = ability;
+            auto coreParam = Pml::PokePara::PokemonParam::newInstance(initialSpec)->cast<Pml::PokePara::CoreParam>();
+            coreParam->SetGetBall(ball);
+            if (shiny == 0) coreParam->SetRareType(Pml::PokePara::RareType::NOT_RARE); // Never shiny
+            if (shiny == 1) coreParam->SetRareType(Pml::PokePara::RareType::CAPTURED); // Shiny
+            if (shiny == 2) coreParam->SetRareType(Pml::PokePara::RareType::DISTRIBUTED); // Square shiny
+            if (formArg >= 0) coreParam->SetMultiPurposeWork(formArg);
+            coreParam->ChangeEgg();
+
+            PlayerWork::getClass()->initIfNeeded();
+            auto pMyStatus = PlayerWork::get_playerStatus();
+            auto placeNo = PlayerWork::get_zoneID();
+            if (receivedFrom >= 0) {
+                placeNo = receivedFrom;
+            }
+            poketool::poke_memo::poketool_poke_memo::SetFromEggTaken(coreParam, pMyStatus, placeNo);
+
+            uiZukanReg->OpenAddMemberOnly(reinterpret_cast<Pml::PokePara::PokemonParam::Object*>(coreParam), false, -1);
+            azukariyaSeq = 0;
+            manager->fields._azukariyaSequence = 1;
+        }
+    }
+    return azukariyaSeq < 0;
+}

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -526,3 +526,18 @@ bool CustomNumberInput(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] nature: (optional) The Nature that the Pokémon will be forced to have. -1 = Random
 //   [Work, Number] ability: (optional) The Ability that the Pokémon will be forced to have. -1 = Random, 0 = A1, 1 = A2, 2 = HA
 bool AddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gives a Pokémon to the Player.
+// Arguments:
+//   [Work, Number] monsno: ID of the species to give.
+//   [Work, Number] formno: ID of the form the species is in.
+//   [Work, Number] level: Level of the Pokémon to give.
+//   [Work, Number] item: (optional) ID of the item the Pokémon is to hold.
+//   [Work, Number] maxIVs: (optional) Number of max IVs the Pokémon will have.
+//   [Work, Number] ball: (optional) ID of the ball the Pokémon will reside in.
+//   [Work, Number] shiny: (optional) Determines if the Pokémon is forced to be shiny. -1 = Random, 0 = Never Shiny, 1 = Shiny, 2 = Square Shiny
+//   [Work, Number] gender: (optional) Gender that the Pokémon will be forced to be. -1 = Random, 0 = Male, 1 = Female, 2 = Genderless
+//   [Work, Number] formArg: (optional) The Variant that the Pokémon will be forced to be. -1 = No argument/Default
+//   [Work, Number] nature: (optional) The Nature that the Pokémon will be forced to have. -1 = Random
+//   [Work, Number] ability: (optional) The Ability that the Pokémon will be forced to have. -1 = Random, 0 = A1, 1 = A2, 2 = HA
+bool AddPokemonExtra(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -512,3 +512,17 @@ bool SetIndividualValue(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] maxValue: Maximum value that the player can input.
 //   [String] headerLabel: Message Label containing text to be displayed in the header.
 bool CustomNumberInput(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gives a Pokémon Egg to the Player.
+// Arguments:
+//   [Work, Number] monsno: ID of the species to give.
+//   [Work, Number] formno: ID of the form the species is in.
+//   [Work, Number] receivedFrom: (optional) Where the egg was recieved from. Will be current zone if no argument is given.
+//   [Work, Number] maxIVs: (optional) Number of max IVs the Pokémon will have.
+//   [Work, Number] ball: (optional) ID of the ball the Pokémon will reside in. Regular Poke Ball if no argument is given.
+//   [Work, Number] shiny: (optional) Determines if the Pokémon is forced to be shiny. -1 = Random, 0 = Never Shiny, 1 = Shiny, 2 = Square Shiny
+//   [Work, Number] gender: (optional) Gender that the Pokémon will be forced to be. -1 = Random, 0 = Male, 1 = Female, 2 = Genderless
+//   [Work, Number] formArg: (optional) The Variant that the Pokémon will be forced to be. -1 = No argument/Default
+//   [Work, Number] nature: (optional) The Nature that the Pokémon will be forced to have. -1 = Random
+//   [Work, Number] ability: (optional) The Ability that the Pokémon will be forced to have. -1 = Random, 0 = A1, 1 = A2, 2 = HA
+bool AddTamagoExtra(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -517,9 +517,9 @@ bool CustomNumberInput(Dpr::EvScript::EvDataManager::Object* manager);
 // Arguments:
 //   [Work, Number] monsno: ID of the species to give.
 //   [Work, Number] formno: ID of the form the species is in.
-//   [Work, Number] receivedFrom: (optional) Where the egg was recieved from. Will be current zone if no argument is given.
-//   [Work, Number] maxIVs: (optional) Number of max IVs the Pokémon will have.
-//   [Work, Number] ball: (optional) ID of the ball the Pokémon will reside in. Regular Poke Ball if no argument is given.
+//   [Work, Number] receivedFrom: (optional) Where the egg was recieved from. Will be current zone if no argument is given. -1 = No Argument
+//   [Work, Number] maxIVs: (optional) Number of max IVs the Pokémon will have. -1 = No Argument
+//   [Work, Number] ball: (optional) ID of the ball the Pokémon will reside in. 4 = Default Poke Ball
 //   [Work, Number] shiny: (optional) Determines if the Pokémon is forced to be shiny. -1 = Random, 0 = Never Shiny, 1 = Shiny, 2 = Square Shiny
 //   [Work, Number] gender: (optional) Gender that the Pokémon will be forced to be. -1 = Random, 0 = Male, 1 = Female, 2 = Genderless
 //   [Work, Number] formArg: (optional) The Variant that the Pokémon will be forced to be. -1 = No argument/Default


### PR DESCRIPTION
Adds Command 1295 _ADD_TAMAGO_EXTRA to allow for giving the player eggs with the following args (only the first two are mandatory):

`monsno, formno, receivedFrom, maxIVs, ball, shiny, gender, formArg, nature, ability`

Adds Command 1296 _ADD_POKEMON_EXTRA to allow for giving the player a Pokemon, with no UI popup, with the following args:

`monsno, formno, level, item, maxIVs, ball, shiny, gender, formArg, nature, ability`