### PR TITLE
Fixes some issues with newer compilers

### DIFF
--- a/cmake/modules.cmake
+++ b/cmake/modules.cmake
@@ -146,7 +146,7 @@ function(create_releases_main module)
     function(create_release target with_ftp path)
         add_custom_target(${module}_release_${target} DEPENDS ${module}_release_variants)
         add_custom_command(
-                TARGET ${module}_release_${target}
+                TARGET ${module}_release_${target} POST_BUILD
                 COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/${module}_releases/${target}/"
                 COMMAND sh -c 'cp -r ${CMAKE_CURRENT_BINARY_DIR}/${module}_*_releases/${target}/* ${CMAKE_CURRENT_BINARY_DIR}/${module}_releases/${target}/'
         )
@@ -155,7 +155,7 @@ function(create_releases_main module)
 
         add_custom_target(${module}_zip_${target} DEPENDS ${module}_release_${target})
         add_custom_command(
-                TARGET ${module}_zip_${target}
+                TARGET ${module}_zip_${target} POST_BUILD
                 COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/zips/
                 COMMAND zip -r "${CMAKE_CURRENT_BINARY_DIR}/zips/${module}_${target}.zip" *
                 WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${module}_releases/${target}/"
@@ -192,7 +192,7 @@ function(create_releases module game_name variant title_id)
     function(create_release target folder)
         add_custom_target(${variant}_release_${target} DEPENDS ${variant}_all)
         add_custom_command(
-                TARGET ${variant}_release_${target}
+                TARGET ${variant}_release_${target} POST_BUILD
                 COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/${variant}_releases/${target}/${folder}
                 COMMAND sh -c \"cp -r ${CMAKE_CURRENT_BINARY_DIR}/${variant}_out/* ${CMAKE_CURRENT_BINARY_DIR}/${variant}_releases/${target}/${folder}\"
         )

--- a/include/nlohmann/json.hpp
+++ b/include/nlohmann/json.hpp
@@ -24315,7 +24315,7 @@ inline namespace json_literals
 /// @brief user-defined string literal for JSON values
 /// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json/
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json operator "" _json(const char* s, std::size_t n)
+inline nlohmann::json operator ""_json(const char* s, std::size_t n)
 {
     return nlohmann::json::parse(s, s + n);
 }
@@ -24323,7 +24323,7 @@ inline nlohmann::json operator "" _json(const char* s, std::size_t n)
 /// @brief user-defined string literal for JSON pointer
 /// @sa https://json.nlohmann.me/api/basic_json/operator_literal_json_pointer/
 JSON_HEDLEY_NON_NULL(1)
-inline nlohmann::json::json_pointer operator "" _json_pointer(const char* s, std::size_t n)
+inline nlohmann::json::json_pointer operator ""_json_pointer(const char* s, std::size_t n)
 {
     return nlohmann::json::json_pointer(std::string(s, n));
 }
@@ -24387,8 +24387,8 @@ inline void swap(nlohmann::NLOHMANN_BASIC_JSON_TPL& j1, nlohmann::NLOHMANN_BASIC
 }  // namespace std
 
 #if JSON_USE_GLOBAL_UDLS
-    using nlohmann::literals::json_literals::operator "" _json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
-    using nlohmann::literals::json_literals::operator "" _json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    using nlohmann::literals::json_literals::operator ""_json; // NOLINT(misc-unused-using-decls,google-global-names-in-headers)
+    using nlohmann::literals::json_literals::operator ""_json_pointer; //NOLINT(misc-unused-using-decls,google-global-names-in-headers)
 #endif
 
 // #include <nlohmann/detail/macro_unscope.hpp>

--- a/include/nn/os.h
+++ b/include/nn/os.h
@@ -23,7 +23,7 @@ struct InternalConditionVariable {
 }  // namespace detail
 
 struct LightEventType {
-    std::aligned_storage_t<0xc, 4> storage;
+    alignas(4) std::byte storage[0xc];
 };
 
 // https://github.com/misson20000/nn-types/blob/master/nn_os.h
@@ -88,7 +88,7 @@ struct MessageQueueType {
 struct ConditionVariableType {};
 
 struct SemaphoreType {
-    std::aligned_storage_t<0x28, 8> storage;
+    alignas(8) std::byte storage[0x28];
 };
 
 struct SystemEvent;

--- a/include/nn/util/util_typed_storage.hpp
+++ b/include/nn/util/util_typed_storage.hpp
@@ -23,9 +23,9 @@
 
 namespace nn::util {
 
-    template <typename T, size_t Size = sizeof(T), size_t Align = alignof(T)>
+    template <typename T>
     struct TypedStorage {
-        typename std::aligned_storage<Size, Align>::type _storage;
+        alignas(T) std::byte _storage[sizeof(T)];
     };
 
     template <typename T>

--- a/src/common/exlaunch/hook/nx64/hook_impl.cpp
+++ b/src/common/exlaunch/hook/nx64/hook_impl.cpp
@@ -77,7 +77,7 @@ namespace exl::hook::nx64 {
         constexpr size_t InlineHookPoolSize = InlineHookSize * InlineHookMax;
 
         typedef uint32_t* __restrict* __restrict instruction;
-        typedef struct {
+        typedef struct ContextInfo {
             struct fix_info {
                 uint32_t* bprx;
                 uint32_t* bprw;

--- a/src/common/exlaunch/patch/patcher_impl.hpp
+++ b/src/common/exlaunch/patch/patcher_impl.hpp
@@ -8,7 +8,7 @@
 namespace exl::patch {
 
     namespace impl {
-        inline util::TypedStorage<const util::RwPages> s_Storage;
+        inline util::TypedStorage<util::RwPages> s_Storage;
 
         inline const util::RwPages& GetRwPages() { return util::GetReference(s_Storage); }
 

--- a/src/common/exlaunch/util/typed_storage.hpp
+++ b/src/common/exlaunch/util/typed_storage.hpp
@@ -22,9 +22,9 @@
 
 namespace exl::util {
 
-    template<typename T, size_t Size = sizeof(T), size_t Align = alignof(T)>
+    template<typename T>
     struct TypedStorage {
-        typename std::aligned_storage<Size, Align>::type _storage;
+        alignas(T) std::byte _storage[sizeof(T)];
     };
 
     template<typename T>


### PR DESCRIPTION
- Fixes errors and warnings on newer GCC compilers so the repo can be built on those newer compilers.
- Regardless, Docker should be the preferred way to build as those builds didn't end up working.