### PR TITLE
Let trainers use the player's color variation via ColorID 255

### DIFF
--- a/src/mod/features/color_variations.cpp
+++ b/src/mod/features/color_variations.cpp
@@ -217,6 +217,17 @@ HOOK_DEFINE_INLINE(SetColorID_TrainerParam_StoreCore) {
     }
 };
 
+// The TrainerTable ColorID column is a uint8, so it can't hold the -1 sentinel that makes
+// a trainer use the player's color variation (like the player's mom). Treat 255 as -1 at
+// the point where BSP_TRAINER_DATA$$SetupTrainerData widens the byte into the int32
+// core_data color_id (W9 holds the zero-extended byte right before the str).
+HOOK_DEFINE_INLINE(SetupTrainerData_ColorID255) {
+    static void Callback(exl::hook::nx64::InlineCtx* ctx) {
+        if (ctx->W[9] == 0xFF)
+            ctx->W[9] = (uint32_t)-1;
+    }
+};
+
 HOOK_DEFINE_INLINE(CardModelViewController_LoadModels) {
     static void Callback(exl::hook::nx64::InlineCtx* ctx) {
         auto trainerParam = (Dpr::Battle::View::TrainerSimpleParam::Object*)ctx->X[1];
@@ -319,4 +330,8 @@ void exl_color_variations_main() {
     exl::patch::CodePatcher p(0x020388ac);
     p.WriteInst(Nop());
     SetColorID_TrainerParam_StoreCore::InstallAtOffset(0x020387c4);
+
+    // TrainerTable ColorID 255 -> player's color variation (both SetupTrainerData overloads)
+    SetupTrainerData_ColorID255::InstallAtOffset(0x01ac48d8);
+    SetupTrainerData_ColorID255::InstallAtOffset(0x01ac4944);
 }


### PR DESCRIPTION
## Summary
Fixes #89

The TrainerTable `ColorID` column is a uint8, so it can't hold the `-1` sentinel that makes a trainer use the player's color variation in battle (the mechanism the player's mom uses). `BSP_TRAINER_DATA$$SetupTrainerData` widens the byte with a plain zero-extension:

```
0x1ac48d4  ldrb w9,[x19,#0x14]   ; ColorID byte from the TrainerTable row
0x1ac48d8  str  w9,[x8,#0x40]    ; BSP_TRAINER_DATA_CORE_DATA.color_id (int32)
```

This adds an inline hook at the `str` in both `SetupTrainerData` overloads (`0x1ac48d8` for TrainerTable trainers, `0x1ac4944` for the instant/tower variant, which loads the byte from `+0x38`) that rewrites W9 from `0xFF` to `-1`, so setting a trainer's ColorID to 255 in the table makes them battle with the player's color variation.

Lives in `color_variations.cpp` and is gated behind the existing **Color Variations** feature flag, same as the other trainer color hooks.

## Testing
- Builds clean with the WSL devkitPro toolchain (RomBase_release_ryujinx).
- In-game check still pending: set a test trainer's ColorID to 255 and confirm the in-battle model uses the player's variation.