### PR TITLE
Add _GET_TEAM_RANDOMIZATION command

### DIFF
--- a/src/mod/externals/Dpr/EvScript/EvCmdID.h
+++ b/src/mod/externals/Dpr/EvScript/EvCmdID.h
@@ -1302,6 +1302,9 @@ namespace Dpr::EvScript {
             _SET_EFFORT_VALUE = 1292,
             _SET_INDIVIDUAL_VALUE = 1293,
             _CUSTOM_NUMBER_INPUT = 1294,
+            // 1295-1298 reserved by the lookers-hat branch (PR #226)
+            // 1299 reserved by the get-game-mode-command branch (PR #246)
+            _GET_TEAM_RANDOMIZATION = 1300,
 
             CUSTOM_CMD_END = 1500,
         };

--- a/src/mod/features/commands.cpp
+++ b/src/mod/features/commands.cpp
@@ -176,6 +176,8 @@ HOOK_DEFINE_TRAMPOLINE(RunEvCmdCustom) {
                     return HandleCmdStepper(SetIndividualValue(__this));
                 case Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT:
                     return HandleCmdStepper(CustomNumberInput(__this));
+                case Dpr::EvScript::EvCmdID::NAME::_GET_TEAM_RANDOMIZATION:
+                    return HandleCmdStepper(GetTeamRandomization(__this));
                 default:
                     break;
             }
@@ -274,6 +276,7 @@ void exl_commands_main() {
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_EFFORT_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_SET_INDIVIDUAL_VALUE);
     SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_CUSTOM_NUMBER_INPUT);
+    SetActivatedCommand(Dpr::EvScript::EvCmdID::NAME::_GET_TEAM_RANDOMIZATION);
 
     exl_commands_hooks_main();
 }

--- a/src/mod/features/commands/commands.h
+++ b/src/mod/features/commands/commands.h
@@ -512,3 +512,8 @@ bool SetIndividualValue(Dpr::EvScript::EvDataManager::Object* manager);
 //   [Work, Number] maxValue: Maximum value that the player can input.
 //   [String] headerLabel: Message Label containing text to be displayed in the header.
 bool CustomNumberInput(Dpr::EvScript::EvDataManager::Object* manager);
+
+// Gets the current Boss Team Randomization setting from the extra settings save data.
+// Arguments:
+//   [Work] result: The work in which to put the result. 0 = Random Always, 1 = Random Once, 2 = Fixed Team 1.
+bool GetTeamRandomization(Dpr::EvScript::EvDataManager::Object* manager);

--- a/src/mod/features/commands/get_team_randomization.cpp
+++ b/src/mod/features/commands/get_team_randomization.cpp
@@ -1,0 +1,18 @@
+#include "externals/Dpr/EvScript/EvDataManager.h"
+
+#include "features/commands/utils/cmd_utils.h"
+#include "logger/logger.h"
+#include "save/save.h"
+
+bool GetTeamRandomization(Dpr::EvScript::EvDataManager::Object* manager) {
+    Logger::log("_GET_TEAM_RANDOMIZATION\n");
+
+    EvData::Aregment::Array* args = manager->fields._evArg;
+
+    if (args->max_length >= 2) {
+        auto randomTeamMode = (int32_t)getCustomSaveData()->settings.randomTeamMode;
+        SetWorkToValue(args->m_Items[1], randomTeamMode);
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
Adds `_GET_TEAM_RANDOMIZATION` (1300) — reads the current Boss Team Randomization setting from the extra settings save data into a work variable: 0 = Random Always, 1 = Random Once, 2 = Fixed Team 1.

Fixes #237

## Notes
- Mirrors the structure of the other save-data-reading commands (new handler in `src/mod/features/commands/get_team_randomization.cpp`, dispatch case + `SetActivatedCommand` in `commands.cpp`).
- Command ID 1300 is used because 1295–1298 are reserved by the lookers-hat branch (PR #226) and 1299 by `_GET_GAME_MODE` (PR #246); comments in `EvCmdID.h` document the reservations so merge order doesn't matter.

## Usage
```
_GET_TEAM_RANDOMIZATION(@RESULT_WORK)
```

## Testing
- Builds clean with the WSL devkitPro toolchain (RomBase_release_ryujinx).