### PR TITLE
Add _GET_GAME_MODE command

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1302,6 +1302,8 @@ namespace Dpr::EvScript {
             _SET_EFFORT_VALUE = 1292,
             _SET_INDIVIDUAL_VALUE = 1293,
             _CUSTOM_NUMBER_INPUT = 1294,
+            // 1295-1298 reserved by the lookers-hat branch (PR #226)
+            _GET_GAME_MODE = 1299,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -176,6 +176,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(SetIndividualValue(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT:
                     return HandleCmdStepper(CustomNumberInput(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GET_GAME_MODE:
+                    return HandleCmdStepper(GetGameMode(__this));
                 default:
                     break;
             }
@@ -274,6 +276,7 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_EFFORT_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_INDIVIDUAL_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_GAME_MODE);
 
     exl_commands_hooks_main();
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -512,3 +512,8 @@ bool SetIndividualValue(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] maxValue: Maximum value that the player can input.
 //   [String] headerLabel: Message Label containing text to be displayed in the header.
 bool CustomNumberInput(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gets the current game mode from the extra settings save data.
+// Arguments:
+//   [Work] result: The work in which to put the result. 0 = 493 Mode, 1 = NatDex Mode, 2 = Challenge Mode.
+bool GetGameMode(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/get_game_mode.cpp
+++ b/src/mod/features/commands/get_game_mode.cpp
@@ -1,0 +1,18 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+#include "save/save.h"
+
+bool GetGameMode(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_GET_GAME_MODE\n");
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    if (args->max_length >= 2) {
+        auto gameMode = (int32_t)getCustomSaveData()->settings.gameMode;
+        SetWorkToValue(args->m_Items[1], gameMode);
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
Adds `_GET_GAME_MODE` (1299) — returns the current game mode from the extra settings save data into a work variable: 0 = 493 Mode, 1 = NatDex Mode, 2 = Challenge Mode.

This lets scripts query the actual saved mode instead of relying on work 487 staying in sync, per TeamLumi/Romhack_Unity#79.

IDs 1295-1298 are left reserved for the commands in #226.

Companion PR: TeamLumi/Romhack_Unity#354 (uses the command in `trainer.ev`)

## Test plan
- [ ] `_GET_GAME_MODE(@SCWK_ANSWER)` returns 0/1/2 matching the mode chosen in settings
- [ ] Trainer ID offsets (+2000/+4000) still resolve correctly in talk battles via the companion PR