### PR TITLE
Add docker based builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git/
+.cache/
+.idea/
+.vscode/
+build/
+build-release/
+cmake-build-*/
+config.cmake
+socket.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 
 FROM devkitpro/devkita64:20260219 AS builder
 
+ARG BUILD_TYPE=Release
+
 ENV DEBIAN_FRONTEND=noninteractive \
     CCACHE_DIR=/root/.cache/ccache \
     CCACHE_COMPRESS=1 \
@@ -16,7 +18,7 @@ WORKDIR /src
 COPY . .
 
 RUN cmake -G "Unix Makefiles" \
-    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
     -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake \
     -DCMAKE_CXX_FLAGS="-fpermissive -fPIC" \
     -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# syntax=docker/dockerfile:1.7
+
+FROM devkitpro/devkita64:20260219 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    CCACHE_DIR=/root/.cache/ccache \
+    CCACHE_COMPRESS=1 \
+    CCACHE_MAXSIZE=1G
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends ccache \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+COPY . .
+
+RUN cmake -G "Unix Makefiles" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake \
+    -DCMAKE_CXX_FLAGS="-fpermissive -fPIC" \
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+    -Bbuild
+
+RUN --mount=type=cache,target=/root/.cache/ccache \
+    cmake --build build --target RomBase_release_all --parallel "$(nproc)"
+
+FROM scratch AS artifacts
+
+COPY --from=builder /src/build/RomBase_releases/atmosphere/ /atmosphere/
+COPY --from=builder /src/build/RomBase_releases/modmanager/ /modmanager/
+COPY --from=builder /src/build/RomBase_releases/ryujinx/ /ryujinx/
+COPY --from=builder /src/build/RomBase_releases/yuzu/ /yuzu/

--- a/README.md
+++ b/README.md
@@ -21,9 +21,20 @@ It has been modified to be used for Pokémon Luminescent.
 - 2-button poketch
 
 ### Building
+
+## Local Build
 Building requires Linux or a WSL instance for the building process.
 
 Detailed instructions can be found on [Team Luminescent's website](https://luminescent.team/rom-hacking/exefs/guide#building).
+
+## Containerized Build
+To build with Docker and export directly to a local `build` folder, run:
+
+```powershell
+docker buildx build --target artifacts --output type=local,dest=./build .
+```
+
+This outputs the build artifacts to `./build/atmosphere`, `./build/modmanager`, `./build/ryujinx`, and `./build/yuzu`.
 
 ### License
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ docker buildx build --target artifacts --output type=local,dest=./build .
 
 This outputs the build artifacts to `./build/atmosphere`, `./build/modmanager`, `./build/ryujinx`, and `./build/yuzu`.
 
+Docker builds default to `Release`. To generate a debug build instead, set `BUILD_TYPE=Debug`:
+
+```powershell
+docker buildx build --build-arg BUILD_TYPE=Debug --target artifacts --output type=local,dest=./build .
+```
+
 ### License
 
 This project is licensed under the terms of the [BSD-3-Clause license](./LICENSE). 


### PR DESCRIPTION
Mirror the GitHub Actions builder for local use with Docker buildx
 - Includes ccache compiler cache