### PR TITLE
Guard _IF_COORDS_CALL/_IF_COORDS_JUMP against missing entities

### DIFF
--- a/src/mod/features/commands/ifcoords_call.cpp
+++ b/src/mod/features/commands/ifcoords_call.cpp
@@ -1,5 +1,6 @@
 #include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/FieldObjectEntity.h"
+#include "externals/UnityEngine/_Object.h"
 
 #include "features/commands/utils/cmd_utils.h"
 #include "logger/logger.h"
@@ -13,6 +14,15 @@ bool IfCoordsCall(Dpr::EvScript::EvDataManager::Object* manager) {
     EvData::Aregment::Array* args = manager->fields._evArg;
 
     FieldObjectEntity::Object* entity = FindEntity(manager, args->m_Items[1]);
+
+    // Zone-entry scripts can run this before the target entity is spawned (or
+    // reference an object missing from the map) — a raw deref here null-crashes
+    // the game (seen at FieldObjectEntity::get_gridPosition+0). Skip the check
+    // like a coord mismatch instead. Same guard obj_pos_get already uses.
+    if (!UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)entity, nullptr)) {
+        Logger::log("_IFCOORDS_CALL: entity not found — skipping\n");
+        return true;
+    }
 
     auto currentGrid = entity->get_gridPosition();
     int32_t currentX = currentGrid.fields.m_X;

--- a/src/mod/features/commands/ifcoords_jump.cpp
+++ b/src/mod/features/commands/ifcoords_jump.cpp
@@ -1,5 +1,6 @@
 #include "externals/Dpr/EvScript/EvDataManager.h"
 #include "externals/FieldObjectEntity.h"
+#include "externals/UnityEngine/_Object.h"
 
 #include "features/commands/utils/cmd_utils.h"
 #include "logger/logger.h"
@@ -13,6 +14,15 @@ bool IfCoordsJump(Dpr::EvScript::EvDataManager::Object* manager) {
     EvData::Aregment::Array* args = manager->fields._evArg;
 
     FieldObjectEntity::Object* entity = FindEntity(manager, args->m_Items[1]);
+
+    // Zone-entry scripts can run this before the target entity is spawned (or
+    // reference an object missing from the map) — a raw deref here null-crashes
+    // the game (seen at FieldObjectEntity::get_gridPosition+0). Skip the check
+    // like a coord mismatch instead. Same guard obj_pos_get already uses.
+    if (!UnityEngine::_Object::op_Inequality((UnityEngine::_Object::Object*)entity, nullptr)) {
+        Logger::log("_IFCOORDS_JUMP: entity not found — skipping\n");
+        return true;
+    }
 
     auto currentGrid = entity->get_gridPosition();
     int32_t currentX = currentGrid.fields.m_X;


### PR DESCRIPTION
`FindEntity` can return null when a zone-entry script runs `_IF_COORDS_CALL` / `_IF_COORDS_JUMP` before the referenced object is spawned (or when the object is missing from the map's placement). The unguarded `get_gridPosition()` deref then crashes the game — reproduced as a guest `InvalidMemoryAccess @ 0x0` with PC at `FieldObjectEntity::get_gridPosition+0` and LR inside the command handler, during a zone load whose init script ran the check on the first frame.

## Fix
Both commands now use the same `UnityEngine.Object` lifetime check that `obj_pos_get` already uses, and treat a missing entity like a coordinate mismatch — the check is skipped (no call/jump) and the script continues, with a `Logger` line for script debugging.

No behavior change when the entity exists.