### PR TITLE
Make Amulet Coin/Luck Incense work from any party slot

### DIFF
--- a/src/mod/data/features.h
+++ b/src/mod/data/features.h
@@ -84,6 +84,7 @@ constexpr int DEBUG_FEATURE_COUNT = sizeof(DEBUG_FEATURES) / sizeof(DEBUG_FEATUR
 
 static constexpr const char* ITEM_FEATURES[] = {
     "Ability Patch",
+    "Amulet Coin",
     "Everlasting Candies",
     "Exp. Share",
     "Infinite TMs",

--- a/src/mod/externals/Dpr/Battle/Logic/MainModule.h
+++ b/src/mod/externals/Dpr/Battle/Logic/MainModule.h
@@ -87,6 +87,10 @@ namespace Dpr::Battle::Logic {
             return external<Pml::PokeParty::Object*>(0x020325a0, this, clientID, fForServer);
         }
 
+        inline void SetMoneyDblUp(uint32_t clientID) {
+            external<void>(0x02036fd0, this, clientID);
+        }
+
         inline bool IsFriendPokeID(uint8_t pokeID1, uint8_t pokeID2) {
             return external<bool>(0x02037470, this, pokeID1, pokeID2);
         }

--- a/src/mod/externals/Dpr/Battle/Logic/MainModule.h
+++ b/src/mod/externals/Dpr/Battle/Logic/MainModule.h
@@ -8,6 +8,7 @@
 #include "externals/Dpr/Battle/Logic/BTL_POKEPARAM.h"
 #include "externals/Dpr/Battle/Logic/BtlEscapeMode.h"
 #include "externals/Dpr/Battle/Logic/BtlRule.h"
+#include "externals/Dpr/Battle/Logic/MoneyDblUpCause.h"
 #include "externals/Dpr/Battle/Logic/MyStatus.h"
 #include "externals/Pml/PokeParty.h"
 #include "externals/System/Collections/IEnumerator.h"
@@ -87,8 +88,8 @@ namespace Dpr::Battle::Logic {
             return external<Pml::PokeParty::Object*>(0x020325a0, this, clientID, fForServer);
         }
 
-        inline void SetMoneyDblUp(uint32_t clientID) {
-            external<void>(0x02036fd0, this, clientID);
+        inline void SetMoneyDblUp(Dpr::Battle::Logic::MoneyDblUpCause cause) {
+            external<void>(0x02036fd0, this, cause);
         }
 
         inline bool IsFriendPokeID(uint8_t pokeID1, uint8_t pokeID2) {

--- a/src/mod/externals/Dpr/Battle/Logic/MoneyDblUpCause.h
+++ b/src/mod/externals/Dpr/Battle/Logic/MoneyDblUpCause.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "externals/il2cpp-api.h"
+
+namespace Dpr::Battle::Logic {
+    enum class MoneyDblUpCause : int32_t {
+        MONEY_DBLUP_STD = 0,
+        MONEY_DBLUP_EXTRA = 1,
+        MONEY_DBLUP_CAUSE_MAX = 2,
+    };
+}

--- a/src/mod/features/items.cpp
+++ b/src/mod/features/items.cpp
@@ -33,6 +33,8 @@ HOOK_DEFINE_INLINE(Infinite_Items) {
 void exl_items_changes_main() {
     if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Ability Patch")))
         exl_items_ability_patch_main();
+    if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Amulet Coin")))
+        exl_items_amulet_coin_main();
     if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Everlasting Candies")))
         exl_items_everlasting_candies_main();
     if (IsActivatedItemFeature(array_index(ITEM_FEATURES, "Exp. Share")))

--- a/src/mod/features/items/amulet_coin.cpp
+++ b/src/mod/features/items/amulet_coin.cpp
@@ -1,0 +1,35 @@
+#include "exlaunch.hpp"
+
+#include "data/items.h"
+#include "data/utils.h"
+#include "externals/PlayerWork.h"
+#include "externals/Pml/PokePara/CoreParam.h"
+#include "externals/Pml/PokeParty.h"
+
+// The Amulet Coin/Luck Incense handlers are held-item event handlers, so they only run for
+// party members that actually entered the battle; a benched holder never sets the per-client
+// money double-up flag. Scan the saved party when the prize ratio is computed and apply the
+// doubling once if anyone holds one of the items.
+HOOK_DEFINE_TRAMPOLINE(MainModule_calcMoneyDblUpRatio) {
+    static int32_t Callback(int64_t __this) {
+        int32_t ratio = Orig(__this);
+
+        if (ratio == 1) {
+            Pml::PokeParty::Object* party = PlayerWork::get_playerParty();
+            for (uint32_t i = 0; i < party->fields.m_memberCount; i++) {
+                auto poke = (Pml::PokePara::CoreParam::Object*)party->GetMemberPointer(i);
+                uint16_t item = poke->GetItem();
+                if (item == array_index(ITEMS, "Amulet Coin") ||
+                    item == array_index(ITEMS, "Luck Incense")) {
+                    return 2;
+                }
+            }
+        }
+
+        return ratio;
+    }
+};
+
+void exl_items_amulet_coin_main() {
+    MainModule_calcMoneyDblUpRatio::InstallAtOffset(0x02036f30);
+};

--- a/src/mod/features/items/amulet_coin.cpp
+++ b/src/mod/features/items/amulet_coin.cpp
@@ -3,28 +3,26 @@
 #include "data/items.h"
 #include "data/utils.h"
 #include "externals/Dpr/Battle/Logic/MainModule.h"
+#include "externals/Dpr/Battle/Logic/MoneyDblUpCause.h"
 #include "externals/Pml/PokePara/CoreParam.h"
 #include "externals/Pml/PokeParty.h"
 
 // The Amulet Coin/Luck Incense handlers are held-item event handlers, so they only run for
-// party members that actually entered the battle; a benched holder never sets the per-client
-// money double-up flag. FixRegularMoney inlines the flag scan that multiplies the prize, so
-// set the player's flag right before it runs if anyone in the party holds one of the items.
-// SetMoneyDblUp just writes a 1 into the per-client flag array, so an in-battle holder that
+// party members that actually entered the battle; a benched holder never sets the STD money
+// double-up cause flag. FixRegularMoney inlines the cause-flag scan that multiplies the
+// prize, so set the flag right before it runs if anyone in the player's party holds one of
+// the items. SetMoneyDblUp just writes a 1 into the cause slot, so an in-battle holder that
 // already set it stays at the vanilla 2x — no stacking.
 HOOK_DEFINE_TRAMPOLINE(MainModule_FixRegularMoney) {
     static uint32_t Callback(Dpr::Battle::Logic::MainModule::Object* __this) {
-        uint8_t clientID = __this->fields.m_myClientID;
-        Pml::PokeParty::Object* party = __this->GetSrcParty(clientID, false);
-        if (party != nullptr) {
-            for (uint32_t i = 0; i < party->fields.m_memberCount; i++) {
-                auto poke = (Pml::PokePara::CoreParam::Object*)party->GetMemberPointer(i);
-                uint16_t item = poke->GetItem();
-                if (item == array_index(ITEMS, "Amulet Coin") ||
-                    item == array_index(ITEMS, "Luck Incense")) {
-                    __this->SetMoneyDblUp(clientID);
-                    break;
-                }
+        Pml::PokeParty::Object* party = __this->GetSrcParty(__this->fields.m_myClientID, false);
+        for (uint32_t i = 0; i < party->fields.m_memberCount; i++) {
+            auto poke = (Pml::PokePara::CoreParam::Object*)party->GetMemberPointer(i);
+            uint16_t item = poke->GetItem();
+            if (item == array_index(ITEMS, "Amulet Coin") ||
+                item == array_index(ITEMS, "Luck Incense")) {
+                __this->SetMoneyDblUp(Dpr::Battle::Logic::MoneyDblUpCause::MONEY_DBLUP_STD);
+                break;
             }
         }
 

--- a/src/mod/features/items/amulet_coin.cpp
+++ b/src/mod/features/items/amulet_coin.cpp
@@ -2,34 +2,36 @@
 
 #include "data/items.h"
 #include "data/utils.h"
-#include "externals/PlayerWork.h"
+#include "externals/Dpr/Battle/Logic/MainModule.h"
 #include "externals/Pml/PokePara/CoreParam.h"
 #include "externals/Pml/PokeParty.h"
 
 // The Amulet Coin/Luck Incense handlers are held-item event handlers, so they only run for
 // party members that actually entered the battle; a benched holder never sets the per-client
-// money double-up flag. Scan the saved party when the prize ratio is computed and apply the
-// doubling once if anyone holds one of the items.
-HOOK_DEFINE_TRAMPOLINE(MainModule_calcMoneyDblUpRatio) {
-    static int32_t Callback(int64_t __this) {
-        int32_t ratio = Orig(__this);
-
-        if (ratio == 1) {
-            Pml::PokeParty::Object* party = PlayerWork::get_playerParty();
+// money double-up flag. FixRegularMoney inlines the flag scan that multiplies the prize, so
+// set the player's flag right before it runs if anyone in the party holds one of the items.
+// SetMoneyDblUp just writes a 1 into the per-client flag array, so an in-battle holder that
+// already set it stays at the vanilla 2x — no stacking.
+HOOK_DEFINE_TRAMPOLINE(MainModule_FixRegularMoney) {
+    static uint32_t Callback(Dpr::Battle::Logic::MainModule::Object* __this) {
+        uint8_t clientID = __this->fields.m_myClientID;
+        Pml::PokeParty::Object* party = __this->GetSrcParty(clientID, false);
+        if (party != nullptr) {
             for (uint32_t i = 0; i < party->fields.m_memberCount; i++) {
                 auto poke = (Pml::PokePara::CoreParam::Object*)party->GetMemberPointer(i);
                 uint16_t item = poke->GetItem();
                 if (item == array_index(ITEMS, "Amulet Coin") ||
                     item == array_index(ITEMS, "Luck Incense")) {
-                    return 2;
+                    __this->SetMoneyDblUp(clientID);
+                    break;
                 }
             }
         }
 
-        return ratio;
+        return Orig(__this);
     }
 };
 
 void exl_items_amulet_coin_main() {
-    MainModule_calcMoneyDblUpRatio::InstallAtOffset(0x02036f30);
+    MainModule_FixRegularMoney::InstallAtOffset(0x02036e50);
 };

--- a/src/mod/features/items/items.h
+++ b/src/mod/features/items/items.h
@@ -5,6 +5,9 @@
 // Allows the Ability Patch to be used to go from hidden ability to ability slot 1.
 void exl_items_ability_patch_main();
 
+// Makes the Amulet Coin/Luck Incense double prize money from any party slot.
+void exl_items_amulet_coin_main();
+
 // Implements the Everlasting Candies.
 void exl_items_everlasting_candies_main();
 


### PR DESCRIPTION
## Summary
Fixes #227

In vanilla, `handler_OmamoriKoban` (registered for both `ItemNo.OMAMORIKOBAN` and `ItemNo.KOUUNNOOKOU` per the handler table) is a held-item event handler, so it only runs for party members that actually enter the battle — a benched Amulet Coin/Luck Incense never sets the per-client money double-up flag that `MainModule$$calcMoneyDblUpRatio` (0x2036F30) folds into the prize money.

This adds a trampoline on `calcMoneyDblUpRatio`: if the vanilla ratio is 1, it scans the saved player party (`PlayerWork::get_playerParty()`, the same accessor the encounter code uses) and returns 2 if any member holds an Amulet Coin or Luck Incense.

- No stacking: the scan only applies when the vanilla ratio is 1, so an active holder (ratio already 2) doesn't get doubled again, and multiple coins still give only 2x — matching vanilla semantics where the flag is per-client.
- Implemented as a new **Item Feature** `"Amulet Coin"` (`features/items/amulet_coin.cpp`), gated at install time like the other item features; absent from features.json = disabled.

## Companion PR
Requires the Romhack_Unity features.json entry (companion PR) to activate.

## Testing
- Builds clean with the WSL devkitPro toolchain (RomBase_release_ryujinx).
- In-game matrix still pending: coin on benched mon → 2x; no coin → 1x; coin on active mon → 2x (not 4x).