### PR TITLE
Illusion Fixes: model reverts on break + target selector shows disguise

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -61,6 +61,7 @@ static constexpr const char* FEATURES[] = {
     "Underground Statue Names",
     "Underground Visible Shinies",
     "More Time Flags",
+    "Illusion Fixes",
 };
 
 constexpr int FEATURE_COUNT = sizeof(FEATURES) / sizeof(FEATURES[0]);

--- a/src/mod/externals/Dpr/Battle/Logic/BTL_POKEPARAM.h
+++ b/src/mod/externals/Dpr/Battle/Logic/BTL_POKEPARAM.h
@@ -202,6 +202,15 @@ namespace Dpr::Battle::Logic {
             return external<uint8_t>(0x01fd8a50, this);
         }
 
+        inline bool IsFakeEnable() {
+            return external<bool>(0x01fe3220, this);
+        }
+
+        // Valid only while IsFakeEnable().
+        inline uint8_t GetFakeTargetPokeID() {
+            return external<uint8_t>(0x01fe3230, this);
+        }
+
         inline bool CONFRONT_REC_IsMatch(int32_t pokeID) {
             return external<bool>(0x01fe39f0, this, pokeID);
         }

--- a/src/mod/externals/Dpr/Battle/Logic/POKECON.h
+++ b/src/mod/externals/Dpr/Battle/Logic/POKECON.h
@@ -7,13 +7,15 @@
 namespace Dpr::Battle::Logic {
     struct MainModule;
 
-    struct POKECON : ILClass<POKECON> {
+    struct POKECON : ILClass<POKECON, 0x04c5aba8> {
         struct Fields {
             MainModule* m_mainModule;
             BTL_PARTY::Array* m_party;
             BTL_POKEPARAM::Array* m_activePokeParam;
             BTL_POKEPARAM::Array* m_storedPokeParam;
         };
+
+        // No singleton static; the only static is a scratch PokeParty.
 
         inline BTL_PARTY::Object* GetPartyData(uint32_t clientID) {
             return external<BTL_PARTY::Object*>(0x02038600, this, clientID);

--- a/src/mod/externals/Dpr/Battle/Logic/ServerCommandPutter.h
+++ b/src/mod/externals/Dpr/Battle/Logic/ServerCommandPutter.h
@@ -4,6 +4,7 @@
 
 #include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
 #include "externals/Dpr/Battle/Logic/ContFlag.h"
+#include "externals/Dpr/Battle/Logic/StrParam.h"
 
 namespace Dpr::Battle::Logic {
     struct BattleEnv;
@@ -51,6 +52,10 @@ namespace Dpr::Battle::Logic {
 
         inline bool Message(StrParam::Object** strParam) {
             return external<bool>(0x01f27ec0, this, strParam);
+        }
+
+        inline void Act_ChangeForm(uint8_t pokeID) {
+            external<void>(0x01f2bdc0, this, pokeID);
         }
     };
 }

--- a/src/mod/features/features.h
+++ b/src/mod/features/features.h
@@ -178,6 +178,10 @@ void exl_text_color_main();
 // Adds more event flags that get reset daily.
 void exl_time_flags_main();
 
+// Zorua/Zoroark Illusion visual fixes (break reveal, target picker portrait).
+void exl_illusion_break_fix_main();
+void exl_illusion_target_selector_fix_main();
+
 // Allows double battles on trainers.
 void exl_trainer_double_battles_main();
 

--- a/src/mod/features/illusion_break_fix.cpp
+++ b/src/mod/features/illusion_break_fix.cpp
@@ -1,0 +1,14 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Battle/Logic/ServerCommandPutter.h"
+
+HOOK_DEFINE_TRAMPOLINE(IllusionBreak_ActFakeDisable) {
+    static void Callback(Dpr::Battle::Logic::ServerCommandPutter::Object* putter,
+                         uint32_t pokeID, void*) {
+        putter->Act_ChangeForm(static_cast<uint8_t>(pokeID));
+    }
+};
+
+void exl_illusion_break_fix_main() {
+    IllusionBreak_ActFakeDisable::InstallAtOffset(0x1F2E000);
+}

--- a/src/mod/features/illusion_target_selector_fix.cpp
+++ b/src/mod/features/illusion_target_selector_fix.cpp
@@ -1,0 +1,40 @@
+#include "exlaunch.hpp"
+
+#include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
+#include "externals/Dpr/Battle/Logic/POKECON.h"
+
+// POKECON has no singleton static; capture the battle's instance at its ctor.
+static Dpr::Battle::Logic::POKECON::Object* s_pokecon = nullptr;
+
+HOOK_DEFINE_TRAMPOLINE(IllusionPokeconCapture) {
+    static void Callback(Dpr::Battle::Logic::POKECON::Object* __this,
+                         void* mainModule, void* fieldStatus, void* mi) {
+        Orig(__this, mainModule, fieldStatus, mi);
+        s_pokecon = __this;
+    }
+};
+
+HOOK_DEFINE_TRAMPOLINE(IllusionTargetSelector_SetPokemon) {
+    static void Callback(void* button,
+                         Dpr::Battle::Logic::BTL_POKEPARAM::Object* pokeParam,
+                         bool showItem,
+                         void* methodInfo) {
+        auto* displayParam = pokeParam;
+        if (pokeParam != nullptr && pokeParam->IsFakeEnable()) {
+            auto* pc = s_pokecon;
+            // GetPokeParamConst indexes m_activePokeParam unchecked.
+            if (pc != nullptr && pc->fields.m_activePokeParam != nullptr) {
+                uint8_t fakeID = pokeParam->GetFakeTargetPokeID();
+                if (auto* fakePP = pc->GetPokeParamConst(fakeID)) {
+                    displayParam = fakePP;
+                }
+            }
+        }
+        Orig(button, displayParam, showItem, methodInfo);
+    }
+};
+
+void exl_illusion_target_selector_fix_main() {
+    IllusionPokeconCapture::InstallAtOffset(0x2040B90);
+    IllusionTargetSelector_SetPokemon::InstallAtOffset(0x1D284F0);
+}

--- a/src/mod/features/main.cpp
+++ b/src/mod/features/main.cpp
@@ -131,6 +131,10 @@ void CallFeatureHooks()
         exl_ug_shinies_main();
     if (IsActivatedFeature(array_index(FEATURES, "More Time Flags")))
         exl_time_flags_main();
+    if (IsActivatedFeature(array_index(FEATURES, "Illusion Fixes"))) {
+        exl_illusion_break_fix_main();
+        exl_illusion_target_selector_fix_main();
+    }
 
     exl_debug_features_main();
     exl_items_changes_main();


### PR DESCRIPTION
This Fixes #155 !

We had an illusion break issue where the model would not change back to the disguised pokemon.

This fixes part of this this by stealing castform's weather forum change hook and applied it here.
I also hooked SetPokemon and swap the passed BTL_POKEPARAM for the fake target's BTL_POKEPARAM whenever IsFakeEnable() which enables this funcitonality on the target-selection screen where you could originally still see the hidden pokemon.