### PR TITLE
UG visible shinies: periodic sparkle glint on shiny Pokémon

### DIFF
--- a/src/mod/externals/FieldManager.h
+++ b/src/mod/externals/FieldManager.h
@@ -101,6 +101,15 @@ struct FieldManager : ILClass<FieldManager, 0x04c5a638> {
         external<void>(0x0179f330, this, type, trainerid1, trainerid2);
     }
 
+    // CallEffect(EffectFieldID index, Transform parent, Action<EffectInstance> load,
+    //            UnityAction<EffectInstance> onFinished) @ 0x178A200 — plays a field
+    // effect (e.g. EF_F_GRASS_SPARKLE=14) parented to a transform; handles async load.
+    // Callbacks are optional (the PlayEffect coroutine null-checks before invoking).
+    inline void CallEffect(int32_t effectId, UnityEngine::Transform::Object* parent,
+                           void* loadCallback, void* onFinished) {
+        external<void>(0x178A200, this, effectId, parent, loadCallback, onFinished);
+    }
+
     inline int32_t get_areaID() {
         return external<int32_t>(0x01797f90, this);
     }

--- a/src/mod/features/ug_shinies.cpp
+++ b/src/mod/features/ug_shinies.cpp
@@ -3,6 +3,7 @@
 #include "externals/Audio/AudioManager.h"
 #include "externals/Dpr/Message/MessageMsgFile.h"
 #include "externals/Dpr/UI/ShopItemItem.h"
+#include "externals/FieldManager.h"
 #include "externals/GameData/DataManager.h"
 #include "externals/Pml/PokePara/PokemonParam.h"
 #include "externals/SmartPoint/AssetAssistant/AssetManager.h"
@@ -16,6 +17,16 @@
 
 const int32_t AUDIOEVENTID_SHINY = 753281501;
 const int32_t AUDIOEVENTID_TEST = 3075682360;
+
+// Shiny-only periodic glint on the wandering UG Pokemon themselves — the same
+// hidden-item-style "kirakira" the overworld uses, so a shiny is spottable at a
+// distance (on top of the shiny model + the scene-init jingle above).
+// EF_F_GRASS_SPARKLE=14, played via FieldManager::CallEffect parented to the mon
+// (the effect prefab is audio-less; FieldManager stays alive underground).
+static constexpr float UG_SHINY_SPARKLE_INTERVAL   = 2.5f;
+static constexpr int32_t UG_SHINY_SPARKLE_EFFECT_ID = 14;
+static constexpr int32_t UG_SPARKLE_MAX_MONS        = 64;
+static float s_ugSparkleTimers[UG_SPARKLE_MAX_MONS] = {};
 
 HOOK_DEFINE_INLINE(UgMainProc_DisplayClass9_0$$CreatePoke_b__0_ShinyFix) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
@@ -76,10 +87,45 @@ HOOK_DEFINE_TRAMPOLINE(UgMainProc$$OnSceneInit_ShinySound) {
 };
 
 
+// UgMainProc::update(float time) — the underground's per-frame tick for the wild
+// symbol mons. After the vanilla update, run the shiny glint pass over _ugMons.
+HOOK_DEFINE_TRAMPOLINE(UgMainProc$$Update_ShinySparkle) {
+    static bool Callback(UgMainProc::Object* __this, float time) {
+        bool result = Orig(__this, time);
+
+        if (__this->fields._ugMons != nullptr) {
+            auto arr = __this->fields._ugMons->instance()->fields;
+            FieldManager::getClass()->initIfNeeded();
+            auto* fm = FieldManager::getClass()->static_fields->_Instance_k__BackingField;
+
+            for (int32_t i = 0; i < arr._size && i < UG_SPARKLE_MAX_MONS; i++) {
+                auto* sm = (arr._items != nullptr) ? arr._items->m_Items[i] : nullptr;
+                if (sm == nullptr) { s_ugSparkleTimers[i] = 0.0f; continue; }
+                auto& f = sm->fields;
+                if (!f.Active || !f.isLoaded || f.transform == nullptr ||
+                    f.pokeParam == nullptr ||
+                    !f.pokeParam->cast<Pml::PokePara::CoreParam>()->IsRare()) {
+                    s_ugSparkleTimers[i] = 0.0f;
+                    continue;
+                }
+                s_ugSparkleTimers[i] += time;
+                if (s_ugSparkleTimers[i] >= UG_SHINY_SPARKLE_INTERVAL) {
+                    s_ugSparkleTimers[i] = 0.0f;
+                    if (fm != nullptr) {
+                        fm->CallEffect(UG_SHINY_SPARKLE_EFFECT_ID, f.transform, nullptr, nullptr);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+};
+
 void exl_ug_shinies_main() {
     UgMainProc_DisplayClass9_0$$CreatePoke_b__0_ShinyFix::InstallAtOffset(0x018d5ea0);
     UgResManager$$AppendAsset_ShinyFix::InstallAtOffset(0x01b1b110);
     UgMainProc$$OnSceneInit_ShinySound::InstallAtOffset(0x018d2af0);
+    UgMainProc$$Update_ShinySparkle::InstallAtOffset(0x018d4270);
 
     using namespace exl::armv8::inst;
     using namespace exl::armv8::reg;


### PR DESCRIPTION
Shiny underground Pokémon now emit the hidden-item-style *kirakira* glint every ~2.5s, parented to the wandering mon so it follows — making shinies spottable at a distance, on top of the shiny model and the scene-init jingle the Underground Visible Shinies feature already provides.

## Implementation
- Hooks `UgMainProc::update(float)` @ `0x18D4270` (the underground's per-frame symbol-mon tick) and runs a glint pass over `_ugMons` after the vanilla update: gated on `Active && isLoaded && pokeParam->IsRare()`, with per-slot timers.
- Plays `EF_F_GRASS_SPARKLE` (14) via a new `FieldManager::CallEffect(EffectFieldID, Transform parent, Action load, UnityAction onFinished)` external @ `0x178A200`. The effect prefab contains only particle systems (no audio component — verified against the vanilla `ef_f_grass_sparkle` bundle), so no stray sound plays.
- `FieldManager` and the effect pipeline remain alive underground, and the parented overload keeps the glint attached while the mon wanders.

## Notes
- The `FieldManager.h` `CallEffect` hunk is identical to the one added on the `symbol-encounters` branch (#232), which uses the same glint for overworld shiny symbols — whichever merges second will see a trivial same-content conflict.
- Timer array is capped at 64 slots (well above the UG's max concurrent symbol mons).